### PR TITLE
Use atomic slices to improve type-checking of lens operations

### DIFF
--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -4,9 +4,9 @@ import { ChildProcess, fork as forkProcess } from '@effection/child_process';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as fprint from 'fprint';
-import { assoc } from 'ramda';
 
 import { Atom } from './orchestrator/atom';
+import { Test } from './test';
 
 const { copyFile, mkdir } = fs.promises;
 
@@ -33,7 +33,9 @@ function* processManifest(options: ManifestBuilderOptions): Operation {
 
   manifest.fileName = fileName;
 
-  options.atom.update(assoc('manifest', manifest));
+
+  let slice = options.atom.slice<Test>(['manifest']);
+  slice.set(manifest as Test);
 
   return distPath;
 }

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -27,28 +27,68 @@ export class Atom {
     this.subscriptions.emit('state', this.state);
   }
 
-  // Ramda Lens types. How do they work?
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  view(lens: any): unknown {
-    return R.view(lens, this.get());
-  }
-
-  // Ramda Lens types. How do they work?
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  over(lens: any, fn: any) {
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.update(R.over(lens, fn) as any as (state: OrchestratorState) => OrchestratorState);
-  }
-
-  // Ramda Lens types. How do they work?
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  set(lens: any, value: unknown) {
-    //eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.update(R.set(lens, value) as any as (state: OrchestratorState) => OrchestratorState);
+  slice<T>(path: string[]): Slice<T> {
+    return new Slice(this, path);
   }
 
   *next(): Operation {
     let [state]: [OrchestratorState] = yield on(this.subscriptions, 'state');
     return state;
+  }
+}
+
+import { lensPath } from 'ramda';
+
+export class Slice<T> {
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  lens: any;
+
+  constructor(private atom: Atom, public path: string[]) {
+    this.lens = lensPath(path);
+  }
+
+  get state() { return this.atom.get(); }
+
+  get(): T {
+    return R.view(this.lens)(this.state) as T;
+  }
+
+  set(value: T): void {
+    this.atom.update(state => {
+      return R.set(this.lens, value, state) as unknown as OrchestratorState;
+    });
+  }
+
+  over(fn: (value: T) => T): void {
+    this.atom.update(state => R.over(this.lens, fn, state) as unknown as OrchestratorState);
+  }
+
+  slice<T>(path: string[]): Slice<T> {
+    return new Slice(this.atom, this.path.concat(path));
+  }
+
+  remove(): void {
+    // If this is the root, then it cannot be removed.
+    if (this.path.length === 0) { return; }
+
+    let parentPath = this.path.slice(0, -1);
+    let parentLens = R.lensPath(parentPath);
+    let parent = R.view(parentLens, this.state);
+    if (Array.isArray(parent)) {
+      this.atom.update(state => {
+        let array = parent as unknown[];
+        return R.set(parentLens, array.filter(el => el !== this.get()), state) as unknown as OrchestratorState;
+      })
+    } else {
+      let [property] = this.path.slice(-1);
+      this.atom.update(state => {
+        return R.set(parentLens, R.dissoc(property, parent), state) as unknown as OrchestratorState;
+      })
+    }
+  }
+
+  *next(): Operation {
+    let state: OrchestratorState = yield this.atom.next();
+    return R.view(this.lens, state);
   }
 }


### PR DESCRIPTION
Handy as they are, using TypeScript with Ramda lenses can be annoying at best, and perilous at worst. There are two basic problems:

1. lens operations are cumbersome in that you have to store a reference to not only the child and the root value, but also the lens.
2. the lenses erase type information. Ideally they shouldn't since they don't in other statically typed languages, but they don't type easily since TS does not support higher kinded types.

This solves both of those problem by capturing a lens into a `Slice` object. That way, there's no need to construct an extra referenc, and all of the operations on that slice are implicity happening on the focus of that lens. It solves the typing problem by the fact that `Slice`s are parameterized with the type of the lens's focus. While it isn't 100% correct, it does side-step the issue of typing lenses entirely by essentially declaring at the point you take the slice "this slice has this type" and while that is not strictly type-safe, if you do get that right, then every subsequent usage of the slice thereafter _is_.

Before:

```ts
import { lensPath } from 'ramda';

const agentsLens = lensPath(['agents']);
// add  an agent
options.atom.over(agentsLens, assoc(identifier, assoc("identifier", identifier, data)));

// remove an agent 
options.atom.over(agentsLens, dissoc(identifier));
```

After:

```ts
let agent = options.atom.slice<AgentState>(['agents', identifier]);

// add the agent 
agent.set(agentData); // must type check against `AgentState`

// remove the agent
agent.remove();
```