### PR TITLE
Add release workflow and rename preview workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,19 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  publish-previews:
+    name: Publish Preview Packages
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@v1.2
+      with:
+        npm_publish: yarn publish
+        ignore: packages/website
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,19 @@
 on:
-  pull_request:
+  push:
     branches:
       - master
 
 jobs:
-  job_name:
-    name: Publish preview package
+  publish-releases:
+    name: Publish Releases
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.2
+    - name: Publish Releases
+      uses: thefrontside/actions/synchronize-with-npm@v1.3
       with:
         npm_publish: yarn publish
-        ignore: packages/website
+        ignore: packages/website packages/convergence packages/interactor packages/cli
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}


### PR DESCRIPTION
## Motivation
With all the new changes to bigtest, we need the mechanism to automatically publish releases upon merging pull requests to the master branch.

## Approach
I've gone ahead and updated the `synchronize-with-npm` action on `@thefrontside/actions` to support monorepos. You can read more about it [here](https://github.com/thefrontside/actions/pull/54). 

And I ran that action from that branch on bigtest [here](https://github.com/thefrontside/bigtest/runs/454029814?check_suite_focus=true) with no issues... except I'm getting a `Creating a browser bundle that depends on Node.js built-in module ('path'). You might need to include https://www.npmjs.com/package/rollup-plugin-node-builtins` notification for `packages/agent` but that doesn't seem to prevent it from building and publishing properly.

Oh and I also renamed the preview workflow to make things tidier.

## TODOs
- [x] Merge `@thefrontside/actions` [PR #54](https://github.com/thefrontside/actions/pull/54)
  - [x] Tag and release as `v1.3`