### PR TITLE
Make Convergences & Interactions thennable

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.6.0] - 2018-03-16
+
 ### Added
 
 - then method to support async / await syntax without calling `.run()`

--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- then method to support async / await syntax without calling `.run()`
+
 ## [0.5.0] - 2018-03-14
 
 ### Added

--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - then method to support async / await syntax without calling `.run()`
 
+### Fixed
+
+- `.append()` method to use `isConvergence` instead of `instanceof`
+
 ## [0.5.0] - 2018-03-14
 
 ### Added

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -158,7 +158,7 @@ class Convergence {
    * @returns {Convergence} a new convergence instance
    */
   append(convergence) {
-    if (!(convergence instanceof Convergence)) {
+    if (!isConvergence(convergence)) {
       throw new Error('.append() only works with convergence instances');
     }
 

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -207,6 +207,32 @@ class Convergence {
       // always resolve with the stats object
       .then(() => stats);
   }
+
+  /**
+   * By being thennable we can enable the usage of async/await syntax
+   * with convergences. This allows us to naturally chain convergences
+   * without calling `.run()`.
+   *
+   * For example:
+   *   async function clickElement(selector) {
+   *     // will resolve when the element exists
+   *     let node = await new Convergence().once(() => {
+   *       let el = document.querySelector('.element');
+   *       return !!el && el;
+   *     });
+   *
+   *     $node.click();
+   *   }
+   *
+   * @private
+   * @returns {Promise}
+   */
+  then() {
+    // resolve with the value of the last function in the stack
+    let promise = this.run().then(({ value }) => value);
+    // pass promise arguments onward
+    return promise.then.apply(promise, arguments);
+  }
 }
 
 // static `isConvergence` method

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -14,6 +14,18 @@ describe('BigTest Convergence', () => {
     it('allows initializing with a different timeout', () => {
       expect(new Convergence(50).timeout()).to.equal(50);
     });
+
+    it('is thennable', async () => {
+      let converge = new Convergence();
+      expect(converge).to.respondTo('then');
+
+      let value = await converge.do(() => 'hello');
+      expect(value).to.equal('hello');
+
+      await expect(converge.do(() => {
+        throw new Error('catch me');
+      })).to.be.rejectedWith('catch me');
+    });
   });
 
   describe('extending convergences', () => {

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.3.0] - 2018-03-16
+
 ### Changed
 
 - upgrade `@bigtest/convergence` to `0.6.0` to support async/await syntax

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- upgrade `@bigtest/convergence` to `0.6.0` to support async/await syntax
+
 ## [0.2.0] - 2018-03-14
 
 ### Changed

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interaction",
   "description": "Interaction library for testing big",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/interaction",
   "main": "dist/index.js",

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -43,6 +43,6 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.5.0"
+    "@bigtest/convergence": "^0.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -452,6 +452,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@bigtest/convergence@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/convergence/-/convergence-0.5.0.tgz#1d84f05e8e88869358050dabc28cf883872c41ca"
+
 JSONStream@^1.0.3:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.2.tgz#c102371b6ec3a7cf3b847ca00c20bb0fce4c6dea"


### PR DESCRIPTION
## Purpose

This will add support for the `async`/`await` syntax with convergences without needing to call `.run()`.

## Approach

A `.then()` method is all that is necessary to support this syntax. By always resolving with the value of the last function in the stack, we can allow convergences to resolve to this value when using `async`/`await`.

``` javascript
async function clickElement(selector) {
  // will resolve to the element when it exists
  let $node = await new Convergence().once(() => {
    let el = document.querySelector('.element');
    return !!el && el;
  });

  $node.click();
}
```

I went ahead and upgraded `@bigtest/interaction` to make use of this as well. So this PR will release two of our packages.