### PR TITLE
Update mocha convergence

### DIFF
--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- upgraded `@bigtest/convergence` to `^0.5.0`
+
 ## [0.3.1]
 
 ### Fixed

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.3.2]
+
 ### Changed
 
 - upgraded `@bigtest/convergence` to `^0.5.0`

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/mocha",
   "description": "Mocha helpers for testing big",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -19,7 +19,7 @@
     "/dist/"
   ],
   "dependencies": {
-    "@bigtest/convergence": "^0.4.0"
+    "@bigtest/convergence": "^0.5.0"
   },
   "peerDependencies": {
     "mocha": "^4.0.1"

--- a/packages/mocha/src/utils.js
+++ b/packages/mocha/src/utils.js
@@ -49,18 +49,11 @@ export function convergent(assertion, always) {
  * @returns {Function} a function able to run the returned object
  */
 export function handleConvergence(fn) {
-  let hasConvergenceInterface = (obj) => {
-    return obj &&
-      Array.isArray(obj._stack) &&
-      typeof obj.timeout === 'function' &&
-      typeof obj.run === 'function';
-  };
-
   return function() {
     let result = fn.apply(this, arguments);
     let timeout = this.timeout();
 
-    if (hasConvergenceInterface(result)) {
+    if (Convergence.isConvergence(result)) {
       // convergences have their own timeout
       this.timeout(0);
       // run the convergence with the original timeout

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,10 +452,6 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@bigtest/convergence@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.4.0.tgz#dc4caa274e4d8e91e5a63eefa8bb76b422e2c7f2"
-
 JSONStream@^1.0.3:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"


### PR DESCRIPTION
Makes use of the new `isConvergence` helper.

Also releases `@bigtest/mocha` `v0.3.2`