### PR TITLE
Build before testing in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,10 @@ references:
       name: Restore cache
       key: *cache_key
 
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: ~/bigtest
+
 version: 2.0
 jobs:
   install:
@@ -30,15 +34,6 @@ jobs:
             # globs don't work for save_cache :(
             - packages/convergence/node_modules
 
-  test:
-    <<: *defaults
-    steps:
-      - checkout
-      - *restore_cache
-      - run:
-          name: Run tests
-          command: yarn test
-
   build:
     <<: *defaults
     steps:
@@ -51,13 +46,22 @@ jobs:
           root: .
           paths: packages/**/dist
 
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_cache
+      - *attach_workspace
+      - run:
+          name: Run tests
+          command: yarn test
+
   deploy:
     <<: *defaults
     steps:
       - checkout
       - *restore_cache
-      - attach_workspace:
-          at: ~/bigtest
+      - *attach_workspace
       - run:
           name: Setup NPM
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
@@ -70,16 +74,15 @@ workflows:
   default:
     jobs:
       - install
-      - test:
-          requires:
-            - install
       - build:
           requires:
             - install
+      - test:
+          requires:
+            - build
       - deploy:
           requires:
             - test
-            - build
           filters:
             branches:
               only: master


### PR DESCRIPTION
When packages depend on one another, they are symlinked in the workspace root. Importing one of these symlinked packages requires that the package be built first.

We previously ran `test` & `build` steps in parallel, but the `build` step should happen first so that tests can find the built packages.

You can reproduce this on the `bigtest-mocha` branch by running the tests before building.

### CI Error
<img width="408" alt="ci-error" src="https://user-images.githubusercontent.com/5005153/34322660-3f110b26-e7f3-11e7-8939-ae28a3cf959b.png">

After cherry-picking this commit, that branch passes successfully in Circle. 

### Future Work
We should probably automatically build packages before running tests locally. To avoid extra work, we should only build packages that haven't already been built. We can create a script that utilizes `each-pkg` to only build packages that don't already have a fresh build. But for now, simply building the dependent packages before running our tests will work locally.
