### PR TITLE
Add caching and running tests in parallel to the test workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,5 @@
+name: Lint
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,3 +1,5 @@
+name: Preview
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,25 +1,54 @@
+name: Test
+
 on:
   pull_request:
     branches:
       - master
 
 jobs:
-  build:
+  prepack-upload:
     runs-on: ubuntu-18.04
-    name: Tests
+    name: Prepack and Upload
     steps:
       - uses: actions/checkout@v1
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - uses: actions/cache@v1
         with:
-          node-version: '12.x'
+          path: /home/runner/.cache/yarn/v6
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn
+      - name: Run prepack
+        run: yarn prepack
+      - name: Tarball prepacked dist
+        run: tar czvf bigtest.dist.tgz ./packages/*/dist
+      - uses: actions/upload-artifact@v1
+        with:
+          name: bigtest.dist.tgz
+          path: bigtest.dist.tgz
+
+  download-test:
+    runs-on: ubuntu-18.04
+    name: ${{ matrix.package }}
+    needs: prepack-upload
+    strategy:
+      matrix:
+        package: [agent, cli, convergence, effection, interactor, logging, parcel, project, server, suite, todomvc]
+    steps:
+      - uses: actions/checkout@v1 
+      - uses: actions/cache@v1
+        with:
+          path: /home/runner/.cache/yarn/v6
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/download-artifact@v1
+        with:
+          name: bigtest.dist.tgz
+      - run: tar -xvf bigtest.dist.tgz/bigtest.dist.tgz
+      - run: pwd && cd packages/agent && ls
       - name: Install XVFB
         run: |
           sudo apt-get update
           sudo apt-get install xvfb
       - name: Install dependencies
         run: yarn
-      - name: Prepackage
-        run: yarn prepack
       - name: Run tests
-        run: xvfb-run --auto-servernum -- yarn test --browsers=ChromeHeadless
+        run: cd packages/${{ matrix.package }} && xvfb-run --auto-servernum -- yarn test --browsers=ChromeHeadless

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
         with:
           name: bigtest.dist.tgz
       - run: tar -xvf bigtest.dist.tgz/bigtest.dist.tgz
-      - run: pwd && cd packages/agent && ls
       - name: Install XVFB
         run: |
           sudo apt-get update
@@ -51,4 +50,4 @@ jobs:
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: cd packages/${{ matrix.package }} && xvfb-run --auto-servernum -- yarn test --browsers=ChromeHeadless
+        run: xvfb-run --auto-servernum -- yarn workspace @bigtest/${{ matrix.package }} test --browsers=ChromeHeadless


### PR DESCRIPTION
## Motivation
To resolve #119: Currently, BigTest's test workflow is running the test suites one after the other and making the whole process take very long. This pull request is to modify that workflow to run the test suites in parallel. 

And in the spirit of streamlining the testing workflow, this pull request will also resolve #201.

## Approach
```
name: Test

jobs:
  prepack-upload:
    cache
    yarn install
    yarn prepack
    tar packages/*/dist
    upload tar

  download-test:
    need: prepack-upload
    matrix: [ packages ]
      cache
      download tar && unzip
      yarn install
      cd packages/${{ matrix.package }}
      yarn test
```
- Split the workflow into two jobs (we need to `yarn install` in both jobs because we need it for both `prepack` and `test`):
  - The first job builds and uploads the `dist` directories as an artifact. 
  - The second job downloads that artifact and runs tests for all the individual packages in parallel.
- The workflow uses caching at the beginning of each job right after checkout. If the dependencies listed in `yarn.lock` are the same, it'll be able to load up the previous cache.
- I named all of the workflows (Test, Lint, Preview, Release) so that in the Github checks you'll see `Test / Prepack and Upload` as opposed to `./github/workflows/test / Prepack and Upload`; it'll be much easier on the eyes.