### PR TITLE
Automatically tag new package versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,9 @@ jobs:
       - run:
           name: Publish to NPM
           command: ./bin/each-pkg --newer npm publish -- --access=public
+      - run:
+          name: Push Tags
+          command: git push --tags
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run:
           name: Publish to NPM
-          command: ./bin/each-pkg --newer npm publish -- --access=public
+          command: ./bin/each-pkg --new npm publish -- --access=public
       - run:
           name: Push Tags
           command: git push --tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ references:
     docker:
       - image: circleci/node:8
 
+  add_ssh_keys: &add_ssh_keys
+    add_ssh_keys:
+      fingerprints:
+        - 2e:3e:1e:98:92:42:17:a6:ee:23:fb:d6:cb:cc:42:5e
+
   cache_key: &cache_key
     bigtest-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
@@ -21,6 +26,7 @@ jobs:
   install:
     <<: *defaults
     steps:
+      - *add_ssh_keys
       - checkout
       - *restore_cache
       - run:
@@ -37,6 +43,7 @@ jobs:
   build:
     <<: *defaults
     steps:
+      - *add_ssh_keys
       - checkout
       - *restore_cache
       - run:
@@ -59,6 +66,7 @@ jobs:
   deploy:
     <<: *defaults
     steps:
+      - *add_ssh_keys
       - checkout
       - *restore_cache
       - *attach_workspace

--- a/bin/each-pkg
+++ b/bin/each-pkg
@@ -3,7 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
-const semver = require('semver');
 const program = require('commander');
 const { spawn, spawnSync } = require('child_process');
 
@@ -63,17 +62,18 @@ function hasChanged(pkg, commit = 'origin/master') {
 }
 
 /**
- * Returns true if a package is newer than the published version
+ * Returns true if a package's version has not been published
  *
  * @param {String} pkg.path - package directory path
  * @param {String} pkg.version - package version
- * @returns {Boolean} true if the package is newer
+ * @returns {Boolean} true if the package version is not published
  */
-function isNewer(pkg) {
-  let published = spawnSync('npm', ['view', pkg.name, 'version']);
+function isNew(pkg) {
+  let published = spawnSync('npm', ['view', pkg.name, 'versions']);
 
   if (published.status === 0) {
-    return semver.gt(pkg.version, published.stdout.toString());
+    let versions = JSON.parse(published.stdout.toString().replace(/'/g, '"'));
+    return !versions.includes(pkg.version);
   } else {
     return true;
   }
@@ -81,13 +81,13 @@ function isNewer(pkg) {
 
 /**
  * Executes a command for each package, optionally filtered by changed
- * or newer packages. Explicity providing a package name is also
- * supported in conjunction with the changed and newer options.
+ * or new packages. Explicity providing a package name is also
+ * supported in conjunction with the changed and new options.
  */
 program
   .description('Executes the specified command for each package')
   .arguments('<cmd> [args...]')
-  .option('-n, --newer', 'target newer versioned packages only')
+  .option('-n, --new', 'target unpublished packages only')
   .option('-c, --changed', 'target packages that have diverged from master')
   .option('-p, --package <name>', 'target a specific package (can be combined with the above)')
   .option('--diff <commit>', 'target packages that have diverged from a specific commit')
@@ -98,8 +98,8 @@ program
 
       if (targeted && (this.changed || this.diff)) {
         return hasChanged(pkg, this.diff);
-      } else if (targeted && this.newer) {
-        return isNewer(pkg);
+      } else if (targeted && this.new) {
+        return isNew(pkg);
       } else {
         return targeted;
       }

--- a/bin/tag-pkg
+++ b/bin/tag-pkg
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+tagname=$(node -p << END_SCRIPT
+  const pkg = require('./package.json');
+  \`\${pkg.name}-\${pkg.version}\`;
+END_SCRIPT);
+
+git tag $tagname

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   ],
   "devDependencies": {
     "chalk": "^2.3.0",
-    "commander": "^2.12.2",
-    "semver": "^5.4.1"
+    "commander": "^2.12.2"
   }
 }

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -8,7 +8,8 @@
   "module": "src/index.js",
   "scripts": {
     "build": "rollup --config",
-    "test": "mocha --opts ./tests/mocha.opts ./tests"
+    "test": "mocha --opts ./tests/mocha.opts ./tests",
+    "postpublish": "../../bin/tag-pkg"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.35",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -8,7 +8,8 @@
   "module": "src/index.js",
   "scripts": {
     "build": "rollup --config",
-    "test": "mocha --opts ./tests/mocha.opts ./tests"
+    "test": "mocha --opts ./tests/mocha.opts ./tests",
+    "postpublish": "../../bin/tag-pkg"
   },
   "dependencies": {
     "@bigtest/convergence": "^0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1106,7 +1106,7 @@ rollup@^0.53.0:
   version "0.53.3"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.53.3.tgz#e7b6777623df912bd0ca30dc24be791d6ebc8e5a"
 
-semver@^5.3.0, semver@^5.4.1:
+semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 


### PR DESCRIPTION
#21 - ~Instead of tagging via each package's`postpublish` hook, tagging is done by the CI. Since the tags also need to be pushed by the CI, tagging can be it's responsibility. This also prevents us from needing to add `postpublish` hooks to every future package we add.~ See below

### TODO
- [x] Add GitHub keys to CircleCI so that `git push --tags` succeeds.