### PR TITLE
Link @bigtest/interaction from the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ thing else. Big questions need big tests.
 
 > Bigtest is in the process of being extracted from several different
 > projects and so it is very much in the "component pieces" phase. You
-> can [use][1] [these][2] [pieces][3] in your own projects, but there
+> can [use][1] [these][2] [pieces][3] [in][4] your own projects, but there
 > is going to be some manual integration involved.
 
 What does a big test look like?
@@ -26,6 +26,8 @@ Does your appication run in a browser? Then if a test is going to
 measure whether it works or not, it also needs to run in a _real_
 browser that a _real_ user might use, and it should dispatch _real_ UI
 events against a _real_ DOM.
+
+- [@bigtest/interaction][4]
 
 ### Real Asynchrony
 
@@ -46,3 +48,4 @@ the network too. Otherwise, you're measuring air.
 [1]: packages/convergence
 [2]: packages/mocha
 [3]: packages/mirage
+[4]: packages/interaction


### PR DESCRIPTION
Bigtest is still very much a loose collection of tools that folks have to manually integrate. Each tool has a very complete README, but the main README is still one of the few places to discover _all_ of the parts.

This adds a link to the interaction package so that folks can find it from the main project.