### PR TITLE
Make Convergences Extendable

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- ability to extend the convergence class
+
+### Changed
+
+- convergence constructor to be more general to allow subclasses to
+  handle their own construction
+
 ## [0.2.0] - 2018-02-16
 
 ### Added

--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.3.0] - 2018-02-18
+
 ### Added
 
 - ability to extend the convergence class

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",


### PR DESCRIPTION
## Purpose
This allows us to create custom convergence by extending the `Convergence` class.

## Approach
Where we were previously calling `new Convergence` in our methods, we need to call `new this.constructor` to allow subclasses to be created when extending the convergence class.

The constructor arguments have been generalized so that subclasses can handle their own initialization with different options as long as they call `super(options, prev)`. Creating a convergence using `new Convergence(timeout)` is still supported as the public API for creating convergences.

I also bumped the version so we can release this with the same PR.