### PR TITLE
Add interaction pause method

### DIFF
--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.2.0] - 2018-03-14
+
 ### Changed
 
 - upgrade `@bigtest/convergence` to `0.5.0`

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
-- upgrade `@bigtest/convergence` to `0.4.0`
+- upgrade `@bigtest/convergence` to `0.5.0`
 
 ### Fixed
 

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -12,3 +12,4 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - `isPresent` property returns false when the root does not exist
+- `.pause()` methods that halts the convergence when it is encountered

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interaction",
   "description": "Interaction library for testing big",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/interaction",
   "main": "dist/index.js",

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -43,6 +43,6 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.4.0"
+    "@bigtest/convergence": "^0.5.0"
   }
 }

--- a/packages/interaction/src/interaction.js
+++ b/packages/interaction/src/interaction.js
@@ -30,6 +30,14 @@ export default class Interaction extends Convergence {
       get: () => $(options.$scope || document.body)
     });
   }
+
+  /**
+   * Pauses an interaction by halting the convergence while it is
+   * running with an unresolving promise
+   */
+  pause() {
+    return this.do(() => new Promise(() => {}));
+  }
 }
 
 // add default interaction methods

--- a/packages/interaction/tests/interaction-test.js
+++ b/packages/interaction/tests/interaction-test.js
@@ -19,6 +19,12 @@ describe('BigTest Interaction: Interaction', () => {
     expect(interaction).to.be.an.instanceOf(Convergence);
   });
 
+  it('has a `pause` method', () => {
+    expect(interaction).to.respondTo('pause');
+    expect(interaction.pause()).to.be.an.instanceOf(Interaction);
+    expect(interaction.pause()).to.not.equal(interaction);
+  });
+
   it('is extendable', async () => {
     let test = false;
 


### PR DESCRIPTION
## Purpose

A pause method that stops the convergence from continuing would be helpful when debugging applications in the middle of an interaction.

## Approach

Updated `@bigtest/convergence` to `0.5.0`

The `.pause()` method on `Interaction` simply returns an unresolving promise from a `.do()` block which will effectively stop the convergence from continuing.
