### PR TITLE
Upgrade agent to use effection 0.5.1

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -40,7 +40,7 @@
     "@types/express": "^4.17.2",
     "@types/node": "^12.7.11",
     "bowser": "^2.9.0",
-    "effection": "^0.5.0",
+    "effection": "^0.5.1",
     "express": "^4.17.1"
   },
   "volta": {


### PR DESCRIPTION
Prior to 0.5.1, effection will not work with `regeneratorRuntime` since it used native generator function prototype to test if an object was a generator. Since the agent needs to support any old browser, it uses `regeneratorRuntime` instead of native generators.

This upgrades the agent to the first version of effection that uses `regeneratorRuntime`