### PR TITLE
Fix Circle deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *restore_cache
       - attach_workspace:
           at: ~/bigtest
       - run:


### PR DESCRIPTION
~The `npm publish` command needs `node_modules` from the cache~

The new `each-pkg` script needs `node_modules` from the cache