### PR TITLE
Add link to v1 docs to header

### DIFF
--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -39,6 +39,16 @@ const Nav = styled.nav`
 //   margin: 0 ${({ theme }) => theme.space.medium};
 // `;
 
+const LegacyLink = styled.a`
+  color: ${({ theme }) => theme.colors.primary};
+  font-size: ${({ theme }) => theme.fontSizes.medium};
+  font-family: ${({ theme }) => theme.fonts.heading};
+  align-content: center;
+  margin-left: ${({ theme }) => theme.space.medium};
+  padding-left: ${({ theme }) => theme.space.medium};
+  border-left: 1px solid ${({ theme }) => theme.colors.primary};
+`;
+
 const Header = () => (
   <HeadWrapper as="header">
     <LogoLink to="/">BigTest</LogoLink>
@@ -55,6 +65,9 @@ const Header = () => (
       <IconLink icon={discord_icon} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
         Discord
       </IconLink>
+      <LegacyLink href="http://v1.bigtestjs.io/">
+        v1.x Docs &#8594;
+      </LegacyLink>
     </Nav>
   </HeadWrapper>
 );

--- a/packages/website/src/components/WhyBigTest.tsx
+++ b/packages/website/src/components/WhyBigTest.tsx
@@ -41,7 +41,7 @@ const WhyBigTest: React.FC<{ title?: string }> = ({ title }) => (
         <p>Designed and implemented to speed up test writing, execution, and maintenance.</p>
       </Item>
       <Item largeOrder="3">
-        <H4>Experienced-centered</H4>
+        <H4>Experience-centered</H4>
         <p>Test what matters to users through a refined developer experience.</p>
       </Item>
       <Item largeOrder="1">


### PR DESCRIPTION
## Motivation

Users of v1 did not have a way to access the archived guides if they visited `https://bigtestjs.io`. 

## Approach

Added a link on the header pointing to `v1` documentation. 