### PR TITLE
Add full support for returning promises in convergence `.do()` blocks

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- full support for returning promises in `.do()` blocks
+- timeout error thrown when convergence exceeds timeout
+
 ## [0.4.0] - 2018-03-02
 
 ### Changed


### PR DESCRIPTION
## Purpose

This was previously, loosely, supported due to the currying nature of `.do()` blocks within a promise. This makes stats for these blocks actually report the true times and return values of the promises.

## Approach

When the result of a `.do()` block is thenable, the stats are calculated when it resolves. Otherwise, they are calculated right away.

If a promise takes longer than the remaining timeout, an error will be thrown after the promise resolves. This same error will now also be thrown before assertions if the elapsed time exceeds the allotted timeout. Before, if a `.do()` block made the convergence exceed the timeout, the following convergent assertion could be called with a negative timeout. That is no longer possible when throwing the new timeout error.