### PR TITLE
Add Test interfaces for use across components

### DIFF
--- a/packages/suite/.eslintrc.json
+++ b/packages/suite/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "plugin:@typescript-eslint/recommended",
+  "plugins": ["prefer-let"],
+  "rules": {
+    "prefer-const": 0,
+    "prefer-let/prefer-let": 2,
+    "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
+}

--- a/packages/suite/.gitignore
+++ b/packages/suite/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/suite/README.md
+++ b/packages/suite/README.md
@@ -1,0 +1,8 @@
+# @bigtest/suite
+
+Define the structure of tests
+
+## Synopsis
+
+Currently, this package only contains interface definitions, but will
+perhaps be the home of the DSL.

--- a/packages/suite/index.ts
+++ b/packages/suite/index.ts
@@ -1,0 +1,65 @@
+/**
+ * A tree of metadata describing a test and all of its children. By
+ * design, this tree is as stripped down as possible so that it can be
+ * seamlessly passed around from system to system. It does not include
+ * any references to the functions which comprise actions and
+ * assertions since they are not serializable, and cannot be shared
+ * between processes.
+ */
+export interface Test extends Node {
+  description: string;
+  steps: Node[];
+  assertions: Node[];
+  children: Test[];
+}
+
+
+/**
+ * A tree of tests that is like the `Test` interface in every way
+ * except that it contains the actual steps and assertions that will
+ * be run. Most of the time this interface is not necessary and
+ * components of the system will be working with the `Test` API, but
+ * in the case of the harness which actually consumes the test
+ * implementation, and in the case of the DSL which produces the test
+ * implementation, it will be needed.
+ */
+export interface TestImplementation extends Test {
+  description: string;
+  steps: Step[];
+  assertions: Assertion[];
+  children: TestImplementation[];
+}
+
+/**
+ * A single operation that is part of the test. It contains an Action
+ * which is an `async` function that accepts the current test
+ * context. If it resolves to another context, that context will be
+ * merged into the current context, otherwise, the context will be
+ * left alone.
+ */
+
+export interface Step extends Node {
+  description: string;
+  action: (context: Context) => Promise<Context | void>;
+}
+
+/**
+ * A single assertion that is part of a test case. It accepts the
+ * current text context which has been built up to this point. It
+ * should throw an exception if the test is failing. Any non-error
+ * result will be considered a pass.
+ */
+export interface Assertion extends Node {
+  description: string;
+  check: (context: Context) => void;
+}
+
+/**
+ * Passed down the line from step to step and to each assertion of a
+ * test.
+ */
+export type Context = Record<string, unknown>;
+
+interface Node {
+  description: string;
+}

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@bigtest/suite",
+  "version": "0.1.0",
+  "description": "Test data structures ",
+  "module": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": [
+    "dist/*",
+    "README.md"
+  ],
+  "scripts": {
+    "lint": "eslint 'index.ts'",
+    "test": "echo success",
+    "prepack": "tsc --outDir dist --declaration"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.3.2",
+    "@typescript-eslint/parser": "^2.3.2",
+    "eslint": "^6.6.0",
+    "eslint-plugin-prefer-let": "^1.0.1",
+    "typescript": "^3.7.0"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "index.ts"
+  ]
+}


### PR DESCRIPTION
Motivation
----------

There are several interfaces that we use across different components to work with tests. Most of them don't need to know about the specifics of the implementation of the test, but instead just the structure of them. There are some systems like the harness and any DSL that will need to know about the test implementation interface however.

Approach
----------
This adds a `@bigtest/suite` package that will serve as a home for the shared interfaces, some of which will need to be bundled on both the browser as well as in `node`. There are two separate interfaces for `Test` and `TestImplemenation` that represent the structure as well as the "live functions" respectively.

In the declaration of the interfaces themselves, there is some duplication for the sake of readability that has no effect on correctness.

Currently, this package only contains shared interface definitions, but is the likely home for the eventual DSL.
