### PR TITLE
Change frontside's domain to .com

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "Website for BigtestJS",
   "version": "0.1.0",
-  "author": "Frontside Inc. <contact@frontside.io>",
+  "author": "Frontside Inc. <contact@frontside.com>",
   "dependencies": {
     "babel-plugin-styled-components": "^1.10.6",
     "gatsby": "^2.18.18",

--- a/packages/website/src/components/Footer.tsx
+++ b/packages/website/src/components/Footer.tsx
@@ -31,7 +31,7 @@ const FooterText = styled.p`
 const Footer = () => (
   <FooterBox>
     <FooterText>Brought to you by</FooterText>
-    <FooterLink href="https://frontside.io/" target="_blank">
+    <FooterLink href="https://frontside.com/" target="_blank">
       <FooterLogo src={frontsideLogoSVG} alt="Frontside" />
     </FooterLink>
   </FooterBox>

--- a/packages/website/src/components/GreetLegacyUsers.tsx
+++ b/packages/website/src/components/GreetLegacyUsers.tsx
@@ -27,7 +27,7 @@ const GreetLegacyUsers: React.FC<GreetLegacyProps> = () => {
           <Text>
             Welcome to the new BigTest! We are making major changes to the project to make BigTest the ultimate
             testing framework. Take a look around, and reach out to us if you have any questions{' '}
-            <WarningBoxLink href="mailto:bigtest@frontside.io">bigtest@frontside.io</WarningBoxLink>.
+            <WarningBoxLink href="mailto:bigtest@frontside.com">bigtest@frontside.com</WarningBoxLink>.
           </Text>
           <Text>
             You can still access the old website here:{' '}

--- a/packages/website/src/components/ReachOut.tsx
+++ b/packages/website/src/components/ReachOut.tsx
@@ -26,8 +26,8 @@ const ReachOut: React.FC = () => {
       >
         @thefrontside #bigTest
       </ReachLink>
-      <ReachLink icon={emailIconSVG} href="mailto:bigtest@frontside.io" title="Email Us" target="_blank">
-        bigtest@frontside.io
+      <ReachLink icon={emailIconSVG} href="mailto:bigtest@frontside.com" title="Email Us" target="_blank">
+        bigtest@frontside.com
       </ReachLink>
       <ReachLink icon={discordIconSVG} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
         Join our Discord!


### PR DESCRIPTION
## Motivation 

We are moving Frontside's website to `.com` instead of `.io`

## Approach

Change all the occurrences of `frontside.io` for `frontside.com`.

⚠️This PR should only be merged once records are changed on the domain and emails. 