### PR TITLE
Add "module" index for systems that can consume ES modules.

### DIFF
--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "scripts": {
     "build": "rollup --config",
     "test": "mocha --opts ./tests/mocha.opts ./tests"


### PR DESCRIPTION
The @bigtest/mocha JavaScript sources are written using ES modules, but not every system that will be consuming @bigtest/mocha understands them. For those systems (specifically Node runtimes), we build an AMD equivalent using rollup.js and put the index for it in `dist/index.js`. On the other hand, if your system understands modules (like a webpack or a broccoli build) then you want to skip the intermediary build and just use the native sources directly.

We can tell systems where the ES module representing the entry point is, by using the "module" property and pointing it to the primary module for our library.