### PR TITLE
Fix mocha each hook timeout error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
         - 2e:3e:1e:98:92:42:17:a6:ee:23:fb:d6:cb:cc:42:5e
 
   cache_key: &cache_key
-    bigtest-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
+    bigtest-v3-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
   restore_cache: &restore_cache
     restore_cache:
@@ -40,6 +40,7 @@ jobs:
             # globs don't work for save_cache :(
             - packages/convergence/node_modules
             - packages/interaction/node_modules
+            - packages/mocha/node_modules
             - packages/mirage/node_modules
 
   build:

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,18 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.3.3] - 2018-03-16
+
 ### Fixed
 
 - each hooks set the timeout back to the original timeout when running
   returned convergences
 
-## [0.3.2]
+## [0.3.2] - 2018-03-14
 
 ### Changed
 
 - upgraded `@bigtest/convergence` to `^0.5.0`
 
-## [0.3.1]
+## [0.3.1] - 2018-03-08
 
 ### Fixed
 

--- a/packages/mocha/CHANGELOG.md
+++ b/packages/mocha/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- each hooks set the timeout back to the original timeout when running
+  returned convergences
+
 ## [0.3.2]
 
 ### Changed

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/mocha",
   "description": "Mocha helpers for testing big",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/mocha",
   "main": "dist/index.js",

--- a/packages/mocha/src/utils.js
+++ b/packages/mocha/src/utils.js
@@ -56,8 +56,12 @@ export function handleConvergence(fn) {
     if (Convergence.isConvergence(result)) {
       // convergences have their own timeout
       this.timeout(0);
+
+      return result
+      // set the mocha timeout back for *each hooks
+        .do(() => this.timeout(timeout))
       // run the convergence with the original timeout
-      return result.timeout(timeout).run();
+        .timeout(timeout).run();
     } else {
       return result;
     }

--- a/packages/mocha/tests/fixtures/hooks-timing-fixture.js
+++ b/packages/mocha/tests/fixtures/hooks-timing-fixture.js
@@ -1,19 +1,39 @@
-import { describe, before, it } from '../../src';
+import { describe, before, beforeEach, it } from '../../src';
 import { expect } from 'chai';
 import Convergence from '@bigtest/convergence';
 
 describe('hooks timing', () => {
   let start;
 
-  before(function() {
-    this.timeout(200);
+  describe('with the context helper', () => {
+    before(function() {
+      this.timeout(200);
 
-    return new Convergence()
-      .do(() => start = Date.now())
-      .always(() => expect(true).to.be.true);
+      return new Convergence()
+        .do(() => start = Date.now())
+        .always(() => expect(true).to.be.true);
+    });
+
+    it('runs the convergence within the timeout', () => {
+      expect(Date.now() - start).to.be.within(200, 220);
+    });
   });
 
-  it('runs the convergence within the timeout', () => {
-    expect(Date.now() - start).to.be.within(200, 220);
+  describe('inherited from the suite', function() {
+    this.timeout(200);
+
+    beforeEach(() => {
+      return new Convergence()
+        .do(() => start = Date.now())
+        .always(() => expect(true).to.be.true);
+    });
+
+    it('runs the convergence within the timeout', () => {
+      expect(Date.now() - start).to.be.within(200, 220);
+    });
+
+    it('continues running the convergence within the timeout', () => {
+      expect(Date.now() - start).to.be.within(200, 220);
+    });
   });
 });

--- a/packages/mocha/tests/hooks-test.js
+++ b/packages/mocha/tests/hooks-test.js
@@ -22,8 +22,8 @@ describe('BigTest Mocha: hooks timing', () => {
     stats = results.stats;
   }));
 
-  it('runs the convergence within the timeout', () => {
-    expect(stats.passes).to.equal(1);
+  it('runs returned convergences within the timeout', () => {
+    expect(stats.passes).to.equal(stats.tests);
     expect(stats.failures).to.equal(0);
   });
 });


### PR DESCRIPTION
## Purpose
When an each hook is run more than once, it retains the old timeout. When our helper sets the timeout to `0`, this causes the next run to give the convergence a timeout of `0`.

## Approach
By setting the timeout back to the original timeout before the convergence finishes, we can ensure that the next run of the hook still has the correct timeout.