### PR TITLE
Suggestion for headline improvement

### DIFF
--- a/packages/website/src/pages/index.tsx
+++ b/packages/website/src/pages/index.tsx
@@ -25,7 +25,7 @@ const IndexPage = () => (
           <H1>
             <Strong>Tests that speed up development,</Strong>
             <br />
-            not the other way around
+            not slow it down
           </H1>
           <Text fontSize="large">
             BigTest lets developers test their applications across browsers and devices and provides them with


### PR DESCRIPTION
## Motivation

*Not the other way around* really trips me up because I keep thinking that the other way around is development speeding up tests.

## Approach

Change it to read: `Tests that speed up development, not slow it down`. It does seem a little redundant.
