### PR TITLE
Fix renovation note typos

### DIFF
--- a/packages/website/src/pages/docs.tsx
+++ b/packages/website/src/pages/docs.tsx
@@ -32,8 +32,8 @@ const GuidesPage = () => (
       <WarningBox>
         <H4>BigTest is going through a major renovation</H4>
         <Text>
-          The core values behind the BigTest remain. But the egonomics, APIs, performance, and scope of the
-          framework have changed to be more ambicious.
+          The core values behind BigTest remain. But the ergonomics, APIs, performance, and scope of the framework
+          have changed to be more ambitious.
         </Text>
         <Text>
           We'll be working on the new Guides shortly. If you need access to v1.x API Docs, they're available at:{' '}

--- a/packages/website/src/pages/guides.tsx
+++ b/packages/website/src/pages/guides.tsx
@@ -32,8 +32,8 @@ const GuidesPage = () => (
       <WarningBox>
         <H4 color="bodyCopy">BigTest is going through a major renovation</H4>
         <Text>
-          The core values behind the BigTest remain. But the egonomics, APIs, performance, and scope of the
-          framework have changed to be more ambicious.
+          The core values behind BigTest remain. But the ergonomics, APIs, performance, and scope of the framework
+          have changed to be more ambitious.
         </Text>
         <Text>
           We'll be working on the new Guides shortly. If you need access to v1.x Guides, they're available at:{' '}


### PR DESCRIPTION
<img width="768" alt="Screen Shot 2020-02-24 at 12 45 05 PM" src="https://user-images.githubusercontent.com/230597/75181288-810f3f80-5703-11ea-939d-dd1702a477ca.png">
