### PR TITLE
Make convergence available as an es module with "module" entry point

### DIFF
--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",
+  "module": "src/index.js",
   "scripts": {
     "build": "rollup --config",
     "test": "mocha --opts ./tests/mocha.opts ./tests"


### PR DESCRIPTION
see https://github.com/thefrontside/bigtest/pull/18