### PR TITLE
Prepack for CI and for development

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           node-version: '12.x'
       - run: yarn
-      - run: yarn build
+      - run: yarn prepack
       - run: yarn test --browsers=ChromeHeadless

--- a/README.md
+++ b/README.md
@@ -5,7 +5,21 @@
 1. Clone this repository `git clone git@github.com:bigtestjs/bigtest.git`
 2. Run `yarn`
 
+### Building
+
+Many of the packages in this repository depend on each other in order
+to function. However, being assembled from TypeScript and HTML
+webapps, these packages need to be built before they can be
+consumed. In order to build dependencies
+
+``` shell
+$ yarn prepack
+```
+
+This will compile each package into the state in which it will
+ultimately appear on NPM.
+
 ### Running tests
 
 1. Run `yarn` to ensure that all dependencies are installed
-2. Run `yarn test` to run automated tests  
+2. Run `yarn test` to run automated tests

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "packages/website/"
   publish = "public/"
-  command = "npm run build"
+  command = "npm run prepack"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "clean": "find . \\( -name node_modules -o -name dist \\) -exec rm -rf {} +",
-    "build": "yarn workspaces run build",
+    "prepack": "yarn workspaces run prepack",
     "test": "yarn workspaces run test",
     "develop": "cd packages/website && gatsby develop"
   }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,7 +16,6 @@
     "lint": "eslint '**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "ts-node bin/start.ts",
-    "build": "echo 'build'",
     "bundle": "parcel watch --out-dir dist/app app/index.html",
     "prepack": "microbundle --entry index.ts --output dist --format modern,es,umd && parcel build --out-dir dist/app app/index.html app/harness.ts"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,6 @@
     "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "ts-node src/index.ts",
-    "build": "echo 'build'",
     "prepack": "tsc --project tsconfig.dist.json --outdir dist --module commonjs"
   },
   "bin": {

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -16,7 +16,7 @@
     "docs": "bigtest-docs",
     "lint": "eslint --ignore-path .gitignore ./",
     "test": "mocha --opts ./tests/mocha.opts ./tests",
-    "prepack": "echo 'prepack'"
+    "prepack": "rollup --config"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -16,7 +16,7 @@
     "docs": "bigtest-docs",
     "lint": "eslint --ignore-path .gitignore ./",
     "test": "mocha --opts ./tests/mocha.opts ./tests",
-    "prepack": "npm run docs && npm run build"
+    "prepack": "echo 'prepack'"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ignore-path .gitignore ./",
     "start": "karma start",
     "test": "yarn start --single-run",
-    "prepack": "npm run docs && npm run build"
+    "prepack": "echo 'prepack'"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -12,12 +12,11 @@
     "src"
   ],
   "scripts": {
-    "build": "rollup --config",
     "docs": "bigtest-docs",
     "lint": "eslint --ignore-path .gitignore ./",
     "start": "karma start",
     "test": "yarn start --single-run",
-    "prepack": "echo 'prepack'"
+    "prepack": "rollup --config"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -11,7 +11,6 @@
   "scripts": {
     "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
-    "build": "microbundle --output dist --format modern,es,umd",
     "prepack": "microbundle --output dist --format modern,es,umd"
   },
   "devDependencies": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -47,7 +47,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "gatsby build",
+    "prepack": "gatsby build",
     "develop": "gatsby develop",
     "format:ts": "prettier --write '**/*.{json,ts,tsx}'",
     "lint:ts": "prettier --check '**/*.{json,ts,tsx}'",


### PR DESCRIPTION
Motivation
----------

Yarn workspaces gives preference to local packages inside the monorepo over anything listed in the package.json. So, for example, the contents of the `packages/agent` directory is preferred over the `@bigest/agent` npm packages.

Approach
----------

As we add many independent NPM packages to the monorepo, this makes development awkward since you need to build your package ahead of time. This adds a `yarn prepack` script to the root package that fans out a prepack over all of the packages. That way, you can run it once before hacking on your individual package, and all the other packages are ready to be used.

Why `prepack` and not `build`?
------------------------------
`prepack` is the npm package state that is "just before the tarball is created". In other words, the exact package contents except in expanded directory form. This is the level of readiness that we should expect all of our packages to be in before we start depending on them from other packages. Otherwise, we may be developing against packages in a different form than how they'll actually take in production.

The website is the outlier here, but since we might at some point support deploying it as an NPM package, I went ahead and changed its build script to be named 'prepack'.

> Note that `convergence` and `interactor` have their `prepack` scripts changed to not generate docs their respective re-writes

Open Questions
--------------

- How do we override local package directories with packages from NPM?
- How do we hack on local packages and have them rebuild
- automatically.