### PR TITLE
Fix @bigtest/interaction isPresent page property

### DIFF
--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -4,3 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+
+### Changed
+
+- upgrade `@bigtest/convergence` to `0.4.0`

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -8,3 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - upgrade `@bigtest/convergence` to `0.4.0`
+
+### Fixed
+
+- `isPresent` property returns false when the root does not exist

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -43,6 +43,6 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.3.0"
+    "@bigtest/convergence": "^0.4.0"
   }
 }

--- a/packages/interaction/src/properties/is-present.js
+++ b/packages/interaction/src/properties/is-present.js
@@ -9,6 +9,11 @@ import { computed } from './helpers';
  */
 export default function(selector) {
   return computed(function() {
-    return !!this.$$(selector).length;
+    try {
+      // throws if the root element cannot be found
+      return !!this.$$(selector).length;
+    } catch (e) {
+      return false;
+    }
   });
 }

--- a/packages/interaction/tests/properties/is-present-test.js
+++ b/packages/interaction/tests/properties/is-present-test.js
@@ -31,5 +31,9 @@ describe('BigTest Interaction: isVisible', () => {
     it('returns false if the element does not exist', () => {
       expect(new TestPage().isNotThere).to.be.false;
     });
+
+    it('returns false with a non-existent scope', () => {
+      expect(new TestPage('#no-exist').isThere).to.be.false;
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@bigtest/convergence@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.3.0.tgz#c69a8219e5c6f3b092651117debd3990610118c8"
-
 JSONStream@^1.0.3:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"


### PR DESCRIPTION
## Purpose

Fixes #58.

When the `selector` is not provided, the property should work with the page's root element. For `isPresent`, it throws an error when the root does not exist when it should return `false`.

## Approach

Wrap the return statement in a try-catch block that returns `false` when an error is thrown.

Also upgraded the `@bigtest/convergence` dependency to bring in the new convergence timing.