### PR TITLE
Can send USR1 to process to print effection backtrace

### DIFF
--- a/packages/server/src/effection/node.ts
+++ b/packages/server/src/effection/node.ts
@@ -4,14 +4,17 @@ export function main(operation: Operation): Context {
   return effectionMain(({ context: mainContext, spawn }) => {
     spawn(function* main() {
       let interrupt = () => { mainContext.halt(); };
+      let debug = () => console.debug(mainContext.toString());
       try {
         process.on('SIGINT', interrupt);
+        process.on('SIGUSR1', debug);
         return yield operation;
       } catch(e) {
         console.error(e);
         process.exit(-1);
       } finally {
         process.off('SIGINT', interrupt);
+        process.off('SIGUSR1', debug);
       }
     });
   });


### PR DESCRIPTION
It's sometimes useful to get a dump of all effection processes to see what's going on. This adds a signal handler so we can send the SIGUSR1 signal to a process to trigger a console dump of the current state.