### PR TITLE
Redefine convergence timing

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- convergent assertions no longer attempt to resolve or reject before
+  their timeout
+
 ## [0.3.0] - 2018-02-18
 
 ### Added

--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.4.0] - 2018-03-02
+
 ### Changed
 
 - convergent assertions no longer attempt to resolve or reject before

--- a/packages/convergence/README.md
+++ b/packages/convergence/README.md
@@ -47,8 +47,7 @@ longer returns false or throws an error. When the function is finally
 successfully executed, it is considered to be passing and a converging
 promise will resolve. However, if the converging function does not pass
 within the provided timeout period the promise will reject with the
-last error thrown from the function. A converging promise will reject
-right before the timeout so it is never reached during it's execution.
+last error thrown from the function.
 
 ### Using `Convergence`
 
@@ -142,7 +141,7 @@ convergeLong.timeout(); // => 5000
 Returns a new `Convergence` instance and adds the provided assertion
 to its stack. When this instance is ran, the `assert` function will be
 looped over repeatedly until it passes, or until the convergence's
-timeout has almost been met.
+timeout has been exceeded.
 
 ``` javascript
 // this convergence will resolve once `total` equals `5`

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",

--- a/packages/convergence/src/converge-on.js
+++ b/packages/convergence/src/converge-on.js
@@ -1,29 +1,24 @@
 /**
- * Capture a promise that will only resolve once a given condition
- * has been met. The condition will be tested once every 10ms and is
+ * Capture a promise that will only resolve once a given condition has
+ * been met. The condition will be tested once every 10ms and is
  * considered to be met when it does not error or return false. If the
- * assertion never passes, then the promise will reject right before
- * the timeout period with the last error it recieved while running
- * the assertion.
+ * assertion never passes within the timeout period, then the promise
+ * will reject as soon as it can with the last error it recieved while
+ * running the assertion.
  *
  * If `always` is true, then the promise will resolve only if the
  * condition has been met consistently over the entire timeout
  * period. And it will reject the first time it encounters an
  * error.
  *
- * When `useStats` is true, the returned promise will resolve with a
- * stats object. This stats object holds various information about how
- * this convergent assertion ran.
- *
  * @param {Function} assertion - run to test condition repeatedly
  * @param {Number} [timeout=2000] - milliseconds to check assertion
  * @param {Boolean} [always] - if true, the assertion must pass
  * throughout the entire timeout period
- * @param {Boolean} [useStats] - if true, resolves with a stats object
  * @returns {Promise} resolves if the assertion passes at least once;
  * if `always` is true, then rejects at the first error instead
  */
-export default function convergeOn(assertion, timeout = 2000, always, useStats) {
+export default function convergeOn(assertion, timeout = 2000, always = false) {
   let context = this;
   let start = Date.now();
   let interval = 10;
@@ -41,31 +36,35 @@ export default function convergeOn(assertion, timeout = 2000, always, useStats) 
 
   return new Promise((resolve, reject) => {
     (function loop() {
-      // sometimes it takes almost an entire interval before the promise
-      // is actually rejected, so we need to stop looping before the
-      // second from last interval.
-      let doLoop = (Date.now() - start) + (interval * 2) < timeout;
-
       // track stats
       stats.runs += 1;
 
       try {
-        let ret = assertion.call(context);
+        let results = assertion.call(context);
+
+        // the timeout calculation comes after the assertion so that
+        // the assertion's execution time is accounted for
+        let doLoop = Date.now() - start < timeout;
 
         if (always && doLoop) {
           setTimeout(loop, interval);
-        } else if (ret === false) {
+        } else if (results === false) {
           throw new Error('convergent assertion returned `false`');
+        } else if (!always && !doLoop) {
+          throw new Error(
+            'convergent assertion was successful, ' +
+            `but exceeded the ${timeout}ms timeout`
+          );
         } else {
-          // calculate some stats right before resolving
+          // calculate some stats right before resolving with them
           stats.end = Date.now();
           stats.elapsed = stats.end - start;
-          stats.value = ret;
-
-          // resolve with stats or the assertion return value
-          resolve(useStats ? stats : ret);
+          stats.value = results;
+          resolve(stats);
         }
       } catch (error) {
+        let doLoop = Date.now() - start < timeout;
+
         if (!always && doLoop) {
           setTimeout(loop, interval);
         } else if (always || !doLoop) {

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -38,8 +38,8 @@ import convergeOn from './converge-on';
  * `first.run()` has 100ms to converge on it's assertion.
  *
  * `second.run()` will log `foo` once the first assertion converges
- * and continue to assert the second assertion until just before the
- * 200ms timeout period has expired.
+ * and continue to assert the second assertion until the 200ms timeout
+ * period has expired.
  */
 export default class Convergence {
   /**
@@ -216,7 +216,7 @@ export default class Convergence {
             timeout = last ? timeout : Math.min(timeout, subject.timeout);
           }
 
-          return convergeOn(assert, timeout, subject.always, true)
+          return convergeOn(assert, timeout, subject.always)
           // incorporate stats and curry the assertion return value
             .then((convergeStats) => {
               addStats(convergeStats);

--- a/packages/convergence/tests/converge-on-test.js
+++ b/packages/convergence/tests/converge-on-test.js
@@ -37,14 +37,20 @@ describe('BigTest Convergence - convergeOn', () => {
       }, 50);
     });
 
-    it('resolves when the assertion passes within the timeout', () => {
+    it('resolves when the assertion passes within the timeout', async () => {
       timeout = setTimeout(() => total = 5, 30);
-      return expect(test(5)).to.be.fulfilled;
+
+      let start = Date.now();
+      await expect(test(5)).to.be.fulfilled;
+      expect(Date.now() - start).to.be.within(30, 50);
     });
 
-    it('rejects if the assertion does not pass within the timeout', () => {
+    it('rejects if the assertion does not pass within the timeout', async () => {
       timeout = setTimeout(() => total = 5, 80);
-      return expect(test(5)).to.be.rejected;
+
+      let start = Date.now();
+      await expect(test(5)).to.be.rejected;
+      expect(Date.now() - start).to.be.lt(50);
     });
   });
 
@@ -56,13 +62,18 @@ describe('BigTest Convergence - convergeOn', () => {
       }, 50, true);
     });
 
-    it('resolves if the assertion does not fail throughout the timeout', () => {
-      return expect(test(5)).to.be.fulfilled;
+    it('resolves if the assertion does not fail throughout the timeout', async () => {
+      let start = Date.now();
+      await expect(test(5)).to.be.fulfilled;
+      expect(Date.now() - start).to.be.lt(50);
     });
 
-    it('rejects when the assertion fails within the timeout', () => {
+    it('rejects when the assertion fails within the timeout', async () => {
       timeout = setTimeout(() => total = 0, 30);
-      return expect(test(5)).to.be.rejected;
+
+      let start = Date.now();
+      await expect(test(5)).to.be.rejected;
+      expect(Date.now() - start).to.be.within(30, 50);
     });
   });
 

--- a/packages/convergence/tests/converge-on-test.js
+++ b/packages/convergence/tests/converge-on-test.js
@@ -12,7 +12,7 @@ describe('BigTest Convergence - convergeOn', () => {
     total = 0;
     test = (num) => convergeOn(() => {
       expect(total).to.equal(num);
-    });
+    }, 50);
   });
 
   afterEach(() => {
@@ -21,37 +21,44 @@ describe('BigTest Convergence - convergeOn', () => {
     }
   });
 
-  it('resolves when the assertion passes', () => {
-    total = 5;
-    return expect(test(5)).to.be.fulfilled;
+  it('resolves when the assertion passes within the timeout', async () => {
+    timeout = setTimeout(() => total = 5, 30);
+
+    let start = Date.now();
+    await expect(test(5)).to.be.fulfilled;
+    expect(Date.now() - start).to.be.within(30, 50);
   });
 
-  it('rejects when the assertion does not pass', () => {
-    return expect(test(5)).to.be.rejected;
+  it('rejects when the assertion does not pass within the timeout', async () => {
+    let start = Date.now();
+    await expect(test(5)).to.be.rejectedWith('expected 0 to equal 5');
+    expect(Date.now() - start).to.be.within(50, 70);
   });
 
-  describe('with a specific timeout', () => {
-    beforeEach(() => {
-      test = (num) => convergeOn(() => {
-        expect(total).to.equal(num);
-      }, 50);
-    });
+  it('rejects if the assertion passes, but just after the timeout', async () => {
+    timeout = setTimeout(() => total = 5, 51);
 
-    it('resolves when the assertion passes within the timeout', async () => {
-      timeout = setTimeout(() => total = 5, 30);
+    let start = Date.now();
+    await expect(test(5)).to.be
+      .rejectedWith('convergent assertion was successful, but exceeded the 50ms timeout');
+    expect(Date.now() - start).to.be.within(50, 70);
+  });
 
-      let start = Date.now();
-      await expect(test(5)).to.be.fulfilled;
-      expect(Date.now() - start).to.be.within(30, 50);
-    });
+  it('resolves with a stats object', async () => {
+    test = (num) => convergeOn(() => total === 5 && total * 100);
+    timeout = setTimeout(() => total = 5, 30);
 
-    it('rejects if the assertion does not pass within the timeout', async () => {
-      timeout = setTimeout(() => total = 5, 80);
+    let start = Date.now();
+    let stats = await expect(test(5)).to.be.fulfilled;
+    let end = Date.now();
 
-      let start = Date.now();
-      await expect(test(5)).to.be.rejected;
-      expect(Date.now() - start).to.be.lt(50);
-    });
+    expect(stats.start).to.be.within(start, start + 1);
+    expect(stats.end).to.be.within(end - 1, end);
+    expect(stats.elapsed).to.be.within(30, 50);
+    expect(stats.runs).to.equal(4);
+    expect(stats.always).to.be.false;
+    expect(stats.timeout).to.equal(2000);
+    expect(stats.value).to.equal(500);
   });
 
   describe('when `always` is true', () => {
@@ -65,7 +72,7 @@ describe('BigTest Convergence - convergeOn', () => {
     it('resolves if the assertion does not fail throughout the timeout', async () => {
       let start = Date.now();
       await expect(test(5)).to.be.fulfilled;
-      expect(Date.now() - start).to.be.lt(50);
+      expect(Date.now() - start).to.be.within(50, 70);
     });
 
     it('rejects when the assertion fails within the timeout', async () => {
@@ -131,50 +138,27 @@ describe('BigTest Convergence - convergeOn', () => {
       }
     };
 
-    it('rejects within the timeout', async () => {
+    it('rejects as soon as it can after the timeout', async () => {
       let start = Date.now();
 
       await expect(
         // 5-10ms latencies start causing an increasing amount of
         // flakiness, anything higher fails more often than not
-        convergeOn(() => !!latency(20), 100)
+        convergeOn(() => !!latency(20), 50)
       ).to.be.rejected;
 
-      expect(Date.now() - start).to.be.lt(100);
+      // 10ms loop interval + 20ms latency = ~+30ms final latency
+      expect(Date.now() - start).to.be.within(50, 80);
     });
 
-    it('using always resolves within the timeout', async () => {
+    it('using always resolves as soon as it can after the timeout', async () => {
       let start = Date.now();
 
       await expect(
-        convergeOn(() => latency(20), 100, true)
+        convergeOn(() => latency(20), 50, true)
       ).to.be.fulfilled;
 
-      expect(Date.now() - start).to.be.lt(100);
-    });
-  });
-
-  describe('when `useStats` is true', () => {
-    beforeEach(() => {
-      test = (num) => convergeOn(() => {
-        return total === num && num * 100;
-      }, 50, false, true);
-    });
-
-    it('resolves with a stats object', async () => {
-      timeout = setTimeout(() => total = 5, 30);
-
-      let start = Date.now();
-      let stats = await expect(test(5)).to.be.fulfilled;
-      let end = Date.now();
-
-      expect(stats.start).to.be.within(start, start + 1);
-      expect(stats.end).to.be.within(end - 1, end);
-      expect(stats.elapsed).to.be.within(28, 52);
-      expect(stats.runs).to.equal(4);
-      expect(stats.always).to.be.false;
-      expect(stats.timeout).to.equal(50);
-      expect(stats.value).to.equal(500);
+      expect(Date.now() - start).to.be.within(50, 80);
     });
   });
 });

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -291,15 +291,18 @@ describe('BigTest Convergence', () => {
         }, 50);
       });
 
-      it('resolves just before the 100ms timeout', async () => {
+      it('resolves after the 100ms timeout', async () => {
         let start = Date.now();
         await expect(assertion.run()).to.be.fulfilled;
-        expect(Date.now() - start).to.be.within(80, 100);
+        expect(Date.now() - start).to.be.within(100, 120);
       });
 
-      it('rejects when the assertion fails', () => {
+      it('rejects when the assertion fails', async () => {
         createTimeout(() => total = 10, 50);
-        return expect(assertion.run()).to.be.rejected;
+
+        let start = Date.now();
+        await expect(assertion.run()).to.be.rejected;
+        expect(Date.now() - start).to.be.within(50, 70);
       });
 
       describe('with additional chaining', () => {
@@ -312,12 +315,15 @@ describe('BigTest Convergence', () => {
         it('resolves after at least 50ms', async () => {
           let start = Date.now();
           await expect(assertion.run()).to.be.fulfilled;
-          expect(Date.now() - start).to.be.within(30, 50);
+          expect(Date.now() - start).to.be.within(50, 70);
         });
 
-        it('rejects if the assertion fails within 50ms', () => {
+        it('rejects if the assertion fails within 50ms', async () => {
           createTimeout(() => total = 10, 30);
-          return expect(assertion.run()).to.be.rejected;
+
+          let start = Date.now();
+          await expect(assertion.run()).to.be.rejected;
+          expect(Date.now() - start).to.be.within(30, 50);
         });
       });
     });
@@ -372,7 +378,7 @@ describe('BigTest Convergence', () => {
     });
 
     describe('after using various chain methods', () => {
-      it('resolves with a stats object', async () => {
+      it('resolves with a combined stats object', async () => {
         let assertion = converge
           .once(() => expect(total).to.equal(5))
           .do(() => total = 10)
@@ -387,7 +393,7 @@ describe('BigTest Convergence', () => {
 
         expect(stats.start).to.be.within(start, start + 1);
         expect(stats.end).to.be.within(end - 1, end);
-        expect(stats.elapsed).to.be.within(50, 70);
+        expect(stats.elapsed).to.be.within(70, 90);
         expect(stats.runs).to.be.within(8, 12);
         expect(stats.timeout).to.equal(100);
         expect(stats.value).to.equal(50);

--- a/packages/interaction/karma.conf.js
+++ b/packages/interaction/karma.conf.js
@@ -20,12 +20,14 @@ module.exports = (config) => {
       module: {
         rules: [{
           test: /\.js$/,
-          exclude: /node_modules/,
+          exclude: /node_modules(?!\/@bigtest)/,
           loader: 'babel-loader',
           options: {
             babelrc: false,
             presets: [
-              ['@babel/env', { modules: false }]
+              ['@babel/preset-env', {
+                modules: false
+              }]
             ]
           }
         }]

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.2.2] - 2018-03-02
+
 ### Changed
 
 - lock `@bigtest/convergence` at `0.3.0`

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- lock `@bigtest/convergence` at `0.3.0`
+
 ## [0.2.1] - 2018-02-20
 
 ### Added

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -19,7 +19,7 @@
     "/dist/"
   ],
   "dependencies": {
-    "@bigtest/convergence": "^0.3.0"
+    "@bigtest/convergence": "0.3.0"
   },
   "peerDependencies": {
     "mocha": "^4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@bigtest/convergence@0.3.0", "@bigtest/convergence@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.3.0.tgz#c69a8219e5c6f3b092651117debd3990610118c8"
+
 JSONStream@^1.0.3:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"


### PR DESCRIPTION
## Purpose

After using `@bigtest/mocha` in  real projects, it seems as though `it.always` [can sometimes be flakey](https://travis-ci.org/folio-org/ui-eholdings/builds/346465220).

After digging into this issue a little bit, I found that the problem is with how we attempt to resolve or reject the converging promise _before the timeout_.

When we created `@bigtest/convergence`, the goal was to help mitigate waiting for the right time to run our tests. What we ended up doing in our convergence is trying to _wait for the right time to settle the promise_. So unknowingly, we ended up creating a very similar problem.

As seen in [these tests](https://circleci.com/gh/thefrontside/bigtest/492), when a convergent assertion has some latency associated with it's execution, it is resolved or rejected _after the timeout_. In `@bigtest/mocha` this results in the convergences not settling in time for mocha's own timeout and causes painful mocha timeout errors.

This issue is not just with `always` convergences. I found that there are situations in which a normal convergence will _successfully_ converge _after_ the timeout. Both situations can be explained by walking through the final loops of a convergence given an assertion with some latency in execution.

Given a `100ms` timeout:
- `79ms` has elapsed within convergence (before the final loop)
- `+6ms` latency for assertion to complete
- `+10ms` wait before looping again (setTimeout)
- `95ms` have elapsed; convergence will settle during this loop
- `+6ms` latency for assertion to complete
- `101ms` - convergence settles, **but not within the timeout**

Even if we just add a rejection after the timeout, that will still cause tests to show cryptic timeout errors when the convergence exceeds the test's timeout.

## Solution

Redefine convergence timing **so that convergences settle as soon as they can**. This means we don't have to attempt to settle one or two intervals before the timeout. We can just settle as soon as the timeout has been exceeded.

For typical convergences, they will still resolve before the timeout, but at any time after the timeout they will reject; _even if the assertion has finally passed_, if it happens after the timeout, the convergence has failed.

For `always` convergences, they will reject before the timeout, and always resolve after the timeout (as long as the assertion passes during every interval).

### Todo / Open Questions

- `@bigtest/convergence` only increments the minor version because this package is not yet at a `1.0.0` release. If we should release this as `1.0.0`, I can amend that commit before merging.

- I locked `@bigtest/mocha` at `@bigtest/convergence: "0.3.0"` so that it still currently works as expected. I also incremented the `@bigtest/mocha` patch version so that dependent projects will not break (as long as they're not locked to a previous version). That does mean that this single PR will release two of our packages at the same time (unless we bump up `@bigtest/convergence` to `1.0.0`)

- After this is released, `@bigtest/mocha` should be updated with this new convergence behavior. I think we could introduce a `latency` to ensure convergence timeouts are at least `x` ms quicker than mocha timeouts. This latency could be customized per project and increased in CI environments where things typically take a bit longer to execute.

- Due to the dependency lock within `@bigtest/mocha`, this is the first time dependencies of other packages within this repo are not linked. As such, it revealed that our module entry points are not set up correctly:

  It is common in a webpack environment when using babel to not transform modules within the `node_modules` directory. When `@bigtest/convergence` is not linked, this causes tests within `@bigtest/interaction` to fail due to transpilation errors. We need to define builds for our packages that compile true es-modules instead of just referencing `src` in our packages' `module` fields.