### PR TITLE
Add helper to converge on a series of convergences

### DIFF
--- a/packages/bigtest-converge/tests/converge-series-test.js
+++ b/packages/bigtest-converge/tests/converge-series-test.js
@@ -1,0 +1,55 @@
+import { describe, beforeEach, afterEach, it } from 'mocha';
+import { use, expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { convergent, convergeSeries } from '../src';
+
+use(chaiAsPromised);
+
+describe('BigTest Converge: convergeSeries', function() {
+  let total, timeouts = [];
+
+  let createTimeout = (fn, timeout) => {
+    timeouts.push(setTimeout(fn, timeout));
+  };
+
+  beforeEach(function() {
+    total = 0;
+  });
+
+  afterEach(function() {
+    timeouts.forEach((timeout) => {
+      clearTimeout(timeout);
+    });
+  });
+
+  it('should resolve after each convergence, in order', function() {
+    createTimeout(() => total = 5, 30);
+    createTimeout(() => total = 10, 50);
+
+    return expect(convergeSeries([
+      convergent(() => expect(total).to.equal(5)),
+      convergent(() => expect(total).to.equal(10))
+    ])).to.be.fulfilled;
+  });
+
+  it('should reject when a convergence is not met within the timeout', function() {
+    createTimeout(() => total = 5, 30);
+    createTimeout(() => total = 10, 80);
+
+    return expect(convergeSeries([
+      convergent(() => expect(total).to.equal(5)),
+      convergent(() => expect(total).to.equal(10))
+    ], 50)).to.be.rejected;
+  });
+
+  it('should chain functions in the series', function() {
+    createTimeout(() => total = 5, 30);
+    createTimeout(() => total = 500, 50);
+
+    return expect(convergeSeries([
+      convergent(() => expect(total).to.equal(5)),
+      () => total * 100,
+      convergent((n) => expect(total).to.equal(n))
+    ])).to.be.fulfilled;
+  });
+});

--- a/packages/bigtest-converge/tests/convergent-test.js
+++ b/packages/bigtest-converge/tests/convergent-test.js
@@ -1,4 +1,4 @@
-import { describe, beforeEach, it } from 'mocha';
+import { describe, beforeEach, afterEach, it } from 'mocha';
 import { use, expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { convergent } from '../src';
@@ -31,22 +31,26 @@ describe('BigTest Converge: convergent', function() {
   });
 
   describe('with a specific timeout', function() {
-    let timeout = 50;
-
     beforeEach(function() {
       test = convergent((num) => {
         expect(total).to.equal(num);
-      }, timeout);
+      }, 50);
     });
 
     it('resolves when the assertion passes within the timeout', function() {
-      timeout = setTimeout(() => total = 5, timeout - 30);
+      timeout = setTimeout(() => total = 5, 30);
       return expect(test(5)).to.be.fulfilled;
     });
 
     it('rejects if the assertion does not pass within the timeout', function() {
-      timeout = setTimeout(() => total = 5, timeout + 30);
+      timeout = setTimeout(() => total = 5, 80);
       return expect(test(5)).to.be.rejected;
+    });
+
+    it('allows changing the timeout before execution', function() {
+      test.timeout = 100;
+      timeout = setTimeout(() => total = 5, 80);
+      return expect(test(5)).to.be.fulfilled;
     });
   });
 


### PR DESCRIPTION
This is useful for when you need to chain multiple convergences but still need to constrain the total timeout period for all of them.

For example, when clicking a button you would first want to converge on the existence of the button, perform the click, then converge on any resulting side effects; but that whole transaction must take place within the constraints a single timeout (a `beforeEach` block for example).

I saw two options to solve this:

1. Track the first `convergeOn` start time so every `convergeOn` that is called within a short period of time can properly track the elapsed time since the first one started.

2. Set the timeout of the following convergent function to be the total timeout, minus the time it has taken any previous convergent functions to complete.

`#1` seemed sub-optimal, as you wouldn't then be able to have unrelated convergences running at the same time.

To achieve `#2`, a convergent function must be able to have it's timeout modified before being executed, so that dealing with the math involved could be handled by another helper. Using the `convergent` helper, you can now modify it's timeout after creation by changing the `timeout` property of the resulting function.

```js
let converge = convergent(() => expect(foo).to.equal('bar'));

console.log(converge.timeout);
// => 2000

converge.timeout = 50;

console.log(converge.timeout);
// => 50

// will fail if it hasn't converged after 50ms
converge().then(...).catch(...);
```

With this ability, the `convergeSeries` helper can now track the total time elapsed, and set the timeouts of other convergent functions accordingly. 

The following will resolve once `Page.clickCount` equals `1`, but _only_ after a button has been successfully clicked:

```js
convergeSeries([
  convergent(() => expect(Page.$btn).to.exist),
  () => Page.$btn.get(0).click(), // this would error if it didn't exist in the DOM
  convergent(() => expect(Page.clickCount).to.equal(1))
], 50);
```