### PR TITLE
Convergent mocha hooks

### DIFF
--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- wrapped hooks that allow automatically running returned convergences
+  with the current timeout
+
 ### Removed
 
 - `rollup-plugin-commonjs` as it is no longer required to import

--- a/packages/mocha/README.md
+++ b/packages/mocha/README.md
@@ -55,6 +55,10 @@ package wraps Mocha's `it` in a convergence helper so that any
 assertions you write using `it` become convergent assertions that
 allow you to easily test asynchronous states.
 
+This package also wraps the Mocha hooks `before`, `after`,
+`beforeEach`, and `afterEach` to support automatically timing and
+running returned `Convergence` instances from `@bigtest/convergence`.
+
 ### Writing Tests
 
 Because convergent assertions are run repeatedly until they pass, it
@@ -130,17 +134,18 @@ describe('clicking my button', () => {
 Sometimes you may attempt to perform an async task to find it fails
 due to a preconceived state not being met. For example, you can't
 click a button if it doesn't exist in the DOM. You may use
-`@bigtest/convergence` to converge on these states and return a
-promise in your hooks to wait for async tasks.
+`@bigtest/convergence` to converge on these states and return
+convergences inside of your hooks. The hooks provided by
+`@bigtest/mocha` will automatically set the timeout and run returned
+`Convergence` instances.
 
 ``` javascript
 describe('clicking my button', () => {
-  // .run() returns a promise that will cause Mocha to wait for the
-  // convergence to resolve before continuing with the assertions
+  // @bigtest/mocha will wait for a returned Convergence to converge
+  // before continuing with the assertions
   beforeEach(() => new Convergence()
     .once(() => expect($button).to.exist)
-    .do(() => $button.click())
-    .run());
+    .do(() => $button.click()));
 
   it('shows a loading indicator', () => {
     expect($button.className).to.include('is-loading');

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -2,7 +2,7 @@ import * as mocha from 'mocha';
 import Convergence from '@bigtest/convergence';
 
 /**
- * Helper to create a convergent assertion using the current testing
+ * Creates a convergent assertion using the current testing
  * context's timeout.
  *
  * @param {Function} assertion - assertion to converge on
@@ -29,9 +29,22 @@ function convergent(assertion, always) {
 }
 
 /**
- * Helper to allow automatically running returned objects that implement
+ * Allows automatically running returned objects that implement
  * a Convergence interface. A Convergence interface is an immutable
  * instance that supports both `.timeout` and `.run` methods.
+ *
+ * Convergences are not only useful for assertions, but also for
+ * setting up your tests as well. For example, converging on the
+ * existence of a button before clicking it. Mocha works with promises
+ * out of the box, so you can use convergences by returning
+ * `convergence.run()` in your mocha hooks. To time it properly, you'd
+ * also have to call `convergence.timeout()` with the same timeout
+ * used for the current mocha context.
+ *
+ * This function allows us to wrap our hooks and automatically set the
+ * `timeout()` and call `run()` on any returned convergence or
+ * convergence-like object. This reduces the boilerplate needed when
+ * using convergences with Mocha's hooks.
  *
  * @param {Function} fn - function that may return a Convergence interface
  * @returns {Function} a function able to run the returned object

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,4 +1,4 @@
-import { it as mochaIt } from 'mocha';
+import * as mocha from 'mocha';
 import Convergence from '@bigtest/convergence';
 
 /**
@@ -29,6 +29,37 @@ function convergent(assertion, always) {
 }
 
 /**
+ * Helper to allow automatically running returned objects that implement
+ * a Convergence interface. A Convergence interface is an immutable
+ * instance that supports both `.timeout` and `.run` methods.
+ *
+ * @param {Function} fn - function that may return a Convergence interface
+ * @returns {Function} a function able to run the returned object
+ */
+function handleRunnable(fn) {
+  let isRunnable = (obj) => {
+    return typeof obj.timeout === 'function' &&
+      typeof obj.run === 'function';
+  };
+
+  return function() {
+    let result = fn.apply(this, arguments);
+
+    if (result && isRunnable(result)) {
+      let timeout = 2000;
+
+      if (typeof this.timeout === 'function') {
+        timeout = this.timeout();
+      }
+
+      return result.timeout(timeout).run();
+    } else {
+      return result;
+    }
+  };
+}
+
+/**
  * Convergent it will use the convergent helper to keep testing the assertion
  * repeatedly until it passes or until the timeout is reached
  *
@@ -36,20 +67,20 @@ function convergent(assertion, always) {
  * @param {Function} assertion - the assertion to converge on
  */
 function it(title, assertion) {
-  if (!assertion) return mochaIt.skip(title);
-  return mochaIt(title, convergent(assertion));
+  if (!assertion) return mocha.it.skip(title);
+  return mocha.it(title, convergent(assertion));
 }
 
 /**
- * Convergent it that will inversely keep testing an assertion reapeatedly until
+ * Convergent it that will inversely keep testing an assertion repeatedly until
  * it fails or until the timeout is reached
  *
  * @param {String} title - specification description
  * @param {Function} assertion - the assertion to inversely converge on
  */
 function itAlways(title, assertion) {
-  if (!assertion) return mochaIt.skip(title);
-  return mochaIt(title, convergent(assertion, true));
+  if (!assertion) return mocha.it.skip(title);
+  return mocha.it(title, convergent(assertion, true));
 }
 
 /**
@@ -59,8 +90,8 @@ function itAlways(title, assertion) {
  * @param {Function} assertion - the assertion to converge on
  */
 function itOnly(title, assertion) {
-  if (!assertion) return mochaIt.skip(title);
-  return mochaIt.only(title, convergent(assertion));
+  if (!assertion) return mocha.it.skip(title);
+  return mocha.it.only(title, convergent(assertion));
 }
 
 /**
@@ -70,8 +101,8 @@ function itOnly(title, assertion) {
  * @param {Function} assertion - the assertion to inversely converge on
  */
 function itAlwaysOnly(title, assertion) {
-  if (!assertion) return mochaIt.skip(title);
-  return mochaIt.only(title, convergent(assertion, true));
+  if (!assertion) return mocha.it.skip(title);
+  return mocha.it.only(title, convergent(assertion, true));
 }
 
 /**
@@ -81,7 +112,7 @@ function itAlwaysOnly(title, assertion) {
  * @param {String} title - specification description
  */
 function itPause(title) {
-  return mochaIt(title, function() {
+  return mocha.it(title, function() {
     return new Promise(() => {});
   }).timeout(0);
 }
@@ -92,7 +123,7 @@ function itPause(title) {
  * @param {String} title - specification description
  */
 function itPauseOnly(title) {
-  return mochaIt.only(title, function() {
+  return mocha.it.only(title, function() {
     return new Promise(() => {});
   }).timeout(0);
 }
@@ -107,30 +138,69 @@ it.pause.only = itPauseOnly;
 it.only.pause = itPauseOnly;
 
 // alias mocha's it.skip
-it.skip = mochaIt.skip;
-it.always.skip = mochaIt.skip;
+it.skip = mocha.it.skip;
+it.always.skip = mocha.it.skip;
 
-// in BDD interface `specify` is an alias for `it`
-let specify = it;
+/**
+ * Just like mocha's before, but with the ability to automatically
+ * run Convergence-like instances.
+ *
+ * @param {Function} setup - setup function
+ */
+function before(setup) {
+  return mocha.before(handleRunnable(setup));
+}
 
-// in TDD interface `test` is an alias for `it`
-let test = it;
+/**
+ * Just like mocha's beforeEach, but with the ability to automatically
+ * run Convergence-like instances.
+ *
+ * @param {Function} setup - setup function
+ */
+function beforeEach(setup) {
+  return mocha.beforeEach(handleRunnable(setup));
+}
 
-// export our convergent it (and aliases)
-export { it, specify, test };
+/**
+ * Just like mocha's after, but with the ability to automatically
+ * run Convergence-like instances.
+ *
+ * @param {Function} teardown - teardown function
+ */
+function after(teardown) {
+  return mocha.after(handleRunnable(teardown));
+}
+
+/**
+ * Just like mocha's afterEach, but with the ability to automatically
+ * run Convergence-like instances.
+ *
+ * @param {Function} teardown - teardown function
+ */
+function afterEach(teardown) {
+  return mocha.afterEach(handleRunnable(teardown));
+}
+
+// export our convergent it, wrapped hooks, and their aliases
+export {
+  it,
+  before,
+  beforeEach,
+  after,
+  afterEach,
+  // TDD interface aliases
+  it as test,
+  // BDD interface aliases
+  it as specify,
+  before as suiteSetup,
+  beforeEach as setup,
+  after as suiteTeardown,
+  afterEach as teardown
+};
 
 // export other mocha functions used for testing
 export {
   describe,
   context,
-  before,
-  beforeEach,
-  after,
-  afterEach,
-  // BDD interface functions
-  suite,
-  suiteSetup,
-  setup,
-  suiteTeardown,
-  teardown
+  suite
 } from 'mocha';

--- a/packages/mocha/tests/fixtures/hooks-fixture.js
+++ b/packages/mocha/tests/fixtures/hooks-fixture.js
@@ -1,0 +1,92 @@
+import {
+  describe,
+  before,
+  beforeEach,
+  after,
+  afterEach,
+  it
+} from '../../src';
+import { expect } from 'chai';
+import Convergence from '@bigtest/convergence';
+
+describe('hooks', () => {
+  let test;
+
+  describe('before', () => {
+    before(() => {
+      return new Convergence()
+        .do(() => test = true);
+    });
+
+    after(() => {
+      return new Convergence()
+        .do(() => test = false);
+    });
+
+    it('runs the before convergence', () => {
+      expect(test).to.be.true;
+    });
+  });
+
+  describe('after', () => {
+    it('runs the after convergence', () => {
+      expect(test).to.be.false;
+    });
+  });
+
+  describe('beforeEach', () => {
+    beforeEach(() => {
+      return new Convergence()
+        .do(() => test = 'hello');
+    });
+
+    afterEach(() => {
+      return new Convergence()
+        .do(() => test = 'goodbye');
+    });
+
+    it('runs the beforeEach convergence', () => {
+      expect(test).to.equal('hello');
+    });
+  });
+
+  describe('afterEach', () => {
+    it('runs the afterEach convergence', () => {
+      expect(test).to.equal('goodbye');
+    });
+  });
+
+  describe('existing functionality', () => {
+    describe('before & beforeEach', () => {
+      before(() => {
+        return Promise.resolve()
+          .then(() => test = 0);
+      });
+
+      beforeEach(() => {
+        return Promise.resolve()
+          .then(() => test += 5);
+      });
+
+      after(() => {
+        return Promise.resolve()
+          .then(() => test -= 2);
+      });
+
+      afterEach(() => {
+        return Promise.resolve()
+          .then(() => test -= 2);
+      });
+
+      it('still works', () => {
+        expect(test).to.equal(5);
+      });
+    });
+
+    describe('after & afterEach', () => {
+      it('still works', () => {
+        expect(test).to.equal(1);
+      });
+    });
+  });
+});

--- a/packages/mocha/tests/fixtures/hooks-timing-fixture.js
+++ b/packages/mocha/tests/fixtures/hooks-timing-fixture.js
@@ -1,0 +1,20 @@
+import { describe, before, it } from '../../src';
+import { expect } from 'chai';
+import Convergence from '@bigtest/convergence';
+
+describe('hooks timing', () => {
+  let start, end;
+
+  before(function() {
+    this.timeout(200);
+
+    return new Convergence()
+      .do(() => start = Date.now())
+      .always(() => expect(true).to.be.true)
+      .do(() => end = Date.now());
+  });
+
+  it('runs the convergence within the timeout', () => {
+    expect(end - start).to.be.within(180, 200);
+  });
+});

--- a/packages/mocha/tests/fixtures/it-fixture.js
+++ b/packages/mocha/tests/fixtures/it-fixture.js
@@ -1,7 +1,7 @@
 import { describe, before, after, it } from '../../src';
 import { expect } from 'chai';
 
-describe('it', function() {
+describe('it', () => {
   let value = 0;
   let interval;
 

--- a/packages/mocha/tests/fixtures/it.always-fixture.js
+++ b/packages/mocha/tests/fixtures/it.always-fixture.js
@@ -1,7 +1,7 @@
 import { describe, beforeEach, afterEach, it } from '../../src';
 import { expect } from 'chai';
 
-describe('it.always', function() {
+describe('it.always', () => {
   let value = 0;
   let timeout;
 

--- a/packages/mocha/tests/fixtures/it.always.only-fixture.js
+++ b/packages/mocha/tests/fixtures/it.always.only-fixture.js
@@ -1,7 +1,7 @@
 import { describe, beforeEach, afterEach, it } from '../../src';
 import { expect } from 'chai';
 
-describe('it.always.only', function() {
+describe('it.always.only', () => {
   let value = 0;
   let timeout;
 

--- a/packages/mocha/tests/fixtures/it.only-fixture.js
+++ b/packages/mocha/tests/fixtures/it.only-fixture.js
@@ -1,7 +1,7 @@
 import { describe, before, after, it } from '../../src';
 import { expect } from 'chai';
 
-describe('it.only', function() {
+describe('it.only', () => {
   let value = 0;
   let interval;
 

--- a/packages/mocha/tests/hooks-test.js
+++ b/packages/mocha/tests/hooks-test.js
@@ -1,0 +1,29 @@
+import { describe, before, it } from 'mocha';
+import { expect } from 'chai';
+import { run } from './helpers';
+
+describe('BigTest Mocha: hooks', () => {
+  let stats;
+
+  before(() => run('hooks-fixture.js').then((results) => {
+    stats = results.stats;
+  }));
+
+  it('runs returned convergences automatically', () => {
+    expect(stats.passes).to.equal(stats.tests);
+    expect(stats.failures).to.equal(0);
+  });
+});
+
+describe('BigTest Mocha: hooks timing', () => {
+  let stats;
+
+  before(() => run('hooks-timing-fixture.js').then((results) => {
+    stats = results.stats;
+  }));
+
+  it('runs the convergence within the timeout', () => {
+    expect(stats.passes).to.equal(1);
+    expect(stats.failures).to.equal(0);
+  });
+});


### PR DESCRIPTION
As per some [discussion in #23](https://github.com/thefrontside/bigtest/pull/23#discussion_r160558026), this wraps Mocha's hooks to automatically run returned convergences within the current timeout period.