### PR TITLE
Call the testing workflow what it is

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-18.04
-    name: Node 12
+    name: Tests
     steps:
       - uses: actions/checkout@v1
       - name: Setup node


### PR DESCRIPTION
We're running the tests in the `actions.yml` workflow, and the name in the box reads "Node 12"

Instead, this should be called `tests.yml` and "tests"