### PR TITLE
Add suspend and ensure operations 

### DIFF
--- a/packages/effection/src/ensure.ts
+++ b/packages/effection/src/ensure.ts
@@ -1,0 +1,11 @@
+import { Operation, Controls } from 'effection';
+
+// an operation which attaches a handler which runs when the current context
+// finishes.
+export function ensure(fn: () => void): Operation {
+  return ({ resume, context }) => {
+    let targetContext = context.parent as unknown as Controls;
+    targetContext.ensure(fn);
+    resume(null);
+  }
+}

--- a/packages/effection/src/index.ts
+++ b/packages/effection/src/index.ts
@@ -1,3 +1,5 @@
 export { once } from './events';
 export { Mailbox } from './mailbox';
 export { any } from './pattern';
+export { suspend } from './suspend';
+export { ensure } from './ensure';

--- a/packages/effection/src/suspend.ts
+++ b/packages/effection/src/suspend.ts
@@ -1,0 +1,9 @@
+import { Operation, Controls } from 'effection';
+
+// run the given operation in the parent context, without blocking it
+export function suspend(operation: Operation): Operation {
+  return ({ context, resume }) => {
+    let targetContext = context.parent.parent as unknown as Controls;
+    resume(targetContext.spawn(operation));
+  }
+}

--- a/packages/effection/test/ensure.test.ts
+++ b/packages/effection/test/ensure.test.ts
@@ -1,0 +1,122 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { Context, fork, monitor } from 'effection';
+
+import { spawn } from './helpers';
+
+import { ensure } from '../src/ensure';
+import { suspend } from '../src/suspend';
+import { Mailbox } from '../src/mailbox';
+
+describe("ensure()", () => {
+  let context: Context;
+  let didRun: boolean;
+
+  beforeEach(() => didRun = false);
+
+  describe('with blocking context', () => {
+    beforeEach(async () => {
+      context = spawn(function*() {
+        yield ensure(() => didRun = true);
+        yield
+      });
+    });
+
+    it('does not run', () => {
+      expect(didRun).toEqual(false);
+    });
+
+    describe('when halted', () => {
+      beforeEach(async () => {
+        context.halt();
+      });
+
+      it('runs', () => {
+        expect(didRun).toEqual(true);
+      });
+    });
+  });
+
+  describe('with successful context', () => {
+    let result;
+
+    beforeEach(async () => {
+      result = await spawn(function*() {
+        yield ensure(() => didRun = true);
+        return 123;
+      });
+    });
+
+    it('runs', async () => {
+      expect(result).toEqual(123)
+      expect(didRun).toEqual(true)
+    });
+  });
+
+  describe('with failed context', () => {
+    let error;
+
+    beforeEach(async () => {
+      try {
+        await spawn(function*() {
+          yield ensure(() => didRun = true);
+          throw new Error("moo");
+        });
+      } catch(e) {
+        error = e;
+      }
+    });
+
+    it('runs', async () => {
+      expect(error.message).toEqual("moo")
+      expect(didRun).toEqual(true)
+    });
+  });
+
+  describe("when suspended", () => {
+    let outer: Context;
+    let inner: Context;
+    let mailbox: Mailbox;
+
+    beforeEach(() => {
+      mailbox = new Mailbox();
+      outer = spawn(function*() {
+        inner = yield fork(function*() {
+          yield suspend(ensure(() => didRun = true));
+          return "from inner";
+        });
+        return yield mailbox.receive();
+      });
+    });
+
+    it('does not block its parent context from exiting', async () => {
+      expect(await inner).toEqual("from inner");
+    });
+
+    it('does not run when parent context exits', async () => {
+      expect(didRun).toEqual(false);
+    });
+
+    describe('when halting parent', function() {
+      beforeEach(() => {
+        outer.halt();
+      });
+
+      it('runs', async () => {
+        expect(didRun).toEqual(true);
+      });
+    });
+
+    describe('when parent exits successfully', function() {
+      beforeEach(async () => {
+        mailbox.send("resume");
+        await outer;
+      });
+
+      it('runs', async () => {
+        expect(didRun).toEqual(true);
+      });
+    });
+  });
+});

--- a/packages/effection/test/suspend.test.ts
+++ b/packages/effection/test/suspend.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { Context, fork, monitor } from 'effection';
+
+import { spawn } from './helpers';
+
+import { suspend } from '../src/suspend';
+import { Mailbox } from '../src/mailbox';
+
+describe("suspend()", () => {
+  let outer: Context;
+  let inner: Context;
+  let suspended: Context;
+  let mailbox: Mailbox;
+
+  beforeEach(() => {
+    mailbox = new Mailbox();
+    outer = spawn(function*() {
+      inner = yield fork(function*() {
+        suspended = yield suspend(monitor(function*() {
+          yield mailbox.receive("suspended");
+          return "from suspended";
+        }));
+        // does not yield
+        return "from inner";
+      });
+      yield mailbox.receive("outer");
+    });
+  });
+
+  it('does not block its parent context from exiting', async () => {
+    expect(await inner).toEqual("from inner");
+  });
+
+  describe('when halting parent', function() {
+    beforeEach(() => {
+      outer.halt();
+    });
+
+    it('also gets halted', async () => {
+      await expect(suspended).rejects.toThrow("Interrupted")
+    });
+  });
+
+  describe('when resumed', function() {
+    beforeEach(() => {
+      mailbox.send("suspended");
+    });
+
+    it('resolves', async () => {
+      expect(await suspended).toEqual("from suspended");
+    });
+  });
+});


### PR DESCRIPTION
These operations can be used to simplify a lot of the code which currently uses control functions, rather than generators.