### PR TITLE
Actually typecheck agent code

### DIFF
--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -1,5 +1,5 @@
 import * as Bowser from 'bowser';
-import { Test } from './test';
+import { Test } from '@bigtest/suite';
 import { TestFrame } from './test-frame';
 import { SocketConnection } from './socket-connection';
 

--- a/packages/agent/app/create-harness.ts
+++ b/packages/agent/app/create-harness.ts
@@ -1,5 +1,7 @@
 import { ParentFrame } from './parent-frame';
-import { Test } from './test';
+import { TestImplementation } from '@bigtest/suite';
+
+declare const __bigtestManifest: TestImplementation;
 
 export function* createHarness() {
   console.log('[harness] starting');
@@ -12,7 +14,7 @@ export function* createHarness() {
     console.info('[harness] got message', message);
 
     if(message.type === 'run') {
-      let manifest = yield loadManifest(message.manifestUrl) as Test;
+      let manifest: TestImplementation = yield loadManifest(message.manifestUrl);
 
       yield runTest(parentFrame, manifest, message.path.slice(1))
     }
@@ -23,7 +25,7 @@ function serializeError({ message, fileName, lineNumber, columnNumber, stack }) 
   return { message, fileName, lineNumber, columnNumber, stack };
 }
 
-function *runTest(parentFrame: ParentFrame, test: Test, path: string[], prefix: string[] = []) {
+function *runTest(parentFrame: ParentFrame, test: TestImplementation, path: string[], prefix: string[] = []) {
   let currentPath = prefix.concat(test.description);
 
   console.debug('[harness] running test', currentPath);

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,7 +16,7 @@
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "start": "parcel serve --out-dir dist/app app/index.html app/harness.ts",
     "bundle": "parcel watch --out-dir dist/app app/index.html app/harness.ts",
-    "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap && parcel build --out-dir dist/app app/index.html app/harness.ts",
+    "prepack": "tsc --outdir dist --project tsconfig.dist.json --declaration --sourcemap && tsc --project tsconfig.app.json --noEmit && parcel build --out-dir dist/app app/index.html app/harness.ts",
     "manifest:build": "parcel build test/fixtures/manifest.src.js --out-dir test/fixtures --out-file manifest.js --global __bigtestManifest"
   },
   "devDependencies": {

--- a/packages/agent/tsconfig.app.json
+++ b/packages/agent/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  },
+  "include": [
+    "app/**/*.ts"
+  ]
+}


### PR DESCRIPTION
For some reason, parcel chooses to compile typescript, but never to actually typecheck the files it builds. To work around this, we run `tsc` manually during prepack so we actually run typechecks.

See:

https://github.com/parcel-bundler/parcel/issues/465