### PR TITLE
Actually release @bigtest/mocha v0.2.2

### DIFF
--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-## [0.2.2] - 2018-03-02
+## [0.2.2] - 2018-03-03
 
 ### Changed
 

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/mocha",
   "description": "Mocha helpers for testing big",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",


### PR DESCRIPTION
Looks like I accidentally forgot to increment the version number in [this commit](https://github.com/thefrontside/bigtest/pull/54/commits/a5a2f0705c96a6c6f633d3b947470378f253239e)