### PR TITLE
Optimize agent for orchestrator-controlled result collection

### DIFF
--- a/packages/agent/app/create-harness.ts
+++ b/packages/agent/app/create-harness.ts
@@ -15,12 +15,12 @@ export function* createHarness() {
 
     if(message.type === 'run') {
       let manifest: TestImplementation = yield loadManifest(message.manifestUrl);
-
+      let path = message.path.slice(1);
       try {
-        parentFrame.send({ type: 'lane:begin' });
-        yield runTest(parentFrame, manifest, message.path.slice(1))
+        parentFrame.send({ type: 'lane:begin', path });
+        yield runTest(parentFrame, manifest, path);
       } finally {
-        parentFrame.send({ type: 'lane:end' });
+        parentFrame.send({ type: 'lane:end', path });
       }
     }
   }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -125,7 +125,7 @@ describe("@bigtest/agent", function() {
           let appUrl = 'http://localhost:8002/app.html';
           inbox.send({ type: 'run', testRunId, agentId, manifestUrl, appUrl, tree: fixtureManifest });
 
-          await spawn(delegate.receive({ type: 'testRun:done', agentId, testRunId }));
+          await spawn(delegate.receive({ type: 'run:end', agentId, testRunId }));
 
           // we're receiving many more of these, but just checking some of them
           success = await spawn(delegate.receive({
@@ -145,7 +145,7 @@ describe("@bigtest/agent", function() {
 
         it('reports success and failure results', () => {
           expect(success.status).toEqual('ok');
-          expect(failure.status).toEqual('failure');
+          expect(failure.status).toEqual('failed');
           expect(failure.error.message).toEqual('boom');
         });
       });


### PR DESCRIPTION
Motivation
----------

When we began to implement the result collection for tests in the orchestrator, the most optimal way to do it was to immediately create a tree of "result listeners" for each test, step and result in the entire hiearchy. Because of this, events like 'test:running' are purely informational, and events like 'test:done' are completely unecessary.

Approach
----------
This PR removes `test:done` entirely, and separates out the `run:begin` and `run:end` to fire a `lane:begin` and `lane:end` event from the harness. These are purely informational and not needed except for perhaps some debugging purposes.