### PR TITLE
Better connectback api

### DIFF
--- a/packages/agent/bin/start.ts
+++ b/packages/agent/bin/start.ts
@@ -7,8 +7,8 @@ import { main, once, self } from './helpers';
 
 
 main(function* start() {
-  let appDir = Path.join(__dirname, '../dist/app');
-  let server: AgentServer = yield AgentServer.create('ws://localhost:24003', port(), appDir);
+  let server: AgentServer = AgentServer.create({ port: port() }, Path.join(__dirname, '../dist/app'));
+
   let context: Context = yield self;
 
   yield function *bundle() {
@@ -27,8 +27,11 @@ main(function* start() {
   }
 
 
+  yield server.listen();
+
+
   console.info(`serving agent application`);
-  console.info(`--> connect agents at ${server.agentAppURL}`);
+  console.info(`--> connect agents at ${server.url}`);
   console.info(`--> harness script at ${server.harnessScriptURL}`);
 
   yield server.join();

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -10,16 +10,16 @@ interface Options {
 
 export class AgentServer {
 
-  protected constructor(public url: string) {}
+  protected constructor(public url: string, protected appDir: string) {}
 
-  static create(options: Options) {
+  static create(options: Options, appDir = Path.join(__dirname, 'app')) {
     if (options.externalURL) {
-      return new AgentServer(options.externalURL);
+      return new AgentServer(options.externalURL, appDir);
     } else {
       if (!options.port) {
         throw new Error('An agent server must be created with either an external url or a port number');
       }
-      return new HttpAgentServer(options.port);
+      return new HttpAgentServer(options.port, appDir);
     }
   }
 
@@ -38,15 +38,14 @@ export class AgentServer {
 
 class HttpAgentServer extends AgentServer {
   http?: Server;
-  constructor(private port: number) {
-    super(`http://localhost:${port}`);
+  constructor(private port: number, appDir: string) {
+    super(`http://localhost:${port}`, appDir);
   }
 
   *listen() {
-    let appDir = Path.join(__dirname, 'app');
     let express = xp;
     let app = express()
-      .use(express.static(appDir));
+      .use(express.static(this.appDir));
 
     let server: Server = yield listen(app, this.port);
     this.http = server;

--- a/packages/agent/index.ts
+++ b/packages/agent/index.ts
@@ -2,40 +2,57 @@ import { Operation, Context } from 'effection';
 import * as xp from 'express';
 import * as Path from 'path';
 import { Server } from 'http';
-import { AddressInfo } from 'net';
+
+interface Options {
+  port: number;
+  externalURL?: string;
+}
 
 export class AgentServer {
-  private constructor(private agentAppURL: string, private http?: Server) {}
+
+  protected constructor(public url: string) {}
+
+  static create(options: Options) {
+    if (options.externalURL) {
+      return new AgentServer(options.externalURL);
+    } else {
+      if (!options.port) {
+        throw new Error('An agent server must be created with either an external url or a port number');
+      }
+      return new HttpAgentServer(options.port);
+    }
+  }
 
   connectURL(connectBackURL: string) {
-    return `${this.agentAppURL}/?connectTo=${encodeURIComponent(connectBackURL)}`;
+    return `${this.url}/?connectTo=${encodeURIComponent(connectBackURL)}`;
   }
 
   get harnessScriptURL() {
-    return `${this.agentAppURL}/harness.js`;
+    return `${this.url}/harness.js`;
   }
 
-  static *create(port?: number, appDir: string = Path.join(__dirname, 'app')): Operation {
+  *listen(): Operation { return; }
+
+  *join(): Operation { yield; }
+}
+
+class HttpAgentServer extends AgentServer {
+  http?: Server;
+  constructor(private port: number) {
+    super(`http://localhost:${port}`);
+  }
+
+  *listen() {
+    let appDir = Path.join(__dirname, 'app');
     let express = xp;
     let app = express()
       .use(express.static(appDir));
 
-    let server: Server = yield listen(app, port);
-
-    let address = server.address() as AddressInfo;
+    let server: Server = yield listen(app, this.port);
+    this.http = server;
 
     let context: Context = yield parent;
     context['ensure'](() => server.close());
-
-    return new AgentServer(`http://localhost:${address.port}`, server);
-  }
-
-
-
-  static *external(agentServerURL: string): Operation {
-    let url = new URL(agentServerURL);
-
-    return new AgentServer(agentServerURL);
   }
 
   join(): Operation {
@@ -43,9 +60,12 @@ export class AgentServer {
       if (this.http) {
         this.http.on('close', resume);
         ensure(() => this.http.off('close', resume));
+      } else {
+        throw new Error('cannot join a server that is not already listening');
       }
     }
   }
+
 }
 
 function listen(app: xp.Express, port?: number): Operation {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts'",
+    "lint": "eslint '**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "ts-node bin/start.ts",
     "build": "echo 'build'",

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -5,7 +5,6 @@ import fetch from 'node-fetch';
 import { AgentServer } from '../index';
 
 describe("@bigtest/agent", () => {
-
   let World: Context;
   async function spawn<T>(operation: Operation): Promise<T> {
     return World["spawn"](operation);
@@ -20,10 +19,7 @@ describe("@bigtest/agent", () => {
   });
 
   describe('starting a new server', () => {
-    let server: AgentServer;
-    beforeEach(async () => {
-      server = await spawn(AgentServer.create());
-    });
+    let server: AgentServer = AgentServer.create({port: 8000});
 
     it('has an agent url where it will server the agent application', () => {
       expect(server.harnessScriptURL).toBeDefined();
@@ -34,6 +30,10 @@ describe("@bigtest/agent", () => {
     });
 
     describe('fetching the harness', () => {
+      beforeEach(async () => {
+        await spawn(server.listen());
+      });
+
       let harnessBytes: string;
       beforeEach(async () => {
         let response = await fetch(server.harnessScriptURL);
@@ -47,22 +47,10 @@ describe("@bigtest/agent", () => {
 
   });
 
-  describe('starting a server on a specific port', () => {
-    let server: AgentServer
-
-    beforeEach(async () => {
-      server = await spawn(AgentServer.create(8000));
-    });
-
-    it('starts the server on the correct port', () => {
-      expect(server.connectURL('')).toContain('http://localhost:8000');
-    });
-  });
-
   describe('a proxy development server', () => {
     let server: AgentServer;
     beforeEach(async () => {
-      server = await spawn(AgentServer.external('http://host.com'));
+      server = AgentServer.create({ port: 8000, externalURL: 'http://host.com' });
     });
 
     it('appends the pre-configured connect back url', () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,7 +1,7 @@
 import { main, Operation, Context } from 'effection';
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
-import fetch, { Response } from 'node-fetch';
+import fetch from 'node-fetch';
 import { AgentServer } from '../index';
 
 describe("@bigtest/agent", () => {
@@ -22,64 +22,51 @@ describe("@bigtest/agent", () => {
   describe('starting a new server', () => {
     let server: AgentServer;
     beforeEach(async () => {
-      server = await spawn(AgentServer.create('ws://localhost:5500'));
+      server = await spawn(AgentServer.create());
     });
 
-    it('has a harness url where it will serve the harness script', () => {
-      expect(server.agentAppURL).toBeDefined();
-    });
     it('has an agent url where it will server the agent application', () => {
       expect(server.harnessScriptURL).toBeDefined();
     });
 
-    describe('reqeusting the agent app without a connect back url', () => {
-      let response: Response;
+    it('can genenrate the full connect URL', () => {
+      expect(server.connectURL('ws://websocket-server.com')).toContain('websocket-server');
+    });
 
+    describe('fetching the harness', () => {
+      let harnessBytes: string;
       beforeEach(async () => {
-        response = await fetch(server.agentAppURL);
+        let response = await fetch(server.harnessScriptURL);
+        harnessBytes = await response.text();
       });
 
-
-      it('redirects to itself wit the connect back url', () => {
-        expect(response.redirected).toEqual(true);
-        expect(response.url).toEqual(`${server.agentAppURL}/?connectTo=ws://localhost:5500`);
+      it('has the javascripts', () => {
+        expect(harnessBytes).toContain('harness');
       });
     });
 
-    describe('requesting with a connect back url', () => {
-      let response: Response;
-
-      beforeEach(async () => {
-        response = await fetch(`${server.agentAppURL}/?connectTo=ws://localhost:8000`);
-      });
-
-      it('does not redirect', () => {
-        expect(response.redirected).toEqual(false);
-      });
-    });
   });
 
   describe('starting a server on a specific port', () => {
     let server: AgentServer
 
     beforeEach(async () => {
-      server = await spawn(AgentServer.create('ws://localhost:5500', 8000));
+      server = await spawn(AgentServer.create(8000));
     });
 
     it('starts the server on the correct port', () => {
-      expect(server.agentAppURL).toEqual('http://localhost:8000');
+      expect(server.connectURL('')).toContain('http://localhost:8000');
     });
   });
 
   describe('a proxy development server', () => {
     let server: AgentServer;
     beforeEach(async () => {
-      server = await spawn(AgentServer.external('http://host.com', 'ws://localhost:5000'));
+      server = await spawn(AgentServer.external('http://host.com'));
     });
 
     it('appends the pre-configured connect back url', () => {
-      expect(server.connectURL).toEqual('http://host.com/?connectTo=ws://localhost:5000');
+      expect(server.connectURL('ws://localhost:5000')).toEqual(`http://host.com/?connectTo=${encodeURIComponent('ws://localhost:5000')}`);
     });
   });
-
-})
+});


### PR DESCRIPTION
We've decided, that any port allocation should be done ahead of time, that way we know what the static configuration of the server is going to be and we don't need to block startup based on different services acquiring urls.