### PR TITLE
Extract logging into separate package

### DIFF
--- a/packages/logging/.eslintrc.json
+++ b/packages/logging/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "extends": "plugin:@typescript-eslint/recommended",
+  "plugins": ["prefer-let"],
+  "rules": {
+    "prefer-const": 0,
+    "prefer-let/prefer-let": 2,
+    "@typescript-eslint/no-use-before-define": 0,
+    "@typescript-eslint/explicit-function-return-type": 0
+  }
+}

--- a/packages/logging/.gitignore
+++ b/packages/logging/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -1,0 +1,9 @@
+# @bigtest/logging
+
+Utilities for working with logging in bigtest projects
+
+To run the tests:
+
+``` sh
+$ yarn test
+```

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bigtest/logging",
+  "version": "0.1.0",
+  "description": "Utilities for logging within BigTest projects",
+  "main": "src/index.ts",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": ["dist/*", "README.md"],
+  "scripts": {
+    "lint": "eslint '{src,test}/**/*.ts'",
+    "test": "true",
+    "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap --module commonjs"
+  },
+  "devDependencies": {
+    "@types/node": "^12.7.11",
+    "@typescript-eslint/eslint-plugin": "^2.3.2",
+    "@typescript-eslint/parser": "^2.3.2",
+    "eslint": "^6.6.0",
+    "eslint-plugin-prefer-let": "^1.0.1",
+    "ts-node": "*",
+    "typescript": "^3.7.0"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  }
+}

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -7,7 +7,7 @@ const HIDDEN_LOGS = {
 
 const { debug, log, warn, error } = console;
 
-export function reset() {
+export function resetLogLevel() {
   console.debug = debug
   console.log = log
   console.warn = warn
@@ -15,7 +15,7 @@ export function reset() {
 }
 
 export function setLogLevel(level) {
-  reset();
+  resetLogLevel();
   HIDDEN_LOGS[level].forEach((level) => {
     console[level] = function() {
       // do nothing

--- a/packages/logging/tsconfig.dist.json
+++ b/packages/logging/tsconfig.dist.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["./test/*"]
+}

--- a/packages/logging/tsconfig.json
+++ b/packages/logging/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts",
+    "test/**/*.ts"
+  ]
+}

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -2,7 +2,7 @@ import { fork } from 'effection';
 import { main } from '@effection/node';
 import { Mailbox } from '@bigtest/effection';
 import * as tempy from 'tempy';
-import { setLogLevel } from '../src/log-level';
+import { setLogLevel } from '@bigtest/logging';
 
 import { createOrchestrator, Atom } from '../src/index';
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,7 @@
     "@bigtest/agent": "^0.1.0",
     "@bigtest/effection": "^0.1.0",
     "@bigtest/suite": "^0.1.0",
+    "@bigtest/logging": "^0.1.0",
     "@types/express": "^4.17.1",
     "@types/graphql": "^14.5.0",
     "@types/http-proxy": "^1.17.0",

--- a/packages/server/test/setup.js
+++ b/packages/server/test/setup.js
@@ -2,6 +2,6 @@ require('module-alias/register');
 require('ts-node/register');
 process = require('process');
 
-let { setLogLevel } = require('../src/log-level')
+let { setLogLevel } = require('@bigtest/logging')
 
 setLogLevel(process.env.LOG_LEVEL || 'warn');


### PR DESCRIPTION
We will want to use the `setLogLevel` function from both the agent and the server. Additionally we might have other logging related utilities in the future.