### PR TITLE
Disable requiring mocha directly in browser environments

### DIFF
--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -6,6 +6,9 @@
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",
   "module": "src/index.js",
+  "browser": {
+    "mocha": false
+  },
   "scripts": {
     "build": "rollup --config",
     "test": "mocha --opts ./tests/mocha.opts ./tests",

--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -1,4 +1,4 @@
-import * as mocha from 'mocha';
+import * as mocha from './mocha';
 import Convergence from '@bigtest/convergence';
 
 /**
@@ -194,6 +194,9 @@ function afterEach(teardown) {
   return mocha.afterEach(handleRunnable(teardown));
 }
 
+// destructure this for exporting
+let { describe } = mocha;
+
 // export our convergent it, wrapped hooks, and their aliases
 export {
   it,
@@ -201,19 +204,15 @@ export {
   beforeEach,
   after,
   afterEach,
+  describe,
   // TDD interface aliases
   it as test,
+  describe as context,
   // BDD interface aliases
   it as specify,
   before as suiteSetup,
   beforeEach as setup,
   after as suiteTeardown,
-  afterEach as teardown
+  afterEach as teardown,
+  describe as suite
 };
-
-// export other mocha functions used for testing
-export {
-  describe,
-  context,
-  suite
-} from 'mocha';

--- a/packages/mocha/src/mocha.js
+++ b/packages/mocha/src/mocha.js
@@ -1,0 +1,32 @@
+// This file exports any globally defined mocha functions, otherwise
+// it exports them from the mocha module directly.
+//
+// In a browser environment, mocha is usually included before the
+// tests and has defined it's functions within the global context.
+// Requiring mocha directly is currently disabled in browser
+// environments via the `browser` field in this package's
+// `package.json` file. This is because the mocha entrypoint has not
+// yet been optimized to work with browser bundles without first
+// disabling certain node modules.
+//
+// @see https://github.com/mochajs/mocha/issues/2448
+
+import * as mocha from 'mocha';
+
+let {
+  describe = global.describe,
+  before = global.before,
+  beforeEach = global.beforeEach,
+  after = global.before,
+  afterEach = global.afterEach,
+  it = global.it
+} = mocha;
+
+export {
+  describe,
+  before,
+  beforeEach,
+  after,
+  afterEach,
+  it
+};


### PR DESCRIPTION
## Purpose

The mocha entrypoint has not yet been optimized to work with browser bundles without first disabling certain node modules.

https://github.com/mochajs/mocha/issues/2448

## Approach

In a browser environment, mocha is usually included before the tests and has defined it's functions within the global context. Requiring mocha directly is now disabled in browser environments via the `browser` field in this package's `package.json` file.

Added a `mocha.js` file which imports all of mocha's exports, and defaults the relevant ones with the defined globals. Since mocha is now disabled for browsers, this will effectively export the globally defined mocha functions as named exports.