### PR TITLE
Add command processor to orchestrator

### DIFF
--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -1,0 +1,43 @@
+import { fork, Operation } from 'effection';
+import { Mailbox } from '@bigtest/effection';
+import { Atom } from './orchestrator/atom';
+import { TestRunState } from './orchestrator/state';
+
+interface CommandProcessorOptions {
+  atom: Atom;
+  inbox: Mailbox;
+  delegate: Mailbox;
+  proxyPort: number;
+  manifestPort: number;
+};
+
+function* run(id: string, options: CommandProcessorOptions): Operation {
+  console.debug('[command processor] running test', id);
+
+  let testRunSlice = options.atom.slice<TestRunState>(['testRuns', id]);
+  let [agent] = Object.values(options.atom.get().agents);
+  let manifest = options.atom.get().manifest;
+
+  let appUrl = `http://localhost:${options.proxyPort}`;
+  let manifestUrl = `http://localhost:${options.manifestPort}/${manifest.fileName}`;
+
+  if(agent) {
+    // todo: we should perform filtering of the manifest here
+    testRunSlice.set({ status: 'pending', tree: manifest, agent });
+
+    console.debug(`[command processor] starting test run ${id} on agent ${agent.identifier}`);
+    options.delegate.send({ type: 'run', status: 'pending', agentId: agent.identifier, appUrl, manifestUrl, testRunId: id, tree: manifest });
+  }
+}
+
+export function* createCommandProcessor(options: CommandProcessorOptions): Operation {
+  while(true) {
+    let message = yield options.inbox.receive();
+
+    console.debug('[command processor] received message', message);
+
+    if(message.type === 'run') {
+      yield fork(run(message.id, options));
+    }
+  }
+}

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -15,7 +15,8 @@ export class Atom {
       assertions: [],
       children: []
     },
-    agents: {}
+    agents: {},
+    testRuns: {},
   };
 
   private subscriptions = new EventEmitter();

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -21,9 +21,16 @@ export type AgentState = {
   };
 }
 
+export type TestRunState = {
+  status: "pending";
+  tree: Test;
+  agent: AgentState;
+}
+
 export type OrchestratorState = {
   agents: Record<string, AgentState>;
   manifest: Manifest;
+  testRuns: Record<string, TestRunState>;
 }
 
 export interface Manifest extends Test {

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -1,0 +1,77 @@
+import { describe, beforeEach, it } from 'mocha';
+import * as expect from 'expect';
+
+import { Mailbox } from '@bigtest/effection';
+
+import { actions } from './helpers';
+import { createCommandProcessor } from '../src/command-processor';
+import { Atom } from '../src/orchestrator/atom';
+
+import { AgentState, Manifest, TestRunState } from 'src/orchestrator/state';
+
+describe('command server', () => {
+  let delegate: Mailbox;
+  let inbox: Mailbox;
+  let atom: Atom;
+
+  beforeEach(async () => {
+    delegate = new Mailbox();
+    inbox = new Mailbox();
+    atom = new Atom();
+    atom.slice<AgentState>(['agents', 'agent-1']).set({
+      identifier: 'agent-1',
+      browser: { name: "Safari", version: "13.0.4" },
+      os: { name: "macOS", version: "10.15.2", versionName: "Catalina" },
+      platform: { type: "desktop", vendor: "Apple" },
+      engine: { name: "Gecko", version: "5.0" }
+    });
+    atom.slice<Manifest>(['manifest']).set({
+      fileName: 'manifest-1234.js',
+      description: 'the manifest',
+      steps: [],
+      assertions: [],
+      children: [],
+    });
+    actions.fork(createCommandProcessor({
+      atom,
+      inbox,
+      delegate,
+      proxyPort: 24201,
+      manifestPort: 24202,
+    }));
+  });
+
+  describe('when sent a `run` message', () => {
+    let pendingMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    beforeEach(async () => {
+      inbox.send({ type: 'run', id: 'test-id-1' });
+      pendingMessage = await actions.fork(delegate.receive({ type: 'run', status: 'pending' }));
+    });
+
+    it('picks the first available agent for now', () => {
+      expect(pendingMessage.agentId).toEqual('agent-1');
+    });
+
+    it('sends the id of the test', () => {
+      expect(pendingMessage.testRunId).toEqual('test-id-1');
+    });
+
+    it('sends appUrl', () => {
+      expect(pendingMessage.appUrl).toEqual('http://localhost:24201');
+    });
+
+    it('sends manifestUrl', () => {
+      expect(pendingMessage.manifestUrl).toEqual('http://localhost:24202/manifest-1234.js');
+    });
+
+    it('sends entire manifest as test tree for now', () => {
+      expect(pendingMessage.tree.description).toEqual('the manifest');
+    });
+
+    it('adds agent and test tree to manifest', () => {
+      let testRun = atom.slice<TestRunState>(['testRuns', 'test-id-1']).get();
+      expect(testRun.agent.identifier).toEqual('agent-1');
+      expect(testRun.tree.description).toEqual('the manifest');
+    });
+  });
+});


### PR DESCRIPTION
The command processor is basically a run-loop for the orchestrator. It picks off commands from its inbox and runs them.

Extracted from #165