### PR TITLE
Publish public packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Publish to NPM
-          command: ./bin/each-pkg --newer npm publish
+          command: ./bin/each-pkg --newer npm publish -- --access=public
 
 workflows:
   version: 2


### PR DESCRIPTION
[By default, scoped packages are private. To publish a public scoped package, we need to set the access option when publishing it.](https://docs.npmjs.com/getting-started/scoped-packages#publishing-a-scoped-package)