### PR TITLE
Convergence Instance Context

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -13,10 +13,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Changed
 
 - updated inline api docs
+- `Convergence` assertions retain the instance context
 
 ### Deprecated
 
 - `.once()` in favor of `.when()`
+
+### Removed
+
+- context currying from `convergeOn`
 
 ## [0.6.0] - 2018-03-16
 

--- a/packages/convergence/src/converge-on.js
+++ b/packages/convergence/src/converge-on.js
@@ -24,7 +24,6 @@
  * if `always` is true, then rejects at the first error instead
  */
 export default function convergeOn(assertion, timeout = 2000, always = false) {
-  let context = this;
   let start = Date.now();
   let interval = 10;
 
@@ -45,7 +44,7 @@ export default function convergeOn(assertion, timeout = 2000, always = false) {
       stats.runs += 1;
 
       try {
-        let results = assertion.call(context);
+        let results = assertion();
 
         // the timeout calculation comes after the assertion so that
         // the assertion's execution time is accounted for

--- a/packages/convergence/src/convergence.js
+++ b/packages/convergence/src/convergence.js
@@ -373,13 +373,16 @@ class Convergence {
 
     // reduce to a single promise that runs each item in the stack
     return this._stack.reduce((promise, subject, i) => {
-      let last = i === (this._stack.length - 1);
+      // the last subject will receive the remaining timeout
+      if (i === (this._stack.length - 1)) {
+        subject = Object.assign({ last: true }, subject);
+      }
 
       return promise.then((ret) => {
         if (subject.assertion) {
-          return runAssertion(subject, ret, last, stats);
+          return runAssertion.call(this, subject, ret, stats);
         } else if (subject.callback) {
-          return runCallback(subject, ret, last, stats);
+          return runCallback.call(this, subject, ret, stats);
         }
       });
     }, Promise.resolve())

--- a/packages/convergence/tests/converge-on-test.js
+++ b/packages/convergence/tests/converge-on-test.js
@@ -84,19 +84,6 @@ describe('BigTest Convergence - convergeOn', () => {
     });
   });
 
-  describe('when bound to the testing context', () => {
-    beforeEach(function() {
-      this.convergent = true;
-      test = () => convergeOn.call(this, function() {
-        expect(this.convergent).to.be.true;
-      });
-    });
-
-    it('should curry the context to our assertion', () => {
-      return expect(test()).to.be.fulfilled;
-    });
-  });
-
   describe('when the assertion returns `false`', () => {
     beforeEach(() => {
       test = (num) => convergeOn(() => total >= num, 50);

--- a/packages/convergence/tests/convergence-test.js
+++ b/packages/convergence/tests/convergence-test.js
@@ -266,6 +266,14 @@ describe('BigTest Convergence', () => {
         return expect(assertion.run()).to.be.rejected;
       });
 
+      it('retains the instance context', () => {
+        assertion = converge.when(function() {
+          expect(this).to.equal(assertion);
+        });
+
+        return expect(assertion.run()).to.be.fulfilled;
+      });
+
       describe('with additional chaining', () => {
         beforeEach(() => {
           assertion = assertion.when(() => expect(total).to.equal(10));
@@ -296,6 +304,14 @@ describe('BigTest Convergence', () => {
         assertion = converge.always(() => {
           expect(total).to.equal(5);
         }, 50);
+      });
+
+      it('retains the instance context', () => {
+        assertion = converge.always(function() {
+          expect(this).to.equal(assertion);
+        });
+
+        return expect(assertion.run()).to.be.fulfilled;
       });
 
       it('resolves after the 100ms timeout', async () => {
@@ -336,8 +352,10 @@ describe('BigTest Convergence', () => {
     });
 
     describe('after using `.do()`', () => {
+      let assertion;
+
       it('triggers the callback before resolving', () => {
-        let assertion = converge
+        assertion = converge
           .when(() => expect(total).to.equal(5))
           .do(() => total * 100);
 
@@ -347,7 +365,7 @@ describe('BigTest Convergence', () => {
       });
 
       it('passes the previous return value to the callback', () => {
-        let assertion = converge
+        assertion = converge
           .when(() => {
             expect(total).to.equal(5);
             return total * 100;
@@ -362,7 +380,7 @@ describe('BigTest Convergence', () => {
       it('is not called when a previous assertion fails', async () => {
         let called = false;
 
-        let assertion = converge
+        assertion = converge
           .when(() => expect(total).to.equal(5))
           .do(() => called = true);
 
@@ -370,9 +388,15 @@ describe('BigTest Convergence', () => {
         expect(called).to.be.false;
       });
 
-      describe('and returning a convergence', () => {
-        let assertion;
+      it('retains the instance context', () => {
+        assertion = converge.do(function() {
+          expect(this).to.equal(assertion);
+        });
 
+        return expect(assertion.run()).to.be.fulfilled;
+      });
+
+      describe('and returning a convergence', () => {
         beforeEach(() => {
           // converge reference can be modified before running
           assertion = converge.do(() => converge);
@@ -431,7 +455,7 @@ describe('BigTest Convergence', () => {
       });
 
       describe('and returning a promise', () => {
-        let assertion, resolve, reject;
+        let resolve, reject;
 
         beforeEach(() => {
           assertion = converge.do(() => {


### PR DESCRIPTION
## Purpose

While working on `@bigtest/interaction`, I realized that this is currently not possible with convergences:

``` javascript
new Convergence().do(function() {
  console.log(this.timeout())
})
```

It might not seem useful in the context of convergences, so here's an example using `@bigtest/interaction`:

``` javascript
// scrolls to the bottom of the page when there is room to scroll
await new Interactor('#page')
  .when(function() {
    return this.$root.scrollHeight > this.$root.offsetHeight
  })
  .do(function() {
    return this.scroll({ top: this.$root.scrollHeight })
  })
```

## Approach

First, bind the instance context to any `assertion`s and `callback`s created using `#when()`, `#always()`, `#do()`, etc.

Previously, `convergeOn` curried its own context onto the assertion ~and always overrode any context bound to the assertion. This was removed to prevent it from overriding the Convergence instance's bound context.~ Turns out this isn't true, but since `convergeOn` is meant to be internal and this context currying isn't used by `Convergence` I don't think it is necessary to add back.

Since we now have to pass the context along to the `runAssertion` and `runCallback` helpers, I reduced their API by moving the `last` argument into the `subject` that gets passed along.