### PR TITLE
Update README image URLs

### DIFF
--- a/packages/convergence/README.md
+++ b/packages/convergence/README.md
@@ -11,13 +11,13 @@ some text that gets loaded from the network.
 In order to do this, you have to make sure that your assertion runs
 _after_ the effect you're testing has been realized.
 
-![Image of assertion after an effect](images/assertion-after.png)
+![Image of assertion after an effect](https://raw.githubusercontent.com/thefrontside/bigtest/master/packages/convergence/images/assertion-after.png)
 
 If not, then you could end up with a false negative, or "flaky test"
 because you ran the assertion too early. If you'd only waited a little
 bit longer, then your test would have passed. So sad!
 
-![Image of false negative test](images/false-negative.png)
+![Image of false negative test](https://raw.githubusercontent.com/thefrontside/bigtest/master/packages/convergence/images/false-negative.png)
 
 In fact, test flakiness is the reason most people shy away from
 writing big tests in JavaScript in the first place. It seems almost
@@ -30,7 +30,7 @@ But what if instead of trying to run our assertions at just the right
 time, we ran them _many_ times until they either pass or we decide to
 give up?
 
-![Image of convergent assertion](images/convergent-assertion.png)
+![Image of convergent assertion](https://raw.githubusercontent.com/thefrontside/bigtest/master/packages/convergence/images/convergent-assertion.png)
 
 This is the essence of what `@bigtest/convergence` provides:
 repeatedly testing for a condition and then allowing code to run once

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",


### PR DESCRIPTION
On npm, relative file paths do not display correctly. We can point the image URLs to their raw paths on GitHub so that npm can properly display them in the README.

In order for npm to show the new README, we need to publish a new version of the package.

#### Before
<img width="698" alt="npm" src="https://user-images.githubusercontent.com/5005153/34313697-bab27178-e732-11e7-92c9-c6a6ae1dcca8.png">
