### PR TITLE
Fix comment removal

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,13 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Fixed
-
-- correctly remove comments from compiled files
-
-## [0.1.1] - 2018-01-09
-
 ### Added
 
 - "module" entry point to support native consumption of @bigtest/mocha
   as es module
+
+### Fixed
+
+- correctly remove comments from compiled files

--- a/packages/convergence/rollup.config.js
+++ b/packages/convergence/rollup.config.js
@@ -10,10 +10,10 @@ export default {
   plugins: [
     babel({
       babelrc: false,
+      comments: false,
       presets: [
         ['@babel/preset-env', {
-          modules: false,
-          comments: false
+          modules: false
         }]
       ]
     })

--- a/packages/mocha/rollup.config.js
+++ b/packages/mocha/rollup.config.js
@@ -16,10 +16,10 @@ export default {
     commonjs(),
     babel({
       babelrc: false,
+      comments: false,
       presets: [
         ['@babel/preset-env', {
-          modules: false,
-          comments: false
+          modules: false
         }]
       ]
     })


### PR DESCRIPTION
To remove comments from compiled files, `comments: false` needs to be at the root of babel's config.