### PR TITLE
Fingerprint manifest so they get unique URLs

### DIFF
--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -4,15 +4,17 @@ import { Mailbox } from '@effection/events';
 import * as tempy from 'tempy';
 import { setLogLevel } from '../src/log-level';
 
-import { createOrchestrator } from '../src/index';
+import { createOrchestrator, Atom } from '../src/index';
 
 setLogLevel('info');
 
 main(function*() {
   let delegate = new Mailbox();
+  let atom = new Atom();
 
   yield fork(createOrchestrator({
     delegate,
+    atom,
     appCommand: "yarn",
     appArgs: ["test:app:start"],
     appEnv: {
@@ -27,8 +29,7 @@ main(function*() {
     externalAgentServerURL: process.env['BIGTEST_AGENT_SERVER_URL'],
     manifestPort: 24005,
     testFiles: ["./test/fixtures/*.t.ts"],
-    manifestPath: tempy.file({ name: 'manifest.js' }),
-    manifestDistPath: tempy.directory(),
+    cacheDir: tempy.directory(),
   }));
 
   yield delegate.receive({ status: 'ready' });

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
     "effection": "^0.5.0",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
+    "fprint": "^1.0.0",
     "glob": "^7.1.6",
     "graphql": "^14.5.8",
     "http-proxy": "^1.18.0",

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -34,10 +34,11 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
     })
 
     yield fork(function* sendRun() {
+      let name = options.atom.get().manifest.name;
       yield sendData(connection, JSON.stringify({
         type: "open",
         url: `http://localhost:${options.proxyPort}`,
-        manifest: `http://localhost:${options.manifestPort}/manifest.js`
+        manifest: `http://localhost:${options.manifestPort}/${name}`
       }));
     });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,2 @@
 export { createOrchestrator } from './orchestrator';
+export { Atom } from './orchestrator/atom';

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -1,30 +1,44 @@
-import { fork, Operation } from 'effection';
+import { Operation } from 'effection';
 import { Mailbox } from '@effection/events';
 import { ChildProcess, fork as forkProcess } from '@effection/child_process';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as fprint from 'fprint';
 import { assoc } from 'ramda';
 
 import { Atom } from './orchestrator/atom';
 
+const { copyFile, mkdir } = fs.promises;
+
 interface ManifestBuilderOptions {
   delegate: Mailbox;
   atom: Atom;
-  manifestPath: string;
-  distPath: string;
+  srcPath: string;
+  buildDir: string;
+  distDir: string;
 };
 
-function* loadManifest(atom: Atom, manifestPath: string) {
-  delete require.cache[manifestPath];
-  let manifest = yield import(manifestPath);
+function* processManifest(options: ManifestBuilderOptions): Operation {
+  let buildDir = path.resolve(options.buildDir, 'manifest.js');
+  let fingerprint = yield fprint(buildDir, 'sha256');
+  let name = `manifest-${fingerprint}.js`;
+  let distPath = path.resolve(options.distDir, name);
 
-  atom.update(assoc('manifest', manifest));
+  yield mkdir(path.dirname(distPath), { recursive: true });
+  yield copyFile(buildDir, distPath);
+
+  let manifest = yield import(distPath);
+  manifest.name = name;
+  options.atom.update(assoc('manifest', manifest));
+
+  return distPath;
 }
 
 export function* createManifestBuilder(options: ManifestBuilderOptions): Operation {
   // TODO: @precompile this should use node rather than ts-node when running as a compiled package
   let child: ChildProcess = yield forkProcess(
     './bin/parcel-server.ts',
-    ['--out-dir', options.distPath, '--out-file', 'manifest.js', '--global', '__bigtestManifest', options.manifestPath],
+    ['--out-dir', options.buildDir, '--out-file', 'manifest.js', '--global', '__bigtestManifest', options.srcPath],
     {
       execPath: 'ts-node',
       execArgv: [],
@@ -34,20 +48,17 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
 
   let messages = yield Mailbox.watch(child, "message", ({ args: [message] }) => message);
 
-  let { options: { outDir } } = yield messages.receive({ type: "ready" });
+  yield messages.receive({ type: "ready" });
+  let distPath = yield processManifest(options);
 
-  let manifestPath = path.resolve(outDir, 'manifest.js');
-
-  yield fork(loadManifest(options.atom, manifestPath));
   console.debug("[manifest builder] manifest ready");
-  options.delegate.send({ status: "ready", path: manifestPath });
+  options.delegate.send({ status: "ready", path: distPath });
 
   while(true) {
     yield messages.receive({ type: "update" });
-
-    yield fork(loadManifest(options.atom, manifestPath));
+    let distPath = yield processManifest(options);
 
     console.debug("[manifest builder] manifest updated");
-    options.delegate.send({ event: "update", path: manifestPath });
+    options.delegate.send({ event: "update", path: distPath });
   }
 }

--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -11,7 +11,7 @@ const { writeFile, mkdir } = fs.promises;
 interface ManifestGeneratorOptions {
   delegate: Mailbox;
   files: [string];
-  manifestPath: string;
+  destinationPath: string;
 };
 
 function* writeManifest(options: ManifestGeneratorOptions) {
@@ -20,7 +20,7 @@ function* writeManifest(options: ManifestGeneratorOptions) {
   let manifest = "const entries = [\n";
 
   for(let file of files) {
-    let filePath = "./" + path.relative(path.dirname(options.manifestPath), file);
+    let filePath = "./" + path.relative(path.dirname(options.destinationPath), file);
     manifest += `  { path: ${JSON.stringify(file)}, test: require(${JSON.stringify(filePath)}).default },\n`;
   }
 
@@ -38,8 +38,8 @@ module.exports = {
 }
 `
 
-  yield mkdir(path.dirname(options.manifestPath), { recursive: true });
-  yield writeFile(options.manifestPath, manifest);
+  yield mkdir(path.dirname(options.destinationPath), { recursive: true });
+  yield writeFile(options.destinationPath, manifest);
 }
 
 export function* createManifestGenerator(options: ManifestGeneratorOptions): Operation {

--- a/packages/server/src/manifest-server.ts
+++ b/packages/server/src/manifest-server.ts
@@ -5,14 +5,14 @@ import { express } from '@effection/express';
 
 interface ManifestServerOptions {
   delegate: Mailbox;
-  path: string;
+  dir: string;
   port: number;
 };
 
 export function* createManifestServer(options: ManifestServerOptions): Operation {
   let app = express();
 
-  app.use(staticMiddleware(options.path));
+  app.use(staticMiddleware(options.dir));
 
   yield app.listen(options.port);
 

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -9,6 +9,7 @@ import { OrchestratorState } from './state';
 export class Atom {
   private state: OrchestratorState = {
     manifest: {
+      name: "-none-",
       sources: [],
       suite: {
         description: "empty",

--- a/packages/server/src/test.ts
+++ b/packages/server/src/test.ts
@@ -26,6 +26,7 @@ export interface Check {
 export type Context = Record<string, unknown>;
 
 export interface Manifest {
+  name: string;
   sources: string[];
   suite: Test;
 }

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -6,8 +6,10 @@ import { beforeEach, afterEach } from 'mocha';
 
 import { createOrchestrator } from '../src/index';
 import { Mailbox } from '../src/effection/events';
+import { Atom } from '../src/orchestrator/atom';
 
 interface Actions {
+  atom: Atom;
   fork<T>(operation: Operation): Context;
   receive(mailbox: Mailbox, pattern: any): PromiseLike<any>;
   fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response>;
@@ -17,6 +19,8 @@ interface Actions {
 let orchestratorPromise: Context;
 
 export const actions: Actions = {
+  atom: new Atom(),
+
   fork(operation: Operation): Context {
     return currentWorld.fork(operation);
   },
@@ -31,26 +35,24 @@ export const actions: Actions = {
 
   startOrchestrator() {
     if(!orchestratorPromise) {
-      let mail = new Mailbox();
-      orchestratorPromise = globalWorld.fork(function*() {
-        yield mail.receive({ status: 'ready' });
-      });
+      let delegate = new Mailbox();
 
       globalWorld.fork(createOrchestrator({
-        delegate: mail,
+        delegate,
+        atom: this.atom,
         appCommand: "bigtest-todomvc 24100",
-        appEnv: {  },
         appDir: "test/app",
         appPort: 24100,
         testFiles: ["test/fixtures/*.t.js"],
-        manifestPath: "./tmp/orchestrator/src/manifest.js",
-        manifestDistPath: "./tmp/orchestrator/dist",
+        cacheDir: "./tmp/test/orchestrator",
         manifestPort: 24105,
         proxyPort: 24101,
         commandPort: 24102,
         connectionPort: 24103,
         agentPort: 24104,
       }));
+
+      orchestratorPromise = this.receive(delegate, { status: 'ready' });
     }
     return orchestratorPromise;
   }

--- a/packages/server/test/manifest-builder.test.ts
+++ b/packages/server/test/manifest-builder.test.ts
@@ -4,7 +4,6 @@ import * as path from 'path';
 import * as rmrf from 'rimraf';
 import * as fs from 'fs';
 
-import { Response } from 'node-fetch';
 import { Mailbox } from '@effection/events';
 
 import { actions } from './helpers';
@@ -13,6 +12,7 @@ import { Atom } from '../src/orchestrator/atom';
 
 const TEST_DIR = "./tmp/manifest-builder"
 const SRC_DIR = `${TEST_DIR}/src`
+const BUILD_DIR = `${TEST_DIR}/build`
 const DIST_DIR = `${TEST_DIR}/dist`
 const MANIFEST_PATH = `${SRC_DIR}/manifest.js`
 
@@ -35,8 +35,9 @@ describe('manifest builder', () => {
       yield createManifestBuilder({
         delegate,
         atom,
-        manifestPath: MANIFEST_PATH,
-        distPath: DIST_DIR,
+        srcPath: MANIFEST_PATH,
+        buildDir: BUILD_DIR,
+        distDir: DIST_DIR,
       });
     });
 

--- a/packages/server/test/manifest-generator.test.ts
+++ b/packages/server/test/manifest-generator.test.ts
@@ -35,7 +35,7 @@ describe('manifest-generator', () => {
     actions.fork(createManifestGenerator({
       delegate,
       files: [TEST_DIR + "/*.t.{js,ts}"],
-      manifestPath: MANIFEST_PATH,
+      destinationPath: MANIFEST_PATH,
     }));
 
     await actions.receive(delegate, { status: 'ready' });

--- a/packages/server/test/orchestrator.test.ts
+++ b/packages/server/test/orchestrator.test.ts
@@ -104,7 +104,8 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.fetch('http://localhost:24105/manifest.js');
+      let name = actions.atom.get().manifest.name;
+      response = await actions.fetch(`http://localhost:24105/${name}`);
       body = await response.text();
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,7 +2986,7 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
-bluebird@^3.3.0, bluebird@^3.5.5, bluebird@^3.7.2:
+bluebird@^3.0.6, bluebird@^3.3.0, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -3393,7 +3393,7 @@ caller-path@^2.0.0:
   dependencies:
     caller-callsite "^2.0.0"
 
-callsite@1.0.0:
+callsite@1.0.0, callsite@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
   integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
@@ -6482,6 +6482,15 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
+fprint@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fprint/-/fprint-1.0.0.tgz#5751aa98bae3c17c7393791b530ea08c066629ed"
+  integrity sha1-V1GqmLrjwXxzk3kbUw6gjAZmKe0=
+  dependencies:
+    bluebird "^3.0.6"
+    callsite "^1.0.0"
+    isstream "^0.1.2"
+
 fragment-cache@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
@@ -8786,7 +8795,7 @@ isomorphic-fetch@^2.1.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
-isstream@~0.1.2:
+isstream@^0.1.2, isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=


### PR DESCRIPTION
> Migrated from https://github.com/bigtestjs/server/pull/103

The fingerprinted filename is stored in the state.

One minor change in this PR is that the orchestrator no longer creates the atom, but must be supplied with one. The reason for this is that we need to be able to extract data from the atom in our tests, and there is no other way of getting hold of it.