### PR TITLE
Lint all the things

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    name: Lint
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: yarn
+      - run: yarn lint

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "clean": "find . \\( -name node_modules -o -name dist \\) -exec rm -rf {} +",
     "prepack": "yarn workspaces run prepack",
     "test": "yarn workspaces run test",
+    "lint": "yarn workspaces run lint",
     "develop": "cd packages/website && gatsby develop"
   },
   "volta": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '**/*.ts'",
+    "lint": "eslint index.ts '{app,bin,test}/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "ts-node bin/start.ts",
     "bundle": "parcel watch --out-dir dist/app app/index.html",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint '{src,test,bin}/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "ts-node src/index.ts",
     "prepack": "tsc --project tsconfig.dist.json --outdir dist --module commonjs"

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "rollup --config",
     "docs": "bigtest-docs",
-    "lint": "eslint --ignore-path .gitignore ./",
+    "lint": "echo '[skip] convergence'",
     "test": "mocha --opts ./tests/mocha.opts ./tests",
     "prepack": "rollup --config"
   },

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "docs": "bigtest-docs",
-    "lint": "eslint --ignore-path .gitignore ./",
+    "lint": "echo '[skip] interactor'",
     "start": "karma start",
     "test": "yarn start --single-run",
     "prepack": "rollup --config"

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "files": ["dist/*", "README.md"],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts'",
+    "lint": "eslint '{src,test}/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "microbundle --output dist --format modern,es,umd"
   },

--- a/packages/server/bin/parcel-server.ts
+++ b/packages/server/bin/parcel-server.ts
@@ -4,7 +4,7 @@ import { createParcelServer } from '../src/parcel-server';
 import * as yargs from 'yargs';
 
 yargs
-  .command('$0 [files..]', 'run the parcel server', () => {}, (argv) => {
+  .command('$0 [files..]', 'run the parcel server', x => x, (argv) => {
     main(createParcelServer(argv.files as string[], { port: argv.port as number }, {
       outDir: argv.outDir,
       outFile: argv.outFile,

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,7 +12,7 @@
     "watch": "ts-node -r module-alias/register bin/watch.ts",
     "query": "ts-node -r module-alias/register bin/query.ts",
     "subscribe": "ts-node -r module-alias/register bin/subscribe.ts",
-    "lint": "eslint 'src/**/*.ts' 'bin/**/*.ts'",
+    "lint": "eslint '{src,bin,test}/**/*.ts'",
     "test": "mocha -r ./test/setup test/**/*.test.ts",
     "mocha": "mocha -r ./test/setup",
     "test:app:start": "bigtest-todomvc 24000",

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -32,7 +32,7 @@ describe('command server', () => {
   });
 
   describe('fetching the agents at the start', () => {
-    let result: Array<any>;
+    let result: unknown;
     beforeEach(async () => {
       result = await query('agents { browser { name } }');
     });
@@ -43,19 +43,19 @@ describe('command server', () => {
   });
 
   describe('running the entire suite', () => {
-    let result: any;
+    let result: unknown;
     beforeEach(async () => {
       result = await mutation('run');
     });
 
     it('returns a test run id', () => {
-      expect(result.data.run).toMatch('test-run');
+      expect(result['data'].run).toMatch('test-run');
     });
 
     it('sends a message to the orchestrator telling it to start the test run', async () => {
       let message = await actions.receive(delegate, { type: "run" });
-      expect(message.type).toEqual("run")
-      expect(message.id).toEqual(result.data.run)
+      expect(message['type']).toEqual("run")
+      expect(message['id']).toEqual(result['data'].run)
     });
   });
 
@@ -114,9 +114,9 @@ describe('command server', () => {
   });
 
   describe('querying the manifest', () => {
-    let result: { data: { manifest: Array<{ path: string; test: string }> } };
+    let result: unknown;
 
-    async function nothing() {}
+    let nothing = async x => x;
     let test1: Test, test2: Test;
     beforeEach(async () => {
       test1 = {
@@ -252,14 +252,12 @@ describe('command server', () => {
   });
 });
 
-// eslint-disable-next-line @typescript/no-explicit-any
-async function query(text: string): Promise<any> {
+async function query(text: string): Promise<unknown> {
   let response = await actions.fetch(`http://localhost:${COMMAND_PORT}?query={${encodeURIComponent(text)}}`);
   return await response.json();
 }
 
-// eslint-disable-next-line @typescript/no-explicit-any
-async function mutation(text: string): Promise<any> {
+async function mutation(text: string): Promise<unknown> {
   let body = `mutation { ${text} }`
   let response = await actions.fetch(`http://localhost:${COMMAND_PORT}`, {
     method: "POST",

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -10,8 +10,8 @@ import { Atom } from '../src/orchestrator/atom';
 
 interface Actions {
   atom: Atom;
-  fork<T>(operation: Operation): Context;
-  receive(mailbox: Mailbox, pattern: any): PromiseLike<any>;
+  fork(operation: Operation): Context;
+  receive(mailbox: Mailbox, pattern: unknown): PromiseLike<unknown>;
   fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response>;
   startOrchestrator(): PromiseLike<Context>;
 }
@@ -25,7 +25,7 @@ export const actions: Actions = {
     return currentWorld.fork(operation);
   },
 
-  receive(mailbox: Mailbox, pattern): PromiseLike<any> {
+  receive(mailbox: Mailbox, pattern): PromiseLike<unknown> {
     return actions.fork(mailbox.receive(pattern));
   },
 

--- a/packages/server/test/helpers/world.ts
+++ b/packages/server/test/helpers/world.ts
@@ -3,7 +3,7 @@ import fetch, { Response, RequestInfo, RequestInit } from 'node-fetch';
 import { AbortController } from 'abort-controller';
 
 export class World {
-  execution: any;
+  execution: Context;
   constructor() {
     this.execution = main(function*() { yield; });
   }
@@ -13,7 +13,7 @@ export class World {
   }
 
   fork(operation: Operation): Context {
-    return this.execution.spawn(operation);
+    return this.execution['spawn'](operation);
   }
 
   fetch(resource: RequestInfo, init: RequestInit = {}): Promise<Response> {
@@ -22,7 +22,7 @@ export class World {
 
     let result = fetch(resource, init);
 
-    this.execution.ensure(() => controller.abort());
+    this.execution['ensure'](() => controller.abort());
 
     return result;
   }

--- a/packages/server/test/manifest-builder.test.ts
+++ b/packages/server/test/manifest-builder.test.ts
@@ -41,7 +41,7 @@ describe('manifest builder', () => {
       });
     });
 
-    resultPath = (await actions.receive(delegate, { status: 'ready' })).path;
+    resultPath = (await actions.receive(delegate, { status: 'ready' }))['path'];
   });
 
   describe('retrieving test file manifest from disk', () => {


### PR DESCRIPTION
Now that we have everything in a monorepo, it's time to get our listing story in line.

This adds a lint workflow to run on each PR that delegates to each package (and also fixes the current crop of listing errors)