### PR TITLE
Don't use placeholder text in site meta description

### DIFF
--- a/packages/website/gatsby-config.js
+++ b/packages/website/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     title: `BigTest`,
-    description: `Bigtest Description Beep`,
+    description: `Test at the same scale as your application`,
     author: `Frontside Inc.`,
   },
   plugins: [


### PR DESCRIPTION
Motivation
----------

People are actually using our site and sharing links to it.

Approach
--------

Use some, any description. It doesn't have to be great, but it needs to not be obviousl placeholder text