### PR TITLE
Default mocha `it.always` timeout to 100ms

### DIFF
--- a/packages/mocha/src/index.js
+++ b/packages/mocha/src/index.js
@@ -93,7 +93,7 @@ function it(title, assertion) {
  */
 function itAlways(title, assertion) {
   if (!assertion) return mocha.it.skip(title);
-  return mocha.it(title, convergent(assertion, true));
+  return mocha.it(title, convergent(assertion, true)).timeout(100);
 }
 
 /**
@@ -115,7 +115,7 @@ function itOnly(title, assertion) {
  */
 function itAlwaysOnly(title, assertion) {
   if (!assertion) return mocha.it.skip(title);
-  return mocha.it.only(title, convergent(assertion, true));
+  return mocha.it.only(title, convergent(assertion, true)).timeout(100);
 }
 
 /**

--- a/packages/mocha/tests/fixtures/it.always-fixture.js
+++ b/packages/mocha/tests/fixtures/it.always-fixture.js
@@ -2,10 +2,10 @@ import { describe, beforeEach, afterEach, it } from '../../src';
 import { expect } from 'chai';
 
 describe('it.always', () => {
-  let value = 0;
-  let timeout;
+  let value, timeout;
 
   beforeEach(() => {
+    value = 0;
     timeout = setTimeout(() => value = 1, 100);
   });
 
@@ -15,9 +15,13 @@ describe('it.always', () => {
 
   it.always('eventually passes before the timeout', () => {
     expect(value).to.equal(0);
-  }).timeout(100);
+  });
 
   it.always('throws if the assertion eventually fails', () => {
     expect(value).to.equal(0);
-  });
+  }).timeout(200);
+
+  it.always('can modify the timeout', () => {
+    expect(value).to.equal(0);
+  }).timeout(50);
 });

--- a/packages/mocha/tests/it.always-test.js
+++ b/packages/mocha/tests/it.always-test.js
@@ -21,6 +21,11 @@ describe('BigTest Mocha: it.always', () => {
     expect(tests[1].err).to.have.property('expected', '0');
   });
 
+  it('can modify the timeout', () => {
+    expect(tests[2].duration).to.be.within(30, 50);
+    expect(tests[2].err).to.be.empty;
+  });
+
   it('.only has multiple aliases', () => {
     expect(convergentIt.always.only).to.equal(convergentIt.only.always);
   });


### PR DESCRIPTION
## Purpose

When using `it.always` the mocha default timeout of 2000ms is used. This makes testing with `it.always` much slower.

## Approach

Mocha `Runnable` instances have a chainable method interface. So returning `test.timeout(50)` allows us to have a default timeout of `50ms` and still allow changing the timeout with `it.always(...).timeout(100)`.

### Open Questions

- Is 50ms a good default timeout for `it.always`? Or should we go a little higher to say 100ms? At 50ms, the test will run at least 2-3 times (because it aborts about ~20ms before the timeout)