### PR TITLE
Handle returned convergences in `.do()` blocks

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - full support for returning promises in `.do()` blocks
 - timeout error thrown when convergence exceeds timeout
+- support for returning convergence in `.do()` blocks
 
 ## [0.4.0] - 2018-03-02
 

--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,11 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.5.0] - 2018-03-14
+
 ### Added
 
 - full support for returning promises in `.do()` blocks
 - timeout error thrown when convergence exceeds timeout
 - support for returning convergence in `.do()` blocks
+- `isConvergence` helper function
 
 ## [0.4.0] - 2018-03-02
 

--- a/packages/convergence/README.md
+++ b/packages/convergence/README.md
@@ -227,6 +227,19 @@ converge
   })
 ```
 
+You can even return promises, or other convergences from this method.
+
+``` javascript
+converge
+  .do(() => Promise.resolve(5))
+  .do((total) => new Convergence()
+    // the final always will still get the remaining time
+    .always(() => total === 5 && total))
+  // ... unless it is followed by additional methods
+  .do((total) => total *= 100)
+```
+
+
 **`.append()`**
 
 Combines convergences to allow composing them together to create brand

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -1,4 +1,8 @@
-import convergeOn from './converge-on';
+import {
+  isConvergence,
+  runAssertion,
+  runExec
+} from './utils';
 
 /**
  * The convergence class. Creating a new Convergence instance allows
@@ -41,7 +45,7 @@ import convergeOn from './converge-on';
  * and continue to assert the second assertion until the 200ms timeout
  * period has expired.
  */
-export default class Convergence {
+class Convergence {
   /**
    * @constructor
    * @param {Object|Number} options - internal options, or a timeout
@@ -121,8 +125,8 @@ export default class Convergence {
   always(assert, timeout) {
     return new this.constructor({
       _stack: [{
-        timeout: Math.max(timeout || (this._timeout / 10), 20),
         always: true,
+        timeout,
         assert
       }]
     }, this);
@@ -188,94 +192,15 @@ export default class Convergence {
       stack: []
     };
 
-    let addStats = (newStats) => {
-      stats.runs += newStats.runs;
-      stats.elapsed += newStats.elapsed;
-      stats.end = newStats.end;
-      stats.value = newStats.value;
-      stats.stack.push(newStats);
-    };
-
-    // throws when the elapsed time exceeds the timeout
-    let getElapsedSince = (start) => {
-      let elapsed = Date.now() - start;
-
-      // we shouldn't continue beyond the timeout
-      if (elapsed >= stats.timeout) {
-        throw new Error(`convergence exceeded the ${stats.timeout}ms timeout`);
-      }
-
-      return elapsed;
-    };
-
+    // reduce to a single promise that runs each item in the stack
     return this._stack.reduce((promise, subject, i) => {
       let last = i === (this._stack.length - 1);
 
       return promise.then((ret) => {
-        // an assertion should be convergent
         if (subject.assert) {
-          let timeout = stats.timeout - getElapsedSince(start);
-          let assert = subject.assert.bind(null, ret);
-
-          // always convergences need timeouts smaller than the
-          // total timeout so that any future assertions can still
-          // converge within the total timeout period
-          if (subject.always) {
-            // if the last assertion in the chain is an always
-            // convergence, then it is allowed to take the remaining
-            // timeout period
-            timeout = last ? timeout : Math.min(timeout, subject.timeout);
-          }
-
-          return convergeOn(assert, timeout, subject.always)
-          // incorporate stats and curry the assertion return value
-            .then((convergeStats) => {
-              addStats(convergeStats);
-              return convergeStats.value;
-            });
-
-        // `.do()` blocks are run once previous assertions converge
+          return runAssertion(subject, ret, last, stats);
         } else if (subject.exec) {
-          let execStart = Date.now();
-          let result = subject.exec(ret);
-
-          let collectStats = (value) => {
-            addStats({
-              runs: 1,
-              start: execStart,
-              end: Date.now(),
-              elapsed: getElapsedSince(execStart),
-              value
-            });
-
-            return value;
-          };
-
-          // a convergence is called with the current remaining timeout
-          if (result && result._stack &&
-              typeof result.timeout === 'function' &&
-              typeof result.run === 'function') {
-            let timeout = stats.timeout - getElapsedSince(start);
-
-            // this .do() just prevents the last .always() from using
-            // the entire timeout
-            return result.do(ret => ret).timeout(timeout).run()
-              // merge stats and curry the return value
-              .then((convergeStats) => {
-                // update elapsed time for sanity
-                convergeStats.elapsed = getElapsedSince(execStart);
-                addStats(convergeStats);
-                return convergeStats.value;
-              });
-
-          // a promise will need to settle first
-          } else if (result && typeof result.then === 'function') {
-            return result.then(collectStats);
-
-          // any other result is just returned
-          } else {
-            return collectStats(result);
-          }
+          return runExec(subject, ret, last, stats);
         }
       });
     }, Promise.resolve())
@@ -283,3 +208,8 @@ export default class Convergence {
       .then(() => stats);
   }
 }
+
+// static `isConvergence` method
+Convergence.isConvergence = isConvergence;
+
+export default Convergence;

--- a/packages/convergence/src/index.js
+++ b/packages/convergence/src/index.js
@@ -1,2 +1,3 @@
+export { isConvergence } from './utils';
 export { default as convergeOn } from './converge-on';
 export { default } from './convergence';

--- a/packages/convergence/src/utils.js
+++ b/packages/convergence/src/utils.js
@@ -1,0 +1,137 @@
+import convergeOn from './converge-on';
+
+/**
+ * Gets the elapsed time since a `start` time; throws if it exceeds
+ * the allowed `max` timeout.
+ *
+ * @param {Number} start - start time
+ * @param {Number} max - maximum elapsed time
+ * @returns {Number} elapsed time since `start`
+ * @throws {Error} if the elapsed time exceeds `max`
+ */
+function getElapsedSince(start, max) {
+  let elapsed = Date.now() - start;
+
+  // we shouldn't continue beyond the timeout
+  if (elapsed >= max) {
+    throw new Error(`convergence exceeded the ${max}ms timeout`);
+  }
+
+  return elapsed;
+};
+
+/**
+ * Adds stats to the accumulator and returns `stats.value`
+ *
+ * @param {Object} accumulator - stats accumulator
+ * @param {Object} stats - new stats to add
+ * @returns {*} stats.value
+ */
+function collectStats(accumulator, stats) {
+  accumulator.runs += stats.runs;
+  accumulator.elapsed += stats.elapsed;
+  accumulator.end = stats.end;
+  accumulator.value = stats.value;
+  accumulator.stack.push(stats);
+
+  return stats.value;
+}
+
+/**
+ * Returns `true` if the object has `_stack`, `timeout`, and `run`
+ * properties of the correct type
+ *
+ * @param {Object} obj - a possible convergence object
+ * @returns {Boolean}
+ */
+export function isConvergence(obj) {
+  return !!obj && typeof obj === 'object' &&
+    '_stack' in obj && Array.isArray(obj._stack) &&
+    'timeout' in obj && typeof obj.timeout === 'function' &&
+    'run' in obj && typeof obj.run === 'function';
+}
+
+/**
+ * Runs a single assertion from a convergence stack with `arg` as the
+ * assertion's argument. Adds convergence stats to the `stats` object.
+ *
+ * @param {Object} subject - convergence assertion stack item
+ * @param {*} arg - passed as the assertion's argument
+ * @param {Boolean} last - true if this assertion is last in the stack
+ * @param {Object} stats - stats accumulator object
+ * @returns {Promise} resolves with the assertion's return value
+ */
+export function runAssertion(subject, arg, last, stats) {
+  let timeout = stats.timeout - getElapsedSince(stats.start, stats.timeout);
+  let assert = subject.assert.bind(null, arg);
+
+  // the last always uses the remaining timeout
+  if (subject.always && !last) {
+    // timeout needs to be smaller than the total timeout
+    if (subject.timeout) {
+      timeout = Math.min(timeout, subject.timeout);
+      // default the timeout to one-tenth the total, or 20ms min
+    } else {
+      timeout = Math.max(stats.timeout / 10, 20);
+    }
+  }
+
+  return convergeOn(assert, timeout, subject.always)
+  // incorporate stats and curry the assertion return value
+    .then((convergeStats) => collectStats(stats, convergeStats));
+}
+
+/**
+ * Runs a single function from a convergence stack with `arg` as the
+ * function's argument. Adds simple stats to the `stats` object.
+ *
+ * When a promise is returned, the time it takes to resolve is
+ * accounted for in `stats`.
+ *
+ * When a convergence is returned, it's own returned stats are
+ * incorporated into the `stats` object, and it's final return value
+ * is curried on.
+ *
+ * @param {Object} subject - convergence exec stack item
+ * @param {*} arg - passed as the function's argument
+ * @param {Boolean} last - true if this item is last in the stack
+ * @param {Object} stats - stats accumulator object
+ * @returns {Promise} resolves with the function's return value
+ */
+export function runExec(subject, arg, last, stats) {
+  let start = Date.now();
+  let result = subject.exec(arg);
+
+  let collectExecStats = (value) => {
+    return collectStats(stats, {
+      start,
+      runs: 1,
+      end: Date.now(),
+      elapsed: getElapsedSince(start, stats.timeout),
+      value
+    });
+  };
+
+  // a convergence is called with the current remaining timeout
+  if (isConvergence(result)) {
+    let timeout = stats.timeout - getElapsedSince(start, stats.timeout);
+
+    if (!last) {
+      // this .do() just prevents the last .always() from
+      // using the entire timeout
+      result = result.do(ret => ret);
+    }
+
+    return result.timeout(timeout).run()
+    // incorporate stats and curry the return value
+      .then((convergeStats) => collectStats(stats, convergeStats));
+
+  // a promise will need to settle first
+  } else if (result && typeof result.then === 'function') {
+    return result.then(collectExecStats);
+
+  // any other result is just returned
+  } else {
+    return collectExecStats(result);
+  }
+}

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -363,6 +363,50 @@ describe('BigTest Convergence', () => {
         expect(called).to.be.false;
       });
 
+      describe('and returning a convergence', () => {
+        let assertion;
+
+        beforeEach(() => {
+          // converge reference can be modified before running
+          assertion = converge.do(() => converge);
+        });
+
+        it('waits for the convergence to settle', async () => {
+          let start = Date.now();
+
+          converge = converge.always(() => true, 50);
+          await expect(assertion.run()).to.be.fulfilled;
+          expect(Date.now() - start).to.be.within(50, 70);
+        });
+
+        it('rejects when the convergence does', async () => {
+          let start = Date.now();
+          let called = false;
+
+          converge = converge.once(() => false);
+          assertion = assertion.do(() => called = true);
+
+          await expect(assertion.timeout(50).run()).to.be.rejected;
+          expect(Date.now() - start).to.be.within(50, 70);
+          expect(called).to.be.false;
+        });
+
+        it('curries the resolved value to the next function', () => {
+          assertion = assertion
+            .once((val) => expect(val).to.equal(1));
+
+          converge = converge.do(() => 1);
+          return expect(assertion.run()).to.be.fulfilled
+            .and.eventually.have.nested.property('stack[0].value', 1);
+        });
+
+        it('rejects after the exceeding the timeout', () => {
+          converge = converge.always(() => true, 60);
+          return expect(assertion.timeout(50).run()).to.be
+            .rejectedWith('convergence exceeded the 50ms timeout');
+        });
+      });
+
       describe('and returning a promise', () => {
         let assertion, resolve, reject;
 
@@ -393,7 +437,7 @@ describe('BigTest Convergence', () => {
 
         it('curries the resolved value to the next function', () => {
           assertion = assertion
-            .do((val) => expect(val).to.equal(1));
+            .once((val) => expect(val).to.equal(1));
 
           createTimeout(() => resolve(1), 10);
           return expect(assertion.run()).to.be.fulfilled

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@bigtest/convergence@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.4.0.tgz#dc4caa274e4d8e91e5a63eefa8bb76b422e2c7f2"
+
 JSONStream@^1.0.3:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"


### PR DESCRIPTION
## Purpose

When a convergence is returned from a `.do()` block, we should run the returned convergence under the current timeout.

## Approach

When the result of a `.do()` block has a convergence interface, it is run with the current remaining timeout. To prevent `.always()` in the returned convergence from using the remaining timeout, a `.do()` is added which just continues currying the last returned value from the convergence.

Refactored the `.run()` method since it was getting pretty large. There are two main util functions for it, but they use other util functions in the `utils.js` file.

Also added an `isConvergence` method and exported it. Not only do we need in in this package, but `@bigtest/mocha` could also use it. Not only is it exported, but it's available as `Convergence.isConvergence` to mimic `Array.isArray`.

Release this as `0.5.0` since it adds two features (returning convergences and the new helper).

### TODO

- [x] ~The body of the `.run()` method is growing pretty large, I'm going to refactor this a bit into helper functions to thin it out.~
- [x] ~When the returned convergence is last in the stack, we shouldn't add the extra `.do()` and allow an `.always()` to take the remaining time.~