### PR TITLE
Generic mailbox

### DIFF
--- a/packages/agent/app/parent-frame.ts
+++ b/packages/agent/app/parent-frame.ts
@@ -1,10 +1,10 @@
 import { Operation } from 'effection';
-import { Mailbox, suspend } from '@bigtest/effection';
+import { Mailbox, suspend, subscribe } from '@bigtest/effection';
 
 export class ParentFrame {
   static *start() {
     let mailbox = new Mailbox();
-    yield suspend(mailbox.subscribe(window, ['message']));
+    yield suspend(subscribe(mailbox, window, ['message']));
     return new ParentFrame(mailbox);
   }
 

--- a/packages/agent/app/socket-connection.ts
+++ b/packages/agent/app/socket-connection.ts
@@ -1,12 +1,12 @@
 import { Operation } from 'effection';
-import { Mailbox, suspend } from '@bigtest/effection';
+import { Mailbox, suspend, subscribe } from '@bigtest/effection';
 
 export class SocketConnection {
   static *start(connectTo: string) {
     let socket = new WebSocket(connectTo);
     let mailbox = new Mailbox();
 
-    yield suspend(mailbox.subscribe(socket, ['open', 'message', 'close']));
+    yield suspend(subscribe(mailbox, socket, ['open', 'message', 'close']));
     yield mailbox.receive({ event: 'open' });
 
     return new SocketConnection(socket, mailbox);

--- a/packages/agent/app/test-frame.ts
+++ b/packages/agent/app/test-frame.ts
@@ -1,12 +1,12 @@
 import { Operation } from 'effection';
-import { Mailbox, suspend } from '@bigtest/effection';
+import { Mailbox, suspend, subscribe } from '@bigtest/effection';
 
 export class TestFrame {
   static *start() {
     let element = document.getElementById('test-frame') as HTMLIFrameElement;
 
     let mailbox = new Mailbox();
-    yield suspend(mailbox.subscribe(window, ['message']));
+    yield suspend(subscribe(mailbox, window, ['message']));
     return new TestFrame(element, mailbox);
   }
 

--- a/packages/agent/src/client.ts
+++ b/packages/agent/src/client.ts
@@ -5,7 +5,6 @@ import { promisify } from 'util';
 import {
   server as WebSocketServer,
   request as Request,
-  IMessage as Message
 } from 'websocket';
 
 import { Mailbox, once, suspend, ensure } from '@bigtest/effection';
@@ -63,10 +62,7 @@ function* acceptConnections(server: WebSocketServer, inbox: Mailbox, delegate: M
         }
       }
 
-      let messages = yield Mailbox.subscribe(connection, "message", ({ args }) => {
-        let [message] = args as Message[];
-        return JSON.parse(message.utf8Data);
-      })
+      let messages = yield Mailbox.subscribe(connection, "message");
 
       yield fork(function*() {
         while (true) {
@@ -77,7 +73,8 @@ function* acceptConnections(server: WebSocketServer, inbox: Mailbox, delegate: M
 
       yield fork(function*() {
         while (true) {
-          let message = yield messages.receive();
+          let { args } = yield messages.receive();
+          let message = JSON.parse(args[0].utf8Data);
           message.agentId = agentId;
           delegate.send(message);
         }

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -25,7 +25,8 @@
     "ts-node": "*"
   },
   "dependencies": {
-    "effection": "^0.5.2"
+    "@types/node": "^12.7.11",
+    "effection": "0.5.2"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/effection/src/index.ts
+++ b/packages/effection/src/index.ts
@@ -1,5 +1,5 @@
 export { once } from './events';
-export { Mailbox } from './mailbox';
+export { Mailbox, SubscriptionMessage, subscribe } from './mailbox';
 export { any } from './pattern';
 export { suspend } from './suspend';
 export { ensure } from './ensure';

--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -9,10 +9,11 @@ import { ensure } from './ensure';
 function isEventTarget(target): target is EventTarget { return typeof target.addEventListener === 'function'; }
 
 export interface SubscriptionMessage {
-  event: string,
-  args: unknown[],
+  event: string;
+  args: unknown[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class Mailbox<T = any> {
   private subscriptions = new EventEmitter();
   private messages = new Set<T>();
@@ -57,7 +58,7 @@ export class Mailbox<T = any> {
   }
 
   *pipe(other: Mailbox<T>) {
-    let that = this;
+    let that = this; // eslint-disable-line @typescript-eslint/no-this-alias
     yield suspend(monitor(function*() {
       while(true) {
         let message = yield that.receive();
@@ -67,7 +68,7 @@ export class Mailbox<T = any> {
   }
 
   *map<R>(fn: (from: T) => R): Operation<Mailbox<R>> {
-    let that = this;
+    let that = this; // eslint-disable-line @typescript-eslint/no-this-alias
     let other: Mailbox<R> = new Mailbox();
     yield suspend(monitor(function*() {
       while(true) {

--- a/packages/effection/test/mailbox.test.ts
+++ b/packages/effection/test/mailbox.test.ts
@@ -164,4 +164,57 @@ describe("Mailbox", () => {
       });
     });
   });
+
+  describe('piping a mailbox into another mailbox', () => {
+    let source: Mailbox;
+    let destination: Mailbox;
+
+    beforeEach(() => {
+      source = new Mailbox();
+      destination = new Mailbox();
+      spawn(function*() {
+        yield source.pipe(destination);
+        yield;
+      });
+    });
+
+    describe('forwards messages from the source mailbox to the destination', () => {
+      let message;
+
+      beforeEach(async () => {
+        source.send("hello");
+        message = await spawn(destination.receive());
+      });
+
+      it('receives message on destination', async () => {
+        expect(message).toEqual("hello");
+      });
+    });
+  });
+
+  describe('mapping over a mailbox', () => {
+    let source: Mailbox;
+    let destination: Mailbox;
+
+    beforeEach(() => {
+      source = new Mailbox();
+      spawn(function*() {
+        destination = yield source.map((message) => message.toUpperCase());
+        yield;
+      });
+    });
+
+    describe('applies mapping function to source mailbox', () => {
+      let message;
+
+      beforeEach(async () => {
+        source.send("hello");
+        message = await spawn(destination.receive());
+      });
+
+      it('receives message on destination', async () => {
+        expect(message).toEqual("HELLO");
+      });
+    });
+  });
 });

--- a/packages/effection/test/mailbox.test.ts
+++ b/packages/effection/test/mailbox.test.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from 'events';
 
 import { spawn } from './helpers';
 
-import { Mailbox } from '../src/mailbox';
+import { Mailbox, SubscriptionMessage, subscribe } from '../src/mailbox';
 import { FakeEventEmitter, FakeEvent } from './fake-event-target';
 
 describe("Mailbox", () => {
@@ -119,12 +119,12 @@ describe("Mailbox", () => {
 
   describe('subscribe to an EventEmitter', () => {
     let emitter: EventEmitter;
-    let mailbox: Mailbox;
+    let mailbox: Mailbox<SubscriptionMessage>;
 
     beforeEach(() => {
       emitter = new EventEmitter();
       mailbox = new Mailbox();
-      spawn(mailbox.subscribe(emitter, "thing"));
+      spawn(subscribe(mailbox, emitter, "thing"));
     });
 
     describe('emitting an event', () => {
@@ -142,13 +142,13 @@ describe("Mailbox", () => {
 
   describe('subscribing to an EventTarget', () => {
     let target: FakeEventEmitter;
-    let mailbox: Mailbox;
+    let mailbox: Mailbox<SubscriptionMessage>;
     let thingEvent: FakeEvent;
 
     beforeEach(() => {
       target = new FakeEventEmitter();
       mailbox = new Mailbox();
-      spawn(mailbox.subscribe(target, "thing"));
+      spawn(subscribe(mailbox, target, "thing"));
     });
 
     describe('emitting an event', () => {

--- a/packages/server/src/command-server/websocket.ts
+++ b/packages/server/src/command-server/websocket.ts
@@ -40,11 +40,12 @@ export function handleMessage(delegate: Mailbox, atom: Atom): (connection: Conne
   }
 
   return function*(connection) {
+    let messages: Mailbox = yield Mailbox.subscribe(connection, "message");
 
-    let messages: Mailbox = yield Mailbox.subscribe(connection, "message", ({args}) => {
+    messages = yield messages.map(({ args }) => {
       let [message] = args as IMessage[];
       return JSON.parse(message.utf8Data);
-    })
+    });
 
     while (true) {
       let message: Message = yield messages.receive();

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -20,10 +20,12 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
   function* handleConnection(connection: Connection): Operation {
     console.debug('[connection] connected');
 
-    let messages = yield Mailbox.subscribe(connection, "message", ({ args }) => {
+    let messages = yield Mailbox.subscribe(connection, "message")
+
+    messages = messages.map(({ args }) => {
       let [message] = args as IMessage[];
       return { message: JSON.parse(message.utf8Data) };
-    })
+    });
 
     let { message: { data } } = yield messages.receive({ message: { type: 'connected' } });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5834,7 +5834,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@^0.5.2:
+effection@0.5.2, effection@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/effection/-/effection-0.5.2.tgz#d312b525a345bc0d2600fb05352177ae2c208a39"
   integrity sha512-Po4umOI5uFIgWs2H8pKOxTr6XHxRsQwoVNGs3kvvE8JxtuTN6sQSM9TCM8AHWldVXR+q/8IgGjAWN7V2o59Mxw==


### PR DESCRIPTION
Make the Mailbox generic over the type of message, this allows us to have more typesafe mailboxes. For now we default this type to `any` so we don't need to specify the type yet, this keeps the diff more manageable.