### PR TITLE
@bigtest/mocha

### DIFF
--- a/packages/mocha/.babelrc
+++ b/packages/mocha/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -1,0 +1,1 @@
+# @bigtest/mocha

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@bigtest/mocha",
+  "description": "Mocha helpers for testing big",
+  "version": "0.1.0",
+  "license": "MIT",
+  "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "rollup --config",
+    "test": "mocha --opts ./tests/mocha.opts ./tests"
+  },
+  "dependencies": {
+    "@bigtest/convergence": "^0.1.2"
+  },
+  "peerDependencies": {
+    "mocha": "^4.0.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.0.0-beta.35",
+    "@babel/preset-env": "^7.0.0-beta.35",
+    "@babel/register": "^7.0.0-beta.35",
+    "chai": "^4.1.2",
+    "mocha": "^4.0.1",
+    "rollup": "^0.53.0",
+    "rollup-plugin-babel": "^4.0.0-beta.0",
+    "rollup-plugin-commonjs": "^8.2.6",
+    "rollup-plugin-node-resolve": "^3.0.0"
+  }
+}

--- a/packages/mocha/rollup.config.js
+++ b/packages/mocha/rollup.config.js
@@ -1,0 +1,27 @@
+import babel from 'rollup-plugin-babel';
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  input: 'src/index.js',
+  output: {
+    file: 'dist/index.js',
+    format: 'umd',
+    name: 'BigTest.Mocha',
+    globals: { mocha: 'mocha' }
+  },
+  external: ['mocha'],
+  plugins: [
+    resolve(),
+    commonjs(),
+    babel({
+      babelrc: false,
+      presets: [
+        ['@babel/preset-env', {
+          modules: false,
+          comments: false
+        }]
+      ]
+    })
+  ]
+};

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,0 +1,136 @@
+import { it as mochaIt } from 'mocha';
+import Convergence from '@bigtest/convergence';
+
+/**
+ * Helper to create a convergent assertion using the current testing
+ * context's timeout.
+ *
+ * @param {Function} assertion - assertion to converge on
+ * @param {Boolean} always - true when the assertion should always pass
+ * @returns {Function} assertion to use with mocha's it
+ */
+function convergent(assertion, always) {
+  return function() {
+    let timeout = 2000;
+
+    if (typeof this.timeout === 'function') {
+      timeout = this.timeout();
+    }
+
+    let converge = new Convergence(timeout);
+    let assert = assertion.bind(this);
+
+    if (always) {
+      return converge.always(assert).run();
+    } else {
+      return converge.once(assert).run();
+    }
+  };
+}
+
+/**
+ * Convergent it will use the convergent helper to keep testing the assertion
+ * repeatedly until it passes or until the timeout is reached
+ *
+ * @param {String} title - specification description
+ * @param {Function} assertion - the assertion to converge on
+ */
+function it(title, assertion) {
+  if (!assertion) return mochaIt.skip(title);
+  return mochaIt(title, convergent(assertion));
+}
+
+/**
+ * Convergent it that will inversely keep testing an assertion reapeatedly until
+ * it fails or until the timeout is reached
+ *
+ * @param {String} title - specification description
+ * @param {Function} assertion - the assertion to inversely converge on
+ */
+function itAlways(title, assertion) {
+  if (!assertion) return mochaIt.skip(title);
+  return mochaIt(title, convergent(assertion, true));
+}
+
+/**
+ * Convergent it, but using mocha `.only`
+ *
+ * @param {String} title - specification description
+ * @param {Function} assertion - the assertion to converge on
+ */
+function itOnly(title, assertion) {
+  if (!assertion) return mochaIt.skip(title);
+  return mochaIt.only(title, convergent(assertion));
+}
+
+/**
+ * Inverted convergent it, but using mocha `.only`
+ *
+ * @param {String} title - specification description
+ * @param {Function} assertion - the assertion to inversely converge on
+ */
+function itAlwaysOnly(title, assertion) {
+  if (!assertion) return mochaIt.skip(title);
+  return mochaIt.only(title, convergent(assertion, true));
+}
+
+/**
+ * Pauses a test by setting the timeout to zero, and returning
+ * a promise that never resolves
+ *
+ * @param {String} title - specification description
+ */
+function itPause(title) {
+  return mochaIt(title, function() {
+    return new Promise(() => {});
+  }).timeout(0);
+}
+
+/**
+ * Pauses a test, but using mocha `.only`
+ *
+ * @param {String} title - specification description
+ */
+function itPauseOnly(title) {
+  return mochaIt.only(title, function() {
+    return new Promise(() => {});
+  }).timeout(0);
+}
+
+// attach everything to `it`
+it.only = itOnly;
+it.always = itAlways;
+it.always.only = itAlwaysOnly;
+it.only.always = itAlwaysOnly;
+it.pause = itPause;
+it.pause.only = itPauseOnly;
+it.only.pause = itPauseOnly;
+
+// alias mocha's it.skip
+it.skip = mochaIt.skip;
+it.always.skip = mochaIt.skip;
+
+// in BDD interface `specify` is an alias for `it`
+let specify = it;
+
+// in TDD interface `test` is an alias for `it`
+let test = it;
+
+// export our convergent it (and aliases)
+export { it, specify, test };
+
+// export other mocha functions used for testing
+export {
+  describe,
+  context,
+  before,
+  beforeEach,
+  after,
+  afterEach,
+  // BDD interface functions
+  suite,
+  suiteSetup,
+  setup,
+  suiteTeardown,
+  teardown
+} from 'mocha';

--- a/packages/mocha/tests/fixtures/it-fixture.js
+++ b/packages/mocha/tests/fixtures/it-fixture.js
@@ -1,0 +1,23 @@
+import { describe, before, after, it } from '../../src';
+import { expect } from 'chai';
+
+describe('it', function () {
+  let value = 0;
+  let interval;
+
+  before(() => {
+    interval = setInterval(() => value += 1, 10);
+  });
+
+  after(() => {
+    clearInterval(interval);
+  });
+
+  it('eventually passes', () => {
+    expect(value).to.equal(5);
+  });
+
+  it('throws just before the timeout', () => {
+    expect(value).to.equal(200);
+  }).timeout(200);
+});

--- a/packages/mocha/tests/fixtures/it.always-fixture.js
+++ b/packages/mocha/tests/fixtures/it.always-fixture.js
@@ -1,0 +1,23 @@
+import { describe, beforeEach, afterEach, it } from '../../src';
+import { expect } from 'chai';
+
+describe('it.always', function () {
+  let value = 0;
+  let timeout;
+
+  beforeEach(() => {
+    timeout = setTimeout(() => value = 1, 100);
+  });
+
+  afterEach(() => {
+    clearTimeout(timeout);
+  });
+
+  it.always('eventually passes before the timeout', () => {
+    expect(value).to.equal(0);
+  }).timeout(100);
+
+  it.always('throws if the assertion eventually fails', () => {
+    expect(value).to.equal(0);
+  });
+});

--- a/packages/mocha/tests/fixtures/it.always.only-fixture.js
+++ b/packages/mocha/tests/fixtures/it.always.only-fixture.js
@@ -1,0 +1,23 @@
+import { describe, beforeEach, afterEach, it } from '../../src';
+import { expect } from 'chai';
+
+describe('it.always.only', function () {
+  let value = 0;
+  let timeout;
+
+  beforeEach(() => {
+    timeout = setTimeout(() => value = 1, 100);
+  });
+
+  afterEach(() => {
+    clearTimeout(timeout);
+  });
+
+  it.always.only('runs this test', () => {
+    expect(value).to.equal(0);
+  }).timeout(100);
+
+  it('does not run this test', () => {
+    expect(0).to.equal(1, 'this test should have been skipped');
+  });
+});

--- a/packages/mocha/tests/fixtures/it.only-fixture.js
+++ b/packages/mocha/tests/fixtures/it.only-fixture.js
@@ -1,0 +1,23 @@
+import { describe, before, after, it } from '../../src';
+import { expect } from 'chai';
+
+describe('it.only', function () {
+  let value = 0;
+  let interval;
+
+  before(() => {
+    interval = setInterval(() => value += 1, 10);
+  });
+
+  after(() => {
+    clearInterval(interval);
+  });
+
+  it.only('runs this test', () => {
+    expect(value).to.equal(5);
+  });
+
+  it('does not run this test', () => {
+    expect(0).to.equal(1, 'this test should have been skipped');
+  });
+});

--- a/packages/mocha/tests/helpers.js
+++ b/packages/mocha/tests/helpers.js
@@ -1,0 +1,48 @@
+import path from 'path';
+import { spawn } from 'child_process';
+
+/**
+ * Runs mocha in a child process with the specified arguments.
+ * Uses the same mocha.opts file as the test suite.
+ *
+ * @param {[String]} args - array of strings as arguments
+ * @returns {Promise} resolves when the child process has exited
+ */
+function mocha(args) {
+  return new Promise((resolve, reject) => {
+    let output = '';
+    let listener = (data) => output += data;
+    let mocha = spawn('mocha', ['--opts', './tests/mocha.opts', ...args]);
+
+    mocha.stdout.on('data', listener);
+    mocha.stderr.on('data', listener);
+    mocha.on('error', reject);
+
+    mocha.on('close', (code) => {
+      resolve({
+        output: output.split('\n').join('\n'),
+        code: code
+      });
+    });
+
+    return mocha;
+  });
+}
+
+/**
+ * Runs a test fixture and returns the results as JSON
+ *
+ * @param {String} fixture - the fixture file name and path
+ * relative to `tests/fixtures`
+ * @returns {Promise} resolves with JSON results from running
+ * the fixture
+ */
+export function run(fixture) {
+  let fixturePath = path.join('./tests/fixtures', fixture);
+
+  return mocha(['--reporter', 'json', fixturePath]).then((res) => {
+    var result = JSON.parse(res.output);
+    result.code = res.code;
+    return result;
+  });
+}

--- a/packages/mocha/tests/it-test.js
+++ b/packages/mocha/tests/it-test.js
@@ -1,0 +1,35 @@
+import { describe, before, it } from 'mocha';
+import { expect } from 'chai';
+import { run } from './helpers';
+
+describe('BigTest Mocha: it', () => {
+  let tests;
+
+  before(() => run('it-fixture.js').then((results) => {
+    tests = results.tests;
+  }));
+
+  it('successfully passes for async tests', () => {
+    expect(tests[0].duration).to.be.within(50, 70);
+    expect(tests[0].err).to.be.empty;
+  });
+
+  it('throws on failure before the timeout', () => {
+    expect(tests[1].duration).to.be.within(180, 200);
+    expect(tests[1].err).to.have.property('expected', 200);
+  });
+});
+
+describe('BigTest Mocha: it.only', () => {
+  let tests;
+
+  before(() => run('it.only-fixture.js').then((results) => {
+    tests = results.tests;
+  }));
+
+  it('runs a single test', () => {
+    expect(tests).to.have.lengthOf(1);
+    expect(tests[0].duration).to.be.within(50, 70);
+    expect(tests[0].err).to.be.empty;
+  });
+});

--- a/packages/mocha/tests/it.always-test.js
+++ b/packages/mocha/tests/it.always-test.js
@@ -1,0 +1,41 @@
+import { describe, before, it } from 'mocha';
+import { expect } from 'chai';
+import { run } from './helpers';
+
+import { it as convergentIt } from '../src';
+
+describe('BigTest Mocha: it.always', () => {
+  let tests;
+
+  before(() => run('it.always-fixture.js').then((results) => {
+    tests = results.tests;
+  }));
+
+  it('successfully passes before the timeout', () => {
+    expect(tests[0].duration).to.be.within(80, 100);
+    expect(tests[0].err).to.be.empty;
+  });
+
+  it('throws when the assertion fails', () => {
+    expect(tests[1].duration).to.be.within(100, 120);
+    expect(tests[1].err).to.have.property('expected', 0);
+  });
+
+  it('.only has multiple aliases', () => {
+    expect(convergentIt.always.only).to.equal(convergentIt.only.always);
+  });
+});
+
+describe('BigTest Mocha: it.always.only', () => {
+  let tests;
+
+  before(() => run('it.always.only-fixture.js').then((results) => {
+    tests = results.tests;
+  }));
+
+  it('runs a single test', () => {
+    expect(tests).to.have.lengthOf(1);
+    expect(tests[0].duration).to.be.within(80, 100);
+    expect(tests[0].err).to.be.empty;
+  });
+});

--- a/packages/mocha/tests/it.pause-test.js
+++ b/packages/mocha/tests/it.pause-test.js
@@ -1,0 +1,24 @@
+import { describe, before, it } from 'mocha';
+import { expect } from 'chai';
+
+import { it as convergentIt } from '../src';
+
+describe('BigTest Mocha: it.pause', () => {
+  let test;
+
+  before(() => {
+    test = convergentIt.pause('test');
+  });
+
+  it('should set the timeout to 0', () => {
+    expect(test._timeout).to.equal(0);
+  });
+
+  it('should return a promise', () => {
+    expect(test.fn()).to.be.a('Promise');
+  });
+
+  it('.only has multiple aliases', () => {
+    expect(convergentIt.pause.only).to.equal(convergentIt.only.pause);
+  });
+});

--- a/packages/mocha/tests/mocha.opts
+++ b/packages/mocha/tests/mocha.opts
@@ -1,0 +1,1 @@
+--require @babel/register

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,6 +443,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+acorn@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
 ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
@@ -490,6 +494,12 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+browser-resolve@^1.11.0:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
@@ -500,6 +510,10 @@ browserslist@^2.4.0:
   dependencies:
     caniuse-lite "^1.0.30000780"
     electron-to-chromium "^1.3.28"
+
+builtin-modules@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 caniuse-lite@^1.0.30000780:
   version "1.0.30000784"
@@ -601,6 +615,14 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.5:
 estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
+estree-walker@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.1.tgz#64fc375053abc6f57d73e9bd2f004644ad3c5854"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -759,6 +781,10 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -833,6 +859,12 @@ loose-envify@^1.0.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  dependencies:
+    vlq "^0.2.1"
 
 make-dir@^1.0.0:
   version "1.1.0"
@@ -1041,7 +1073,11 @@ repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
-resolve@^1.3.2:
+resolve@1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -1053,12 +1089,38 @@ rollup-plugin-babel@^4.0.0-beta.0:
   dependencies:
     rollup-pluginutils "^1.5.0"
 
+rollup-plugin-commonjs@^8.2.6:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.6.tgz#27e5b9069ff94005bb01e01bb46a1e4873784677"
+  dependencies:
+    acorn "^5.2.1"
+    estree-walker "^0.5.0"
+    magic-string "^0.22.4"
+    resolve "^1.4.0"
+    rollup-pluginutils "^2.0.1"
+
+rollup-plugin-node-resolve@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
+  dependencies:
+    browser-resolve "^1.11.0"
+    builtin-modules "^1.1.0"
+    is-module "^1.0.0"
+    resolve "^1.1.6"
+
 rollup-pluginutils@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
 
 rollup@^0.53.0:
   version "0.53.0"
@@ -1124,6 +1186,10 @@ unicode-match-property-value-ecmascript@^1.0.1:
 unicode-property-aliases-ecmascript@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.3.tgz#ac3522583b9e630580f916635333e00c5ead690d"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
## What is this?
`@bigtest/mocha` simply wraps assertions passed to mocha's `it` with a `Convergence` from `@bigtest/convergence`. It uses the timeout specified using mocha's `timeout` method.

``` javascript
it('passes within 1 second', function() {
  expect(total).to.equal(5);
}).timeout(1000);
```

## TODO
- [x] ~Write tests for `it.only`, `it.always.only`, and `it.pause`. We should take an approach directly from mocha and run each test suite with a different mocha context.~
- [x] ~Write tests for failing convergences. Need to look into how mocha sets up these successfully-failing tests to figure out how we should do it.~
- [ ] Write a README detailing why this package exists, how to use it, and outline warnings & best practices when writing convergent tests.
  