### PR TITLE
Placeholder /guides and /docs pages with redirects for children routes

### DIFF
--- a/packages/website/src/components/DidYouKnow.tsx
+++ b/packages/website/src/components/DidYouKnow.tsx
@@ -18,7 +18,8 @@ const DidYouKnow: React.FC = () => {
     <SideBox>
       <H3>Flexible &amp; framework agnostic</H3>
       <Text>
-        BigTest is a powerful framework planned and architectured to be extensible. We provide APIs that allow teams to build on top of BigTest and integrate tests more deeply into their development processes.
+        BigTest is a powerful framework planned and architectured to be extensible. We provide APIs that allow
+        teams to build on top of BigTest and integrate tests more deeply into their development processes.
       </Text>
     </SideBox>
   );

--- a/packages/website/src/components/GreetLegacyUsers.tsx
+++ b/packages/website/src/components/GreetLegacyUsers.tsx
@@ -1,26 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import styled from 'styled-components';
 
 import Text from './Text';
-import { H4 } from './Heading';
-import Box from './Box';
 import Section from './Section';
+import { H4 } from './Heading';
+import WarningBox, { WarningBoxLink } from './WarningBox';
 
 interface GreetLegacyProps {
   location: { search: string };
 }
-
-const GreetLegacyBox = styled(Box)`
-  background: #ffe9bf;
-  width: 60%;
-  padding: ${({ theme }) => theme.space.large} ${({ theme }) => theme.space.large} ${({ theme }) => theme.space.xSmall} ${({ theme }) => theme.space.large};
-  margin-bottom: ${({ theme }) => theme.space.medium};
-  border-radius: 4px;
-`;
-
-const GreetLegacyLink = styled.a`
-  border-bottom: 1px dotted ${({ theme }) => theme.colors.bodyCopy};
-`;
 
 const GreetLegacyUsers: React.FC<GreetLegacyProps> = () => {
   const [legacy, setLegacy] = useState(false);
@@ -30,21 +17,23 @@ const GreetLegacyUsers: React.FC<GreetLegacyProps> = () => {
       const from_legacy = new URLSearchParams(window.location.search).get('archived-page');
       from_legacy ? setLegacy(true) : setLegacy(false);
     }
-  })
+  });
 
   if (legacy) {
     return (
       <Section>
-        <GreetLegacyBox>
-          <H4 color={'bodyCopy'}>Coming from the old BigTest Site?</H4>
+        <WarningBox>
+          <H4 color="bodyCopy">Coming from the old BigTest Site?</H4>
           <Text>
-            Welcome to the new BigTest! We are making major changes to the project to make BigTest the ultimate testing framework. Take a look around, and reach out to us if you have any questions{' '}
-            <GreetLegacyLink href="mailto:bigtest@frontside.io">bigtest@frontside.io</GreetLegacyLink>.
-            </Text>
-          <Text>
-            You can still access the old website here: <GreetLegacyLink href="https://v1.bigtestjs.io">https://v1.bigtestjs.io</GreetLegacyLink>
+            Welcome to the new BigTest! We are making major changes to the project to make BigTest the ultimate
+            testing framework. Take a look around, and reach out to us if you have any questions{' '}
+            <WarningBoxLink href="mailto:bigtest@frontside.io">bigtest@frontside.io</WarningBoxLink>.
           </Text>
-        </GreetLegacyBox>
+          <Text>
+            You can still access the old website here:{' '}
+            <WarningBoxLink href="https://v1.bigtestjs.io">https://v1.bigtestjs.io</WarningBoxLink>
+          </Text>
+        </WarningBox>
       </Section>
     );
   } else {

--- a/packages/website/src/components/Hero.tsx
+++ b/packages/website/src/components/Hero.tsx
@@ -7,6 +7,13 @@ const HeroLine = styled.section`
   padding: ${({ theme }) => theme.space.medium} 0;
 `;
 
+export const HeroLink = styled.a`
+  display: inline-block;
+  font-family: ${({ theme }) => theme.fonts.heading};
+  font-weight: ${({ theme }) => theme.fontWeights.bold};
+  color: ${({ theme }) => theme.colors.secondary};
+`;
+
 const Hero: React.FC = ({ children }) => (
   <HeroLine>
     <Section as="div">{children}</Section>

--- a/packages/website/src/components/Text.ts
+++ b/packages/website/src/components/Text.ts
@@ -10,4 +10,9 @@ export const Strong = styled.strong`
   color: ${({ color, theme }) => (color ? theme.colors[color] : theme.colors.primary)};
 `;
 
+export const Emphasis = styled.em`
+  font-style: italic;
+  color: ${({ color, theme }) => (color ? theme.colors[color] : theme.colors.primary)};
+`;
+
 export default Text;

--- a/packages/website/src/components/WarningBox.tsx
+++ b/packages/website/src/components/WarningBox.tsx
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import Box from './Box';
+
+const WarningBox = styled(Box)`
+  background: #ffe9bf;
+  width: 60%;
+  padding: ${({ theme }) => theme.space.large} ${({ theme }) => theme.space.large}
+    ${({ theme }) => theme.space.xSmall} ${({ theme }) => theme.space.large};
+  margin-bottom: ${({ theme }) => theme.space.medium};
+  border-radius: 4px;
+`;
+
+export const WarningBoxLink = styled.a`
+  border-bottom: 1px dotted ${({ theme }) => theme.colors.bodyCopy};
+`;
+
+export default WarningBox;

--- a/packages/website/src/components/WhyBigTest.tsx
+++ b/packages/website/src/components/WhyBigTest.tsx
@@ -32,9 +32,9 @@ const Item = styled.li<ItemProp>`
   }
 `;
 
-const WhyBigTest: React.FC = () => (
+const WhyBigTest: React.FC<{ title?: string }> = ({ title }) => (
   <Section>
-    <H2 color="secondary">Why BigTest?</H2>
+    <H2 color="secondary">{title ? title : 'Why BigTest?'}</H2>
     <List>
       <Item largeOrder="0">
         <H4>Seriously fast</H4>

--- a/packages/website/src/pages/docs.tsx
+++ b/packages/website/src/pages/docs.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import Section from '../components/Section';
+import Flex from '../components/Flex';
+import Box from '../components/Box';
+import Hero, { HeroLink } from '../components/Hero';
+import { H1, H2, H4 } from '../components/Heading';
+import Layout from '../components/Layout';
+import Text, { Emphasis } from '../components/Text';
+import WarningBox, { WarningBoxLink } from '../components/WarningBox';
+
+import SubscribeForm from '../components/SubscribeForm';
+import WhyBigTest from '../components/WhyBigTest';
+import ReachOut from '../components/ReachOut';
+
+const GuidesPage = () => (
+  <Layout>
+    <Hero>
+      <H1>API</H1>
+      <Text>
+        <Emphasis>Enjoyable developer experiences start with great documentation.</Emphasis>
+        <br />
+      </Text>
+      <HeroLink
+        href="https://github.com/thefrontside/bigtest/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation"
+        target="_blank"
+      >
+        Help us build BigTest's new API docs &rarr;
+      </HeroLink>
+    </Hero>
+    <Section>
+      <WarningBox>
+        <H4>BigTest is going through a major renovation</H4>
+        <Text>
+          The core values behind the BigTest remain. But the egonomics, APIs, performance, and scope of the
+          framework have changed to be more ambicious.
+        </Text>
+        <Text>
+          We'll be working on the new Guides shortly. If you need access to v1.x API Docs, they're available at:{' '}
+          <WarningBoxLink href="https://v1.bigtestjs.io/docs">https://v1.bigtestjs.io/docs</WarningBoxLink>.
+        </Text>
+      </WarningBox>
+    </Section>
+    <WhyBigTest title="What's new on BigTest?" />
+    <Hero>
+      <Flex alignItems="center">
+        <Box width={[1, 1 / 2, 2 / 3]} paddingRight={[0, 'medium', 'xxLarge']}>
+          <H2 color="dark-blue">Want to know more about BigTest?</H2>
+          <Text>
+            Join our mailing list! Receive updates and be an expert by the time BigTest is officially released.
+          </Text>
+          <SubscribeForm id={2} />
+        </Box>
+        <Box width={[1, 1 / 2, 1 / 3]}>
+          <ReachOut />
+        </Box>
+      </Flex>
+    </Hero>
+  </Layout>
+);
+
+export default GuidesPage;

--- a/packages/website/src/pages/guides.tsx
+++ b/packages/website/src/pages/guides.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import Section from '../components/Section';
+import Flex from '../components/Flex';
+import Box from '../components/Box';
+import Hero, { HeroLink } from '../components/Hero';
+import { H1, H2, H4 } from '../components/Heading';
+import Layout from '../components/Layout';
+import Text, { Emphasis } from '../components/Text';
+import WarningBox, { WarningBoxLink } from '../components/WarningBox';
+
+import SubscribeForm from '../components/SubscribeForm';
+import WhyBigTest from '../components/WhyBigTest';
+import ReachOut from '../components/ReachOut';
+
+const GuidesPage = () => (
+  <Layout>
+    <Hero>
+      <H1>Guides</H1>
+      <Text>
+        <Emphasis>Enjoyable developer experiences start with great documentation.</Emphasis>
+        <br />
+      </Text>
+      <HeroLink
+        href="https://github.com/thefrontside/bigtest/issues?q=is%3Aissue+is%3Aopen+label%3Adocumentation"
+        target="_blank"
+      >
+        Help us build BigTest's new guides &rarr;
+      </HeroLink>
+    </Hero>
+    <Section>
+      <WarningBox>
+        <H4 color="bodyCopy">BigTest is going through a major renovation</H4>
+        <Text>
+          The core values behind the BigTest remain. But the egonomics, APIs, performance, and scope of the
+          framework have changed to be more ambicious.
+        </Text>
+        <Text>
+          We'll be working on the new Guides shortly. If you need access to v1.x Guides, they're available at:{' '}
+          <WarningBoxLink href="https://v1.bigtestjs.io/guides">https://v1.bigtestjs.io/guides</WarningBoxLink>.
+        </Text>
+      </WarningBox>
+    </Section>
+    <WhyBigTest title="What's new on BigTest?" />
+    <Hero>
+      <Flex alignItems="center">
+        <Box width={[1, 1 / 2, 2 / 3]} paddingRight={[0, 'medium', 'xxLarge']}>
+          <H2 color="dark-blue">Want to know more about BigTest?</H2>
+          <Text>
+            Join our mailing list! Receive updates and be an expert by the time BigTest is officially released.
+          </Text>
+          <SubscribeForm id={2} />
+        </Box>
+        <Box width={[1, 1 / 2, 1 / 3]}>
+          <ReachOut />
+        </Box>
+      </Flex>
+    </Hero>
+  </Layout>
+);
+
+export default GuidesPage;

--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -17,7 +17,7 @@ import WhyBigTest from '../components/WhyBigTest';
 
 import { reusable, tests_intro, user_experience } from '../images';
 
-const IndexPage = (props) => (
+const IndexPage = props => (
   <Layout>
     <Hero>
       <Flex alignItems="center" flexWrap="wrap">
@@ -83,7 +83,8 @@ const IndexPage = (props) => (
             time-intensive in both setup and run time.
           </Text>
           <Text>
-            BigTest brings a new stateful architecture, along with several paradigm shifts that allow tests to be faster to write, execute, and maintain.
+            BigTest brings a new stateful architecture, along with several paradigm shifts that allow tests to be
+            faster to write, execute, and maintain.
           </Text>
         </Box>
         <Box width={[1, 1 / 2, 1 / 3]}>
@@ -92,7 +93,7 @@ const IndexPage = (props) => (
       </Flex>
     </Section>
     <Section>
-      <Flex flexWrap='wrap'>
+      <Flex flexWrap="wrap">
         <Box width={[1, 1 / 2, 2 / 3]} paddingRight={[0, 'medium', 'xxLarge']}>
           <H2 color="secondary">BigTest makes your tests reusable</H2>
           <Text>
@@ -129,7 +130,6 @@ const IndexPage = (props) => (
         </Box>
       </Flex>
     </Hero>
-
   </Layout>
 );
 

--- a/packages/website/static/_redirects
+++ b/packages/website/static/_redirects
@@ -1,0 +1,2 @@
+/guides/* /guides/index.html 307
+/docs/* /docs/index.html 307


### PR DESCRIPTION
## Motivation

We changed the website, but still have routes from the old site that are missing in the new site.

## Approach

This PR introduces a placeholder page for Guides and one for Docs. It also adds redirects for any subroute of /guides and /docs to their respective placeholder page with a note about the changes.