### PR TITLE
Allow sharing of effection utilities between bigtest packages.

### DIFF
--- a/packages/effection/.eslintrc.json
+++ b/packages/effection/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "plugin:@typescript-eslint/recommended",
+  "plugins": ["prefer-let"],
+  "rules": {
+    "prefer-const": 0,
+    "prefer-let/prefer-let": 2,
+    "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
+}

--- a/packages/effection/.gitignore
+++ b/packages/effection/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/effection/README.md
+++ b/packages/effection/README.md
@@ -1,0 +1,12 @@
+# @bigtest/effection
+
+
+Utitilies used throughout the codebase to work with
+Effection. Eventually these will be published under the @effection
+namespace.
+
+To run the tests:
+
+``` sh
+$ yarn test
+```

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@bigtest/effection",
+  "version": "0.1.0",
+  "description": "Collection of handly utilities for working with effection. May find a different home later",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.js",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": ["dist/*", "README.md"],
+  "scripts": {
+    "lint": "eslint '{src,test}/**/*.ts'",
+    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs"
+  },
+  "devDependencies": {
+    "@types/mocha": "^7.0.1",
+    "@typescript-eslint/eslint-plugin": "^2.3.2",
+    "@typescript-eslint/parser": "^2.3.2",
+    "eslint": "^6.6.0",
+    "eslint-plugin-prefer-let": "^1.0.1",
+    "expect": "^24.9.0",
+    "mocha": "^6.2.2",
+    "ts-node": "*",
+    "typescript": "^3.7.0"
+  },
+  "dependencies": {
+    "@types/node": "^12.7.11",
+    "effection": "^0.5.1"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/effection/src/events.ts
+++ b/packages/effection/src/events.ts
@@ -1,0 +1,17 @@
+import { Operation } from 'effection';
+import { EventEmitter } from 'events';
+
+type EventName = string | symbol;
+
+/**
+ * Takes an event emitter and event name and returns a yieldable
+ * operation which resumes when the event occurs.
+ */
+export function once(emitter: EventEmitter, eventName: EventName): Operation {
+  return ({ resume, ensure }) => {
+    let listener = (...args: unknown[]) => resume(args);
+    ensure(() => emitter.off(eventName, listener));
+
+    emitter.on(eventName, listener);
+  };
+}

--- a/packages/effection/src/index.ts
+++ b/packages/effection/src/index.ts
@@ -1,0 +1,1 @@
+export { once } from './events';

--- a/packages/effection/test/helpers.ts
+++ b/packages/effection/test/helpers.ts
@@ -1,0 +1,27 @@
+import { main, Context, Operation } from 'effection';
+
+class World {
+  static current: World;
+
+  context: Context = main(undefined);
+
+  spawn<T>(operation: Operation): Context & PromiseLike<T>{
+    return this.context['spawn'](operation);
+  }
+
+  halt() {
+    this.context.halt();
+  }
+}
+
+export function spawn<T>(operation: Operation): Context & PromiseLike<T> {
+  return World.current.spawn(operation);
+}
+
+beforeEach(() => {
+  World.current = new World();
+});
+
+afterEach(() => {
+  World.current.halt();
+})

--- a/packages/effection/test/once.test.ts
+++ b/packages/effection/test/once.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { Context } from 'effection';
+import { EventEmitter } from 'events';
+
+import { spawn } from './helpers';
+
+import { once } from '../src/events';
+
+describe("once()", () => {
+  let context: Context;
+  let source: EventEmitter;
+  let params: unknown[];
+
+  beforeEach(() => {
+    params = undefined;
+    source = new EventEmitter();
+    context = spawn(function*() {
+      params = yield once(source, 'event');
+    });
+  });
+
+  it('pauses before the event is received', () => {
+    expect(params).toBeUndefined();
+  });
+
+  describe('emitting the event on which it is waiting', () => {
+    beforeEach(() => {
+      source.emit('event', 1,2,10);
+    });
+
+    it('returs the parameters of the event', () => {
+      expect(params).toEqual([1,2,10]);
+    });
+  });
+
+  describe('emitting an event on which it is not waiting', () => {
+    beforeEach(() => {
+      source.emit('non-event', 1, 2, 10);
+    });
+    it('remains paused', () => {
+      expect(params).toBeUndefined();
+    });
+  });
+
+  describe('shutting down the context and then emitting the event on which it is waiting', () => {
+    beforeEach(() => {
+      context.halt();
+      source.emit('event', 1,2, 10);
+    });
+
+    it('never returns', () => {
+      expect(params).toBeUndefined();
+    });
+  });
+});

--- a/packages/effection/tsconfig.dist.json
+++ b/packages/effection/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["./test/*"]
+}

--- a/packages/effection/tsconfig.json
+++ b/packages/effection/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/server/bin/watch.ts
+++ b/packages/server/bin/watch.ts
@@ -1,7 +1,7 @@
 import { watch } from 'fs';
 import { spawn } from 'child_process';
 import { main, fork, Operation, Context } from 'effection';
-import { on } from '@effection/events';
+import { once } from '@bigtest/effection';
 
 const self: Operation = ({ resume, context: { parent }}) => resume(parent);
 
@@ -12,7 +12,7 @@ function* start(): Operation {
     let watcher = watch('src', { recursive: true });
     try {
       while (true) {
-        yield on(watcher, "change");
+        yield once(watcher, "change");
         console.log('change detected, restarting....');
         restart();
       }
@@ -43,12 +43,12 @@ function* launch(cmd: string, args: string[]): Operation {
 
   yield fork(function*() {
     let errors = yield fork(function*() {
-      let [ error ] = yield on(child, "error");
+      let [ error ] = yield once(child, "error");
       throw error;
     });
 
     try {
-      let [ code ] = yield on(child, 'exit');
+      let [ code ] = yield once(child, 'exit');
       errors.halt();
 
       if (code > 0) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -37,6 +37,7 @@
     "@babel/plugin-transform-runtime": "7.8.3",
     "@babel/preset-env": "7.8.4",
     "@bigtest/agent": "^0.1.0",
+    "@bigtest/effection": "^0.1.0",
     "@bigtest/suite": "^0.1.0",
     "@types/express": "^4.17.1",
     "@types/graphql": "^14.5.0",

--- a/packages/server/src/app-server.ts
+++ b/packages/server/src/app-server.ts
@@ -1,5 +1,6 @@
 import { fork, timeout, Operation } from 'effection';
-import { on, Mailbox } from '@effection/events';
+import { Mailbox } from '@effection/events';
+import { once } from '@bigtest/effection';
 import { spawn } from '@effection/child_process';
 import { Socket } from 'net';
 import * as process from 'process';
@@ -43,7 +44,7 @@ export function* createAppServer(options: AppServerOptions): Operation {
   });
 
   let errorMonitor = yield fork(function*() {
-    let [error]: [Error] = yield on(child, "error");
+    let [error]: [Error] = yield once(child, "error");
     throw error;
   });
 
@@ -53,7 +54,7 @@ export function* createAppServer(options: AppServerOptions): Operation {
 
   options.delegate.send({ status: 'ready' });
 
-  yield on(child, "exit");
+  yield once(child, "exit");
 
   errorMonitor.halt();
 }

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -1,7 +1,8 @@
 import { w3cwebsocket as WebSocket } from 'websocket';
 import { EventEmitter } from 'events';
 import { monitor, Operation, Context } from 'effection';
-import { on } from './effection/events'
+
+import { once } from '@bigtest/effection';
 
 import { Message, isErrorResponse, isDataResponse } from './protocol';
 
@@ -21,12 +22,12 @@ export class Client {
     });
 
     context['spawn'](monitor(function* () {
-      let [error]: [Error] = yield on(subscriptions, 'error');
+      let [error]: [Error] = yield once(subscriptions, 'error');
       throw error;
     }));
 
     context['spawn'](monitor(function* () {
-      yield on(subscriptions, 'close');
+      yield once(subscriptions, 'close');
       throw new Error('Socket closed on the remote end');
     }));
   }
@@ -34,7 +35,7 @@ export class Client {
   static *create(url: string): Operation {
     let client = new Client(new WebSocket(url), yield parent);
 
-    yield on(client.subscriptions, 'open');
+    yield once(client.subscriptions, 'open');
 
     return client;
   }
@@ -62,7 +63,7 @@ export class Client {
 
     let next = function* getNextResponse() {
       while (true) {
-        let [event]: [MessageEvent] = yield on(subscriptions, 'message');
+        let [event]: [MessageEvent] = yield once(subscriptions, 'message');
         let message: Message = JSON.parse(event.data);
 
         if (message.responseId === responseId) {

--- a/packages/server/src/effection/child_process.ts
+++ b/packages/server/src/effection/child_process.ts
@@ -1,5 +1,5 @@
 import { monitor, Operation } from 'effection';
-import { on } from '@effection/events';
+import { once } from '@bigtest/effection';
 
 import * as childProcess from 'child_process';
 import { SpawnOptions, ForkOptions, ChildProcess } from 'child_process';
@@ -26,12 +26,12 @@ function supervise(execution: any, child: ChildProcess) { // eslint-disable-line
   });
 
   execution.spawn(monitor(function*() {
-    let [error]: [Error] = yield on(child, "error");
+    let [error]: [Error] = yield once(child, "error");
     throw error;
   }));
 
   execution.spawn(monitor(function*() {
-    let [code]: [number] = yield on(child, "exit");
+    let [code]: [number] = yield once(child, "exit");
     if(code !== 0) { throw new Error("child exited with non-zero exit code") }
   }));
 }

--- a/packages/server/src/effection/events.ts
+++ b/packages/server/src/effection/events.ts
@@ -1,38 +1,13 @@
 import { EventEmitter } from 'events';
 import { Operation, monitor } from 'effection';
+import { once } from '@bigtest/effection';
 export { Mailbox, any } from './events/mailbox';
 
 export type EventName = string | symbol;
 
-/**
- * Takes an event emitter and event name and returns a yieldable
- * operation which resumes when the event occurrs.
- */
-export function on(emitter: EventEmitter, eventName: EventName): Operation {
-  return ({ resume, ensure }) => {
-    let handle = (...args: unknown[]) => resume(args);
-    emitter.on(eventName, handle);
-    ensure(() => emitter.off(eventName, handle));
-  }
-}
-
-/**
- * Takes an event emmitter and an event name, and runs the operation
- * returned by the `each` function every time an event with
- * `eventName` is received.
- */
-export function onEach(source: EventEmitter, event: EventName, each: (...args: unknown[]) => Operation): Operation {
-  return ({ spawn, ensure }) => {
-    let dispatch = (...args: unknown[]) => spawn(monitor(each(...args)))
-
-    source.on(event, dispatch);
-    ensure(() => source.off(event, dispatch));
-  }
-}
-
 export function watchError(emitter: EventEmitter): Operation {
   return monitor(function*() {
-    let [error]: [Error] = yield on(emitter, 'error');
+    let [error]: [Error] = yield once(emitter, 'error');
     throw error;
   });
 }

--- a/packages/server/src/http.ts
+++ b/packages/server/src/http.ts
@@ -1,6 +1,6 @@
 import * as http from 'http';
 import { Operation, fork } from 'effection';
-import { on } from '@effection/events';
+import { once } from '@bigtest/effection';
 
 export { IncomingMessage } from 'http';
 
@@ -9,13 +9,13 @@ export type ReadyCallback = (server: http.Server) => void;
 export function* listen(server: http.Server, port: number): Operation {
 
   let errors = yield fork(function* errorListener() {
-    let [error]: [Error] = yield on(server, "error");
+    let [error]: [Error] = yield once(server, "error");
     throw error;
   })
 
   try {
     server.listen(port);
-    yield on(server, "listening");
+    yield once(server, "listening");
   } finally {
     errors.halt();
   }

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -2,7 +2,7 @@ import * as R from 'ramda';
 
 import { EventEmitter } from 'events';
 import { Operation } from 'effection';
-import { on } from '@effection/events';
+import { once } from '@bigtest/effection';
 
 import { OrchestratorState } from './state';
 
@@ -34,7 +34,7 @@ export class Atom {
   }
 
   *next(): Operation {
-    let [state]: [OrchestratorState] = yield on(this.subscriptions, 'state');
+    let [state]: [OrchestratorState] = yield once(this.subscriptions, 'state');
     return state;
   }
 }

--- a/packages/server/src/proxy.ts
+++ b/packages/server/src/proxy.ts
@@ -1,5 +1,6 @@
 import { fork, Operation } from 'effection';
-import { on, watchError, Mailbox, any } from '@effection/events';
+import { once } from '@bigtest/effection';
+import { watchError, Mailbox, any } from '@effection/events';
 
 import * as proxy from 'http-proxy';
 import * as http from 'http';
@@ -58,7 +59,7 @@ export function* createProxyServer(options: ProxyOptions): Operation {
       tr.pipe(res);
 
       try {
-        yield on(tr, 'end');
+        yield once(tr, 'end');
       } finally {
         // tr.close(); there is no close method on Trumpet, how do we not leak it in case of errors?
         unzip.close();
@@ -68,7 +69,7 @@ export function* createProxyServer(options: ProxyOptions): Operation {
 
       proxyRes.pipe(res);
 
-      yield on(proxyRes, 'end');
+      yield once(proxyRes, 'end');
     }
     console.debug('[proxy]', 'finish', req.method, req.url);
   };

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -9,7 +9,7 @@ import {
 import { fork, Operation } from 'effection';
 import { resumeOnCb } from './util';
 
-import { on } from '@effection/events';
+import { once } from '@bigtest/effection';
 
 import { listen } from './http';
 
@@ -36,7 +36,7 @@ export function* listenWS(server: Server, handler: ConnectionHandler): Operation
 
   try {
     while (true) {
-      let [request]: [Request] = yield on(socket, "request");
+      let [request]: [Request] = yield once(socket, "request");
       let connection = request.accept(null, request.origin);
 
       let handle = yield fork(function* setupConnection() {


### PR DESCRIPTION
Motivation
----------

While effection makes working with async processes a lot eaiser, it is still a primitive, and to be truly useful, most of the time what you really want is to be working with higher level constructs. We've built a lot of these constructs for working in a variety of environments: nodejs, event emitters, etc... Now that we a bunch of packages, we need to have these utitilies on-hand so that they can be used everywhere rather than be copy-pasted around like they are now.

Approach
--------

Ideally, we'd like to publish these package in the `@effection` namespace. However, we don't currently have monorepo support set up for effection, and so rather than go through the hassle of that, this just creates a single package that can be shared within the bigtest project itself. Once we start using effection outside of bigtest, then we can take up the work of migrating these utilities to their permanent home.

To start with, this extracts perhaps the most-used utility for async programming: the `once()` method which allows synchronization on the `EventEmitter.once()` interface. Other places in the codebase that were using their own copies have been updated to use the shared version.

After this, we can introduce one utility at a time along with the changes that replace local copies to use the central version.