### PR TITLE
Use Typekit's link directly

### DIFF
--- a/packages/website/gatsby-config.js
+++ b/packages/website/gatsby-config.js
@@ -41,13 +41,5 @@ module.exports = {
     `gatsby-plugin-styled-components`,
     `gatsby-plugin-typescript`,
     `gatsby-transformer-sharp`,
-    {
-      resolve: 'gatsby-plugin-web-font-loader',
-      options: {
-        typekit: {
-          id: 'gyc5wys'
-        }
-      }
-    },
   ],
 };

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -17,7 +17,6 @@
     "gatsby-plugin-sharp": "^2.3.5",
     "gatsby-plugin-styled-components": "^3.1.16",
     "gatsby-plugin-typescript": "^2.1.26",
-    "gatsby-plugin-web-font-loader": "^1.0.4",
     "gatsby-source-filesystem": "^2.1.40",
     "gatsby-transformer-sharp": "^2.3.7",
     "precss": "^4.0.0",

--- a/packages/website/src/components/Layout.tsx
+++ b/packages/website/src/components/Layout.tsx
@@ -25,6 +25,7 @@ const Layout: React.FC = ({ children }) => {
             <html lang="en" />
             <title>{data.site.siteMetadata.title}</title>
             <meta name="description" content={data.site.siteMetadata.description} />
+            <link rel="stylesheet" href="https://use.typekit.net/gyc5wys.css"></link>
           </Helmet>
           <ThemeProvider>
             <Header />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6909,14 +6909,6 @@ gatsby-plugin-typescript@^2.1.26:
     "@babel/runtime" "^7.7.6"
     babel-plugin-remove-graphql-queries "^2.7.23"
 
-gatsby-plugin-web-font-loader@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-web-font-loader/-/gatsby-plugin-web-font-loader-1.0.4.tgz#c50bdb0c1980110b3fd213a5be70feb2459514c3"
-  integrity sha512-3c39bX9CcsYJQFhhmTyjuMJSqpld2rX+HsTOxP9k1PKFR4Rvo3lpzBW4d1tVpmUesR8BNL6u9eHT7/XksS1iog==
-  dependencies:
-    babel-runtime "^6.26.0"
-    webfontloader "^1.6.28"
-
 gatsby-react-router-scroll@^2.1.21:
   version "2.1.21"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.21.tgz#bc4aeee424da034287b6fe64d6b08f47d6cb6881"
@@ -16089,11 +16081,6 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
-
-webfontloader@^1.6.28:
-  version "1.6.28"
-  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
-  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
## Motivation 

#122 

## Approach

I rechecked the package that I using the first time, `gatsby-plugin-web-font-loader`, and realized that the plugin defaults to async font loading. Under the hood, it uses [typekit/webfontloader](https://github.com/typekit/webfontloader) which does not default to async (but offer the option for it).

My solution was to keep it simple and opt for Typescript's default solution: a stylesheet link. They've done a lot of research and work to make it work as good as possible. 

There is a brief flash the first time you visit the page (when you don't have the fonts cached), but in subsequent pages and reloads the fonts work pretty smoothly. 

## Alternative

If we wanted to completely remove any sight of unstyled text, then we could implement  [typekit/webfontloader](https://github.com/typekit/webfontloader)  which provides APIs to know exactly when types are loaded. With that in place, we could block the page from showing or display a loading state while the fonts aren't ready.

However, that is a relatively elaborate task so I opted for a simple solution for now. We can evaluate implementing the full-blown solution, if it's worth the effort (I personally doubt it for our use-cases), and maybe turn it into a Gatsby plugin? We could use it on our other websites too.