### PR TITLE
Change convergence `.once()` to `.when()`

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- `.when()` to replace the `.once()` method
+
+### Deprecated
+
+- `.once()` in favor of `.when()`
+
 ## [0.6.0] - 2018-03-16
 
 ### Added

--- a/packages/convergence/README.md
+++ b/packages/convergence/README.md
@@ -33,7 +33,7 @@ give up?
 ![Image of convergent assertion](https://raw.githubusercontent.com/thefrontside/bigtest/master/packages/convergence/images/convergent-assertion.png)
 
 This is the essence of what `@bigtest/convergence` provides:
-repeatedly testing for a condition and then allowing code to run once
+repeatedly testing for a condition and then allowing code to run when
 that condition has been met.
 
 And it isn't just for assertions either. Because it is a general
@@ -61,14 +61,14 @@ import Convergence from '@bigtest/convergence'
 // starts a new stack
 new Convergence()
   // adds a convergent function to the stack
-  .once(() => expect($el).to.exist)
+  .when(() => expect($el).to.exist)
   // called when the previous function converges
   .do(() => $el.get(0).click())
   // adds a convergent function that resolves when it is true
   // for the remaining timeout period
   .always(() => expect($el).to.have.prop('disabled', true))
   // starts converging and returns a promise that resolves
-  // once all convergences have been met
+  // when all convergences have been met
   .run()
 ```
 
@@ -78,12 +78,12 @@ new Convergence()
 return new instances.
 
 ``` javascript
-// will converge once the total equals 5
-let convergeOnce = new Convergence()
-  .once(() => total === 5);
+// will converge when the total equals 5
+let convergeWhen = new Convergence()
+  .when(() => total === 5);
 
 // will log the total after the first convergence
-let convergeAndLog = convergeOnce
+let convergeAndLog = convergeWhen
   .do(() => console.log(total));
 
 // after logging the total, will converge when it remains 5 for the
@@ -92,7 +92,7 @@ let convergeAlways = convergeAndLog
   .always(() => total === 5);
 
 // all three convergences can be ran in parallel
-convergeOnce.run();
+convergeWhen.run();
 convergeAndLog.run();
 convergeAlways.run();
 ```
@@ -136,7 +136,7 @@ converge.timeout();  // => 1000
 convergeLong.timeout(); // => 5000
 ```
 
-**`.once(assert)`**
+**`.when(assert)`**
 
 Returns a new `Convergence` instance and adds the provided assertion
 to its stack. When this instance is ran, the `assert` function will be
@@ -144,8 +144,8 @@ looped over repeatedly until it passes, or until the convergence's
 timeout has been exceeded.
 
 ``` javascript
-// this convergence will resolve once `total` equals `5`
-converge.once(() => total === 5)
+// this convergence will resolve when `total` equals `5`
+converge.when(() => total === 5)
 ```
 
 **`.always(assert[, timeout])`**
@@ -154,7 +154,7 @@ Another common pattern is asserting that something **has not**
 changed. With a typical convergence, the state may change after an
 assertion converges immediately. So for these scenarios, you want to
 converge _when the assertion passes for the duration of a timeout._
-`.always()` is just like `.once()` above, except that the `assert`
+`.always()` is just like `.when()` above, except that the `assert`
 function is looped over repeatedly until it fails for the first time
 or never fails for the duration of the timeout.
 
@@ -178,7 +178,7 @@ converge
 converge
   // will use the 500ms timeout instead
   .always(() => total === 5, 500)
-  .once(() => total === 10)
+  .when(() => total === 10)
 
 new Convergence(2000)
   // defaults to 200ms
@@ -196,7 +196,7 @@ allows you to run side effects between convergences.
 
 ``` javascript
 converge
-  .once(() => total === 5)
+  .when(() => total === 5)
   // executes after the total is equal to 5
   .do(() => total *= 100)
   // starts converging after the total has been multiplied
@@ -211,7 +211,7 @@ given to the next function in the stack.
 ``` javascript
 converge
   // returns the element when it exists in the DOM
-  .once(() => {
+  .when(() => {
     let $el = $('[data-test-element]');
     expect($el).to.exist;
     return $el;
@@ -246,8 +246,8 @@ Combines convergences to allow composing them together to create brand
 new convergence instances.
 
 ``` javascript
-let converge1 = converge.once(() => total === 1)
-let converge5 = converge.once(() => total === 5)
+let converge1 = converge.when(() => total === 1)
+let converge5 = converge.when(() => total === 5)
 
 // converges when the total first equals `1` and then equals `5`
 converge1.append(converge5)

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -33,7 +33,7 @@ import {
  *
  * Example:
  *   let first = new Convergence(100)
- *     .once(() => expect(foo).to.equal('bar'))
+ *     .when(() => expect(foo).to.equal('bar'))
  *
  *   let second = first.timeout(200)
  *     .do(() => console.log('foo', foo))
@@ -41,7 +41,7 @@ import {
  *
  * `first.run()` has 100ms to converge on it's assertion.
  *
- * `second.run()` will log `foo` once the first assertion converges
+ * `second.run()` will log `foo` when the first assertion converges
  * and continue to assert the second assertion until the 200ms timeout
  * period has expired.
  */
@@ -92,21 +92,31 @@ class Convergence {
   /**
    * Creates a new convergence with the given assertion added to its
    * stack. The new convergence's initial stack will be inherited from
-   * this convergence instance. The assertion given to `.once()` will
+   * this convergence instance. The assertion given to `.when()` will
    * be converged on using the `convergeOn` helper, but it's timeout
    * will be managed by this convergence instance
    *
    * @param {Function} assert - the assertion to converge on
    * @returns {Convergence} a new convergence instance
    */
-  once(assert) {
+  when(assert) {
     return new this.constructor({
       _stack: [{ assert }]
     }, this);
   }
 
   /**
-   * Similar to `.once()`, creates a new convergence with the given
+   * Alias for `.when()`
+   *
+   * @deprecated
+   * @returns {Convergence} a new convergence instance
+   */
+  once() {
+    return this.when(...arguments);
+  }
+
+  /**
+   * Similar to `.when()`, creates a new convergence with the given
    * assertion added to its stack. However, the assertion given to
    * `.always()` will be ran until it fails, or passes for its entire
    * timeout period. When an `.always()` is last in a stack, it will
@@ -216,7 +226,7 @@ class Convergence {
    * For example:
    *   async function clickElement(selector) {
    *     // will resolve when the element exists
-   *     let node = await new Convergence().once(() => {
+   *     let node = await new Convergence().when(() => {
    *       let el = document.querySelector('.element');
    *       return !!el && el;
    *     });

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -112,6 +112,7 @@ class Convergence {
    * @returns {Convergence} a new convergence instance
    */
   once() {
+    console.warn('#once() has been deprecated in favor of #when()');
     return this.when(...arguments);
   }
 

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -109,11 +109,11 @@ describe('BigTest Convergence', () => {
       });
     });
 
-    describe('adding assertions with `.once()`', () => {
+    describe('adding assertions with `.when()`', () => {
       let assertion;
 
       beforeEach(() => {
-        assertion = converge.once(() => {});
+        assertion = converge.when(() => {});
       });
 
       it('creates a new instance', () => {
@@ -130,7 +130,7 @@ describe('BigTest Convergence', () => {
       it('adds the assertion to the new stack', () => {
         let assert = () => {};
 
-        assertion = assertion.once(assert);
+        assertion = assertion.when(assert);
         expect(assertion._stack[1]).to.have.property('assert', assert);
       });
     });
@@ -194,7 +194,7 @@ describe('BigTest Convergence', () => {
 
       beforeEach(() => {
         combined = converge.append(
-          new Convergence().once(() => {})
+          new Convergence().when(() => {})
         );
       });
 
@@ -247,11 +247,11 @@ describe('BigTest Convergence', () => {
       return expect(converge.run()).to.be.fulfilled;
     });
 
-    describe('after using `.once()`', () => {
+    describe('after using `.when()`', () => {
       let assertion;
 
       beforeEach(() => {
-        assertion = converge.once(() => expect(total).to.equal(5));
+        assertion = converge.when(() => expect(total).to.equal(5));
       });
 
       it('resolves after assertions converge', async () => {
@@ -268,7 +268,7 @@ describe('BigTest Convergence', () => {
 
       describe('with additional chaining', () => {
         beforeEach(() => {
-          assertion = assertion.once(() => expect(total).to.equal(10));
+          assertion = assertion.when(() => expect(total).to.equal(10));
         });
 
         it('resolves after at all assertions are met', async () => {
@@ -316,7 +316,7 @@ describe('BigTest Convergence', () => {
         beforeEach(() => {
           assertion = assertion
             .do(() => total = 10)
-            .once(() => expect(total).to.equal(10));
+            .when(() => expect(total).to.equal(10));
         });
 
         it('resolves after at least 50ms', async () => {
@@ -338,7 +338,7 @@ describe('BigTest Convergence', () => {
     describe('after using `.do()`', () => {
       it('triggers the callback before resolving', () => {
         let assertion = converge
-          .once(() => expect(total).to.equal(5))
+          .when(() => expect(total).to.equal(5))
           .do(() => total * 100);
 
         createTimeout(() => total = 5, 50);
@@ -348,7 +348,7 @@ describe('BigTest Convergence', () => {
 
       it('passes the previous return value to the callback', () => {
         let assertion = converge
-          .once(() => {
+          .when(() => {
             expect(total).to.equal(5);
             return total * 100;
           })
@@ -363,7 +363,7 @@ describe('BigTest Convergence', () => {
         let called = false;
 
         let assertion = converge
-          .once(() => expect(total).to.equal(5))
+          .when(() => expect(total).to.equal(5))
           .do(() => called = true);
 
         await expect(assertion.run()).to.be.rejected;
@@ -382,7 +382,7 @@ describe('BigTest Convergence', () => {
           let start = Date.now();
           let done = false;
 
-          converge = converge.once(() => done === true);
+          converge = converge.when(() => done === true);
           createTimeout(() => done = true, 50);
 
           await expect(assertion.run()).to.be.fulfilled;
@@ -393,7 +393,7 @@ describe('BigTest Convergence', () => {
           let start = Date.now();
           let called = false;
 
-          converge = converge.once(() => false);
+          converge = converge.when(() => false);
           assertion = assertion.do(() => called = true);
 
           await expect(assertion.timeout(50).run()).to.be.rejected;
@@ -411,7 +411,7 @@ describe('BigTest Convergence', () => {
 
         it('curries the resolved value to the next function', () => {
           assertion = assertion
-            .once((val) => expect(val).to.equal(1));
+            .when((val) => expect(val).to.equal(1));
 
           converge = converge.do(() => 1);
           return expect(assertion.run()).to.be.fulfilled
@@ -460,7 +460,7 @@ describe('BigTest Convergence', () => {
 
         it('curries the resolved value to the next function', () => {
           assertion = assertion
-            .once((val) => expect(val).to.equal(1));
+            .when((val) => expect(val).to.equal(1));
 
           createTimeout(() => resolve(1), 10);
           return expect(assertion.run()).to.be.fulfilled
@@ -479,7 +479,7 @@ describe('BigTest Convergence', () => {
       it('runs methods from the other convergence', async () => {
         let called = false;
 
-        let assertion = converge.once(() => expect(total).to.equal(5));
+        let assertion = converge.when(() => expect(total).to.equal(5));
         assertion = assertion.append(converge.do(() => called = true));
 
         createTimeout(() => total = 5, 50);
@@ -491,7 +491,7 @@ describe('BigTest Convergence', () => {
     describe('after using various chain methods', () => {
       it('resolves with a combined stats object', async () => {
         let assertion = converge
-          .once(() => expect(total).to.equal(5))
+          .when(() => expect(total).to.equal(5))
           .do(() => total = 10)
           .always(() => expect(total).to.equal(10))
           .do(() => total * 5);


### PR DESCRIPTION
## Purpose

Addresses #72 

`.when()` reads better in most situations. 

## Approach

Search-and-replaced pretty much every instance of `once` that made sense.

To avoid breaking changes, `.once()` was aliased to `.when()`.