### PR TITLE
Fix mocha convergence autorun

### DIFF
--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.3.1]
+
 ### Fixed
 
 - correctly identify a convergence interface when auto-running from hooks

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- correctly identify a convergence interface when auto-running from hooks
+
 ## [0.3.0] - 2018-03-05
 
 ### Changed

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/mocha",
   "description": "Mocha helpers for testing big",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",

--- a/packages/mocha/src/utils.js
+++ b/packages/mocha/src/utils.js
@@ -49,11 +49,18 @@ export function convergent(assertion, always) {
  * @returns {Function} a function able to run the returned object
  */
 export function handleConvergence(fn) {
+  let hasConvergenceInterface = (obj) => {
+    return obj &&
+      Array.isArray(obj._stack) &&
+      typeof obj.timeout === 'function' &&
+      typeof obj.run === 'function';
+  };
+
   return function() {
     let result = fn.apply(this, arguments);
     let timeout = this.timeout();
 
-    if (result && result instanceof Convergence) {
+    if (hasConvergenceInterface(result)) {
       // convergences have their own timeout
       this.timeout(0);
       // run the convergence with the original timeout


### PR DESCRIPTION
## Purpose

Since `@bigtest/interaction` was changed to extend the `Convergence` class, we checked for a convergence instance via `instanceof`. Turns out when the `@bigtest/convergence` versions are different, `instanceof` does not work as expected because `Convergence` in `@bigtest/mocha` references a _technically_ different class (a newer one).

## Approach

Add a `hasConvergenceInterface` helper to the hook wrapper that will return `true` if the instance has a `_stack` array property, and both `.timeout()` and `.run()` methods.