### PR TITLE
Make description mandatory again

### DIFF
--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -29,6 +29,7 @@ function* writeManifest(options: ManifestGeneratorOptions) {
   manifest +=
 `
 module.exports = {
+  description: "All tests",
   steps: [],
   assertions: [],
   children: children,

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -9,6 +9,7 @@ import { OrchestratorState } from './state';
 export class Atom {
   private state: OrchestratorState = {
     manifest: {
+      description: "None",
       steps: [],
       assertions: [],
       children: []

--- a/packages/server/src/test.ts
+++ b/packages/server/src/test.ts
@@ -2,7 +2,7 @@ export interface Test {
   steps: Step[];
   assertions: Assertion[];
   children: Test[];
-  description?: string;
+  description: string;
   fileName?: string;
   path?: string;
 }


### PR DESCRIPTION
It makes generating paths to tests trickier, since we end up having an odd-looking "undefined" in there somewhere".