### PR TITLE
Use built assets as package contents

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,7 +2,8 @@
   "name": "@bigtest/server",
   "version": "0.1.0",
   "description": "BigTest Server",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "repository": "https://github.com/bigtestjs/server.git",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
@@ -15,8 +16,12 @@
     "test": "mocha ./test/setup test/**/*.test.ts",
     "mocha": "mocha ./test/setup",
     "test:app:start": "ts-node ./bin/todomvc.ts",
-    "prepack": "tsc --project tsconfig.dist.json --outdir dist --module commonjs --sourcemap"
+    "prepack": "tsc --project tsconfig.dist.json --outdir dist --module commonjs --sourcemap --declaration"
   },
+  "files": [
+    "README.md",
+    "dist/*"
+  ],
   "devDependencies": {
     "@bigtest/todomvc": "^0.1.0",
     "@effection/node": "^0.5.2",

--- a/packages/server/tsconfig.dist.json
+++ b/packages/server/tsconfig.dist.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["./test/*"]
+  "exclude": ["./test/*", "./bin/*"]
 }


### PR DESCRIPTION
Motivation
---------- 

Even using the prepack script, the server package does not include the compiled assets because they are not included in the files property of the package.json That means that the actual code is not shipped to NPM and you end up with `Error: Cannot find module './orchestrator'` when trying to start bigtest server.

As a result, trying to use this in a standalone project was failing: https://github.com/cowboyd/bigtest-example/blob/7367576e770bae3991ac8a859c671fa5281c5bf7/bin/test.js

Approach
----------

This explicitly distributes all of the files in `dist/` along with their typescript declarations with NPM package.