### PR TITLE
Update preview and release workflow to use v1.4

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.2
+      uses: thefrontside/actions/publish-pr-preview@v1.4
       with:
+        before_all: yarn prepack
         npm_publish: yarn publish
         ignore: packages/website packages/server
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.3
+      uses: thefrontside/actions/synchronize-with-npm@v1.4
       with:
+        before_all: yarn prepack
         npm_publish: yarn publish
         ignore: packages/website packages/convergence packages/interactor packages/cli packages/server
       env:


### PR DESCRIPTION
## Motivation
From pull request #194 we found that we need to be able to run `yarn prepack` for the entire monorepo before the preview/release actions start navigating into the individual packages to run the publishing process.

## Approach
Pull request [#55](https://github.com/thefrontside/actions/pull/55) introduced a new input argument for the release (`synchronize-with-npm`) and preview action (`publish-pr-preview`) so that we can run any command we'd like after `yarn install` but before the publishing loop begins.

I've added the feature to @thefrontside/actions and released v1.4 and updated the workflows on bigtest.

## Tests
You can see the original failing run [here](https://github.com/thefrontside/bigtest/runs/488061869) and the successful run [here](https://github.com/thefrontside/bigtest/runs/488192497) after the feature was implemented.