### PR TITLE
Disable timestamp caching for proxied html responses

### DIFF
--- a/packages/server/src/proxy.ts
+++ b/packages/server/src/proxy.ts
@@ -30,7 +30,7 @@ export function* createProxyServer(options: ProxyOptions): Operation {
     if(contentType && contentType.split(';')[0] === 'text/html') {
       res.removeHeader('content-length');
       res.removeHeader('content-encoding');
-      res.removeHeader('cache-control');
+      res.removeHeader('last-modified');
       res.removeHeader('etag');
 
       res.writeHead(proxyRes.statusCode, proxyRes.statusMessage);


### PR DESCRIPTION
Motivation
-----------

Similar to the way that express sending `etag` headers in the response was causing stale copies of the harness-injected application because the browser would send back the `if-none-match`. If we have `last-modified` headers in the response, then the browser would send a request with a `if-modified-since` header that would trigger a 304 from express. Worse, when express responded this way, it only checks the fstat to check the timestamp of the file on the filesystem and did not even bother to do any further introspection before sending back a 304 response. As a result, there were no `Content-Type` or `Content-Encoding` headers being set. This meant that our special code-path for HTML files was not being hit at all.

The reason we didn't see this before was that we had been using the Webpack dev server which does not send a `last-modified` header since it's meant to be constantly serving fresh copies. When we switched to Express which is meant to actually serve static files, it has these optimizations.

Approach
----------

This removes the `last-modified` timestamp from HTML responses so that agent browsers cannot use it to attempt caching.

I took out the "pre-emptive" removal of the `Cache-Control` header since I think we want to take a minimalist approach to proxying, and it wasn't actually breaking anything.