### PR TITLE
@bigtest/convergence v0.7.0 & @bigtest/interaction v0.4.0

### DIFF
--- a/packages/convergence/CHANGELOG.md
+++ b/packages/convergence/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.7.0] - 2018-04-07
+
 ### Added
 
 - `docs` script to generate documentation

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/convergence",
   "description": "Convergence helpers for testing big",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/convergence",
   "main": "dist/index.js",

--- a/packages/interaction/CHANGELOG.md
+++ b/packages/interaction/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [0.4.0] - 2018-04-07
+
 ### Added
 
 - `docs` script to generate documentation
@@ -21,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
   selector as the first argument
 - the `collection` helper now lazily finds the root for collection
   interactors instead of eagerly doing so
+- upgrade `@bigtest/convergence` to `0.7.0`
 
 ### Removed
 

--- a/packages/interaction/package.json
+++ b/packages/interaction/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bigtest/interaction",
   "description": "Interaction library for testing big",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": "https://github.com/thefrontside/bigtest/tree/master/packages/interaction",
   "main": "dist/index.js",
@@ -44,6 +44,6 @@
     "webpack": "^3.10.0"
   },
   "dependencies": {
-    "@bigtest/convergence": "^0.6.0"
+    "@bigtest/convergence": "^0.7.0"
   }
 }


### PR DESCRIPTION
This releases `@bigtest/convergence` 0.7.0 and `@bigtest/interaction` 0.4.0 at the same time due to test failures when trying to release `@bigtest/convergence` 0.7.0 alone (#91).

This highlights some potential pitfalls of a monorepo. Since the dependency in `@bigtest/interaction` was automatically linked, recent changes utilized an unreleased feature of `@bigtes/convergence`. When changing the version number of `@bigtest/convergence`, the link was broken and `@bigtest/interaction` used the version from npm instead, which did not support `#when()`. Failures can be seen for that release [here](https://circleci.com/gh/thefrontside/bigtest/773).

Released packages are not effected since the version numbers are correct, but this requires us to release these two packages at once to avoid CI/CD failures.