### PR TITLE
Add convergence .append() method

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- `.append()` method to combine convergences together
+
 - "module" entry point to support native consumption of @bigtest/mocha
   as es module
 

--- a/packages/convergence/README.md
+++ b/packages/convergence/README.md
@@ -228,6 +228,19 @@ converge
   })
 ```
 
+**`.append()`**
+
+Combines convergences to allow composing them together to create brand
+new convergence instances.
+
+``` javascript
+let converge1 = converge.once(() => total === 1)
+let converge5 = converge.once(() => total === 5)
+
+// converges when the total first equals `1` and then equals `5`
+converge1.append(converge5)
+```
+
 **`.run()`**
 
 In order to actually run a `Convergence` instance, you must call the

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -135,6 +135,24 @@ export default class Convergence {
   }
 
   /**
+   * Appends a convergence to this convergence's stack to allow
+   * composing different convergences together
+   *
+   * @param {Convergence} convergence - a convergence instance
+   * @returns {Convergence} a new convergence instance
+   */
+  append(convergence) {
+    if (!(convergence instanceof Convergence)) {
+      throw new Error('.append() only works with other convergence instances');
+    }
+
+    return new Convergence(this._timeout, [
+      ...this._stack,
+      ...convergence._stack
+    ]);
+  }
+
+  /**
    * Returns a promise that will resolve once all convergences in the
    * stack have been met within this instance's timeout period. The
    * return value from previous functions in the stack will be given

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -125,6 +125,37 @@ describe('BigTest Convergence', () => {
         expect(callback._stack[1]).to.have.property('exec', fn);
       });
     });
+
+    describe('combining convergences with `.append()`', () => {
+      let combined;
+
+      beforeEach(() => {
+        combined = converge.append(
+          new Convergence().once(() => {})
+        );
+      });
+
+      it('creates a new instance', () => {
+        expect(combined).to.be.an.instanceOf(Convergence);
+        expect(combined).to.not.equal(converge);
+      });
+
+      it('creates a new stack', () => {
+        expect(combined._stack).to.not.equal(converge._stack);
+        expect(combined._stack).to.have.lengthOf(1);
+        expect(converge._stack).to.have.lengthOf(0);
+      });
+
+      it('combines the two stacks', () => {
+        let fn = () => {};
+
+        combined = combined.append(
+          new Convergence().do(fn)
+        );
+
+        expect(combined._stack[1]).to.have.property('exec', fn);
+      });
+    });
   });
 
   describe('running convergences', () => {
@@ -268,6 +299,19 @@ describe('BigTest Convergence', () => {
 
         await expect(assertion.run()).to.be.rejected;
         expect(called).to.be.false;
+      });
+    });
+
+    describe('after using `.append()`', () => {
+      it('runs methods from the other convergence', async () => {
+        let called = false;
+
+        let assertion = converge.once(() => expect(total).to.equal(5));
+        assertion = assertion.append(converge.do(() => called = true));
+
+        createTimeout(() => total = 5, 50);
+        await expect(assertion.run()).to.be.fulfilled;
+        expect(called).to.be.true;
       });
     });
 


### PR DESCRIPTION
## Purpose

Convergences are basically Monoids, and by extension SemiGroups. They should support an `.append()` method to "smash" two convergences together.

## Open Questions

Should we also have a `.reduce()` method? Or I also considered allowing `.append()` to take multiple arguments like `.append(...convergences)`. Which would be similar to a monoid's `reduce`