### PR TITLE
Use package name instead of path for version check

### DIFF
--- a/bin/each-pkg
+++ b/bin/each-pkg
@@ -70,7 +70,7 @@ function hasChanged(pkg, commit = 'origin/master') {
  * @returns {Boolean} true if the package is newer
  */
 function isNewer(pkg) {
-  let published = spawnSync('npm', ['view', pkg.path, 'version']);
+  let published = spawnSync('npm', ['view', pkg.name, 'version']);
 
   if (published.status === 0) {
     return semver.gt(pkg.version, published.stdout.toString());


### PR DESCRIPTION
During early iterations of `each-pkg` the current directory was set as the package path for the `npm view .\ version` command. When not inside of that package's directory, the command does not return the expected version number. Instead, we can use the package's `name` to check the latest version.