### PR TITLE
Report test results through the GraphQL API.

### DIFF
--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -32,7 +32,7 @@ export class Client {
     }));
   }
 
-  static *create(url: string): Operation {
+  static *create(url: string): Operation<Client> {
     let client = new Client(new WebSocket(url), yield parent);
 
     yield once(client.subscriptions, 'open');

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -1,6 +1,7 @@
-import { fork, Operation } from 'effection';
+import { fork, monitor, Operation } from 'effection';
 import { Mailbox } from '@bigtest/effection';
-import { Atom } from './orchestrator/atom';
+import { Test, TestResult, StepResult, AssertionResult, ResultStatus } from '@bigtest/suite';
+import { Atom, Slice} from './orchestrator/atom';
 import { TestRunState } from './orchestrator/state';
 
 interface CommandProcessorOptions {
@@ -11,10 +12,10 @@ interface CommandProcessorOptions {
   manifestPort: number;
 };
 
-function* run(id: string, options: CommandProcessorOptions): Operation {
-  console.debug('[command processor] running test', id);
+function* run(testRunId: string, options: CommandProcessorOptions): Operation {
+  console.debug('[command processor] running test', testRunId);
 
-  let testRunSlice = options.atom.slice<TestRunState>(['testRuns', id]);
+  let testRunSlice = options.atom.slice<TestRunState>(['testRuns', testRunId]);
   let [agent] = Object.values(options.atom.get().agents);
   let manifest = options.atom.get().manifest;
 
@@ -23,21 +24,134 @@ function* run(id: string, options: CommandProcessorOptions): Operation {
 
   if(agent) {
     // todo: we should perform filtering of the manifest here
-    testRunSlice.set({ status: 'pending', tree: manifest, agent });
+    testRunSlice.set({ testRunId: testRunId, status: 'pending', tree: resultsFor(manifest), agent });
 
-    console.debug(`[command processor] starting test run ${id} on agent ${agent.identifier}`);
-    options.delegate.send({ type: 'run', status: 'pending', agentId: agent.identifier, appUrl, manifestUrl, testRunId: id, tree: manifest });
+    console.debug(`[command processor] starting test run ${testRunId} on agent ${agent.agentId}`);
+
+    options.delegate.send({ type: 'run', status: 'pending', agentId: agent.agentId, appUrl, manifestUrl, testRunId: testRunId, tree: manifest });
+
+    let status = testRunSlice.slice<'running'|'done'>(['status']);
+
+    status.set('running');
+    try {
+
+      let result = testRunSlice.slice<TestResult>(['tree']);
+
+      yield runTest(result, [result.get().description]);
+
+    } finally {
+      status.set('done');
+    }
   }
+
+  function* runTest(result: Slice<TestResult>, path: string[]) {
+    let status = result.slice<ResultStatus>(['status']);
+
+    yield monitor(function* () {
+      yield options.inbox.receive({ type: 'test:running', testRunId, path });
+      status.set('running');
+    })
+
+    try {
+
+      yield collectTestResult(result, path);
+
+      status.set('ok');
+
+    } catch (error) {
+      status.set('failed');
+    } finally {
+      if (status.get() === 'pending' || status.get() === 'running') {
+        status.set('disregarded');
+      }
+    }
+  }
+
+  function* collectTestResult(result: Slice<TestResult>, path: string[]) {
+
+    for (let [index, child] of result.get().children.entries()) {
+      yield fork(runTest(result.slice<TestResult>(['children', index]), path.concat(child.description)));
+    }
+
+    for (let [index, assertion] of result.get().assertions.entries()) {
+      yield fork(collectAssertionResult(result.slice<AssertionResult>(['assertions', index]), path.concat(assertion.description)));
+    }
+
+    for (let [index, step] of result.get().steps.entries()) {
+      yield fork(collectStepResult(result.slice<StepResult>(['steps', index]), path.concat(step.description)));
+    }
+  }
+
+  function* collectStepResult(result: Slice<StepResult>, path: string[]) {
+    let status = result.slice<ResultStatus>(['status']);
+
+    yield monitor(function* () {
+      yield options.inbox.receive({ type: 'step:running', testRunId, path });
+      status.set('running');
+    })
+
+    try {
+
+      let update: {status: ResultStatus} = yield options.inbox.receive({ type: 'step:result', testRunId, path });
+
+      if (update.status === 'failed') {
+        status.set('failed');
+        throw new Error('Step Failed');
+      }
+
+      status.set(update.status);
+    } finally {
+      if (status.get() === 'pending' || status.get() === 'running') {
+        status.set('disregarded');
+      }
+    }
+  }
+
+  function* collectAssertionResult(result: Slice<AssertionResult>, path: string[]) {
+    let status = result.slice<ResultStatus>(['status']);
+
+    try {
+      yield options.inbox.receive({ type: 'assertion:running', testRunId, path });
+
+      status.set('running');
+
+      let update: {status: ResultStatus} = yield options.inbox.receive({ type: 'assertion:result', testRunId, path });
+
+      status.set(update.status);
+    } finally {
+      if (status.get() === 'pending' || status.get() === 'running') {
+        status.set('disregarded');
+      }
+    }
+  }
+
 }
+
+
 
 export function* createCommandProcessor(options: CommandProcessorOptions): Operation {
   while(true) {
-    let message = yield options.inbox.receive();
+    let message = yield options.inbox.receive({ type: 'run' });
 
     console.debug('[command processor] received message', message);
 
-    if(message.type === 'run') {
-      yield fork(run(message.id, options));
-    }
+    yield fork(run(message.id, options));
+  }
+}
+
+
+function resultsFor(tree: Test): TestResult {
+  return {
+    description: tree.description,
+    status: 'pending',
+    steps: tree.steps.map(step => ({
+      description: step.description,
+      status: 'pending'
+    })),
+    assertions: tree.assertions.map(assertion => ({
+      description: assertion.description,
+      status: 'pending'
+    })),
+    children: tree.children.map(resultsFor)
   }
 }

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -64,6 +64,7 @@ export function graphqlOptions(delegate: Mailbox, state: OrchestratorState) {
       echo: ({text}) => text,
       agents: () => Object.values(state.agents),
       manifest: state.manifest,
+      testRuns: Object.values(state.testRuns),
       run: () => {
         let id = `test-run-${testIdCounter++}`;
         delegate.send({ type: "run", id });

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -152,12 +152,16 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
 
   options.delegate.send({ status: 'ready' });
 
+  let commandProcessorInbox = new Mailbox();
+  yield connectionServerDelegate.pipe(commandProcessorInbox);
+  yield commandServerDelegate.pipe(commandProcessorInbox);
+
   try {
     yield createCommandProcessor({
       proxyPort: options.proxyPort,
       manifestPort: options.manifestPort,
       atom: options.atom,
-      inbox: commandServerDelegate, // note that this is intentionally inverted
+      inbox: commandProcessorInbox,
       delegate: connectionServerInbox,
     });
   } finally {

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -1,7 +1,7 @@
-import { Test } from '@bigtest/suite';
+import { Test, TestResult } from '@bigtest/suite';
 
 export type AgentState = {
-  identifier: string;
+  agentId: string;
   browser: {
     name: string;
     version: string;
@@ -22,8 +22,9 @@ export type AgentState = {
 }
 
 export type TestRunState = {
-  status: "pending";
-  tree: Test;
+  testRunId: string;
+  status: "pending" | "running" | "done";
+  tree: TestResult;
   agent: AgentState;
 }
 

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -7,6 +7,7 @@ type Query {
   echo(text: String!): String
   agents: [Agent!]!
   manifest: Test!
+  testRuns: [TestRun!]!
 }
 
 type Mutation {
@@ -14,7 +15,7 @@ type Mutation {
 }
 
 type Agent {
-  identifier: String!
+  agentId: String!
   browser: Browser!
   os: OS!
   platform: Platform!
@@ -56,5 +57,40 @@ type Step {
 
 type Assertion {
   description: String!
+}
+
+type TestRun {
+  testRunId: TestRunId!
+  status: String!
+  agent: Agent!
+  tree: TestResult!
+}
+
+type TestResult {
+  description: String!
+  status: String!
+  steps: [StepResult!]!
+  assertions: [AssertionResult!]!
+  children: [TestResult!]!
+}
+
+type StepResult {
+  description: String!
+  status: String!
+  error: Error
+}
+
+type AssertionResult {
+  description: String!
+  status: String!
+  error: Error
+}
+
+type Error {
+  message: String!
+  fileName: String!
+  lineNumber: Int!
+  columnNumber: Int!
+  stack: String!
 }
 `);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -42,7 +42,7 @@ export function* listenWS(server: Server, handler: ConnectionHandler): Operation
       let handle = yield fork(function* setupConnection() {
         let halt = () => handle.halt();
         let fail = (error: Error) => {
-          if(error["code"] === 'ECONNRESET') {
+          if(error["code"] === 'ECONNRESET' || error["code"] === 'ERR_STREAM_WRITE_AFTER_END') {
             handle.halt();
           } else {
             handle.fail(error);

--- a/packages/server/test/.eslintrc.json
+++ b/packages/server/test/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@frontside",
+  "rules": {
+    "@typescript-eslint/no-explicit-any": 0
+  }
+}

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -19,7 +19,7 @@ describe('command server', () => {
     inbox = new Mailbox();
     atom = new Atom();
     atom.slice<AgentState>(['agents', 'agent-1']).set({
-      identifier: 'agent-1',
+      agentId: 'agent-1',
       browser: { name: "Safari", version: "13.0.4" },
       os: { name: "macOS", version: "10.15.2", versionName: "Catalina" },
       platform: { type: "desktop", vendor: "Apple" },
@@ -70,7 +70,7 @@ describe('command server', () => {
 
     it('adds agent and test tree to manifest', () => {
       let testRun = atom.slice<TestRunState>(['testRuns', 'test-id-1']).get();
-      expect(testRun.agent.identifier).toEqual('agent-1');
+      expect(testRun.agent.agentId).toEqual('agent-1');
       expect(testRun.tree.description).toEqual('the manifest');
     });
   });

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -67,7 +67,7 @@ describe('command server', () => {
     beforeEach(async () => {
       agents.set({
         safari: {
-          "identifier": "agent.1",
+          "agentId": "agent.1",
           "browser": {
             "name": "Safari",
             "version": "13.0.4"
@@ -210,7 +210,7 @@ describe('command server', () => {
         sync = done;
         agents.set({
           safari: {
-            "identifier": "agent.1",
+            "agentId": "agent.1",
             "browser": {
               "name": "Safari",
               "version": "13.0.4"

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -1,22 +1,34 @@
 import { Response, RequestInfo, RequestInit } from 'node-fetch';
 import { Context, Operation } from 'effection';
 import { Mailbox } from '@bigtest/effection';
-import { World } from './helpers/world';
-
 import { beforeEach, afterEach } from 'mocha';
+import { w3cwebsocket } from 'websocket';
+import { Agent } from '@bigtest/agent';
+
+import { World } from './helpers/world';
 
 import { createOrchestrator } from '../src/index';
 import { Atom } from '../src/orchestrator/atom';
+import { Manifest } from '../src/orchestrator/state';
+import { Client } from '../src/client';
+
+import { Subscription } from './helpers/subscription';
+export { Subscription } from './helpers/subscription';
 
 interface Actions {
   atom: Atom;
-  fork(operation: Operation): Context;
+  fork<Result>(operation: Operation<Result>): Context<Result>;
   receive(mailbox: Mailbox, pattern: unknown): PromiseLike<unknown>;
   fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response>;
+  query(source: string, until?: (data: any) => boolean): PromiseLike<any>;
+  subscribe<Shape>(source: string, extract: (result: unknown) => Shape): PromiseLike<Subscription<Shape>>;
+  createAgent(): PromiseLike<Agent>;
+  createClient(): PromiseLike<Client>;
   startOrchestrator(): PromiseLike<Context>;
 }
 
 let orchestratorPromise: Context;
+let manifest: Manifest;
 
 export const actions: Actions = {
   atom: new Atom(),
@@ -33,7 +45,43 @@ export const actions: Actions = {
     return actions.fork(currentWorld.fetch(resource, init));
   },
 
-  startOrchestrator() {
+  async query(source: string, until: (data: any) => boolean = () => true) {
+    let client = await this.createClient();
+
+    return actions.fork(function*() {
+      while (true) {
+        let data = yield client.query(source);
+        if (until(data)) {
+          return data;
+        }
+      }
+    });
+  },
+
+  async subscribe<Shape>(source: string, extract: (result: unknown) => Shape = x => x as Shape) {
+    let client = await this.createClient();
+    return actions.fork(Subscription.create(client, source, extract));
+  },
+
+  async createClient(): Promise<Client> {
+    if (!this.client) {
+      this.client = await actions.fork(Client.create(`http://localhost:24102`));
+      currentWorld.ensure(() => delete this.client);
+    }
+    return this.client;
+  },
+
+  async createAgent() {
+    // the types are broken in the 'websocket' package.... the `w3cwebsocket` class
+    // _is_ in fact an EventTarget, but it is not declared as such. So we have
+    // to dynamically cast it.
+    type W3CWebSocket = w3cwebsocket & EventTarget;
+    let socket = new w3cwebsocket(`http://localhost:24103`) as W3CWebSocket;
+
+    return actions.fork(Agent.start(socket));
+  },
+
+  async startOrchestrator() {
     if(!orchestratorPromise) {
       let delegate = new Mailbox();
 
@@ -54,7 +102,10 @@ export const actions: Actions = {
 
       orchestratorPromise = this.receive(delegate, { status: 'ready' });
     }
-    return orchestratorPromise;
+    return orchestratorPromise.then(cxt => {
+      manifest = actions.atom.get().manifest;
+      return cxt;
+    });
   }
 }
 
@@ -66,6 +117,9 @@ after(async function() {
 });
 
 beforeEach(() => {
+  //reset all the state in the global atom, except for the manifest
+  actions.atom.reset(initial => ({ ...initial, manifest }));
+
   currentWorld = new World();
 });
 

--- a/packages/server/test/helpers/subscription.ts
+++ b/packages/server/test/helpers/subscription.ts
@@ -1,0 +1,49 @@
+import { EventEmitter } from 'events';
+import { monitor, Operation } from 'effection';
+import { suspend, Mailbox, once } from '@bigtest/effection';
+import { Client } from '../../src/client';
+
+/**
+ * A helper class for testing subscriptions
+ */
+export class Subscription<Shape = any> {
+  listeners = new EventEmitter();
+  frames: Shape[] = [];
+
+  get latest() { return this.frames[this.frames.length - 1]; }
+
+  static *create<Shape>(client: Client, query: string, extract: (result: unknown) => Shape): Operation<Subscription<Shape>> {
+    let subscription = new Subscription();
+    yield suspend(monitor(client.subscribe(query, function*(response) {
+      let frame = extract(response)
+      subscription.frames.push(frame);
+      subscription.listeners.emit("frame", frame);
+    })));
+    return subscription;
+  }
+
+  /**
+   * get the _very_ next frame of the subscription. Useful to ensure that sending
+   * a message has an immediate effect on the next state, but not useful if an event
+   * could trigger multiple state changes
+   */
+  *next(): Operation<Shape> {
+    let [frame]: [Shape] = yield once(this.listeners, "frame");
+    return frame;
+  }
+
+  *until(predicate: (frame: Shape) => boolean): Operation<Shape> {
+    if (this.latest && predicate(this.latest)) {
+      return this.latest;
+    }
+
+    let mailbox = yield Mailbox.subscribe(this.listeners, "frame");
+
+    while (true) {
+      let { args: [frame] } = yield mailbox.receive();
+      if (predicate(frame)) {
+        return frame;
+      }
+    }
+  }
+}

--- a/packages/server/test/helpers/world.ts
+++ b/packages/server/test/helpers/world.ts
@@ -12,6 +12,10 @@ export class World {
     this.execution.halt();
   }
 
+  ensure(hook: () => void) {
+    this.execution['ensure'](hook);
+  }
+
   fork(operation: Operation): Context {
     return this.execution['spawn'](operation);
   }

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -1,0 +1,148 @@
+import * as expect from 'expect';
+import { Agent, Command } from '@bigtest/agent';
+import { TestResult } from '@bigtest/suite';
+import { actions, Subscription } from './helpers';
+
+describe('running tests on an agent', () => {
+  let agent: Agent;
+
+  beforeEach(async () => {
+    await actions.startOrchestrator();
+    agent = await actions.createAgent();
+
+    agent.send({
+      type: 'connected',
+      data: {
+        platform: {
+          type: 'tests',
+          vendor: 'Frontside'
+        }
+      }
+    });
+
+    await actions.query(`{ agents { agentId } }`, ({ agents }: any) => agents.length > 0);
+  });
+
+  describe('with the fixture tree', () => {
+    let subscription: Subscription<TestRun>;
+    let runCommand: Command;
+    beforeEach(async () => {
+      await actions.query(`mutation { run }`);
+    });
+
+    beforeEach(async () => {
+      runCommand = await actions.fork(agent.receive());
+    });
+
+    beforeEach(async () => {
+      subscription = await actions.subscribe(`
+fragment results on TestResult {
+  description
+  status
+  steps {
+    description
+    status
+  }
+  assertions {
+    description
+    status
+  }
+}
+
+{
+  testRuns {
+    testRunId
+    status
+    tree {
+      ...results
+      children {
+        ...results
+        children {
+          ...results
+        }
+      }
+    }
+  }
+}
+`, data => (data as any).testRuns.find((r: TestRun) => r.testRunId === runCommand.testRunId));
+    });
+
+    it('receives a run event on the agent', () => {
+      expect(runCommand.type).toEqual('run');
+      expect(runCommand.appUrl).toEqual(`http://localhost:24101`);
+      expect(runCommand.tree.description).toEqual('All tests');
+    });
+
+    describe('when the agent reports that it is running', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'run:begin',
+          testRunId: runCommand.testRunId
+        });
+      });
+
+      it('is marks the run as running', async () => {
+        await actions.fork(subscription.until(run => run.status === 'running'));
+      });
+    });
+
+    describe('when a test is reported as running', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'test:running',
+          testRunId: runCommand.testRunId,
+          path: ['All tests']
+        });
+      });
+
+      it('marks that particular test as running', async () => {
+        await actions.fork(subscription.until(run => run.tree.status === 'running'));
+      });
+    });
+
+    describe('when a step fails', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'step:result',
+          status: 'failed',
+          testRunId: runCommand.testRunId,
+          path: ['All tests', "Signing In", "when I fill in the login form"],
+          error: {
+            message: "this step failed",
+            fileName: 'here.js',
+            lineNumber: 5,
+            columnNumber: 10,
+            stack: ['here.js', 'there.js']
+          }
+        })
+      });
+
+      it('marks that step as failed', async () => {
+        await actions.fork(subscription.until(run => {
+          return run.tree.children
+            .find(child => child.description === "Signing In" ).steps
+            .find(child => child.description === "when I fill in the login form").status === 'failed';
+        }))
+      });
+
+      it('disregards the remaining steps, and remaining children', async() => {
+        await actions.fork(subscription.until(run => {
+          let tree = run.tree.children
+            .find(child => child.description === "Signing In" )
+
+          let { assertions, children } = tree;
+
+          return assertions.every(assertion => assertion.status === 'disregarded')
+            && children.every(child => child.status === 'disregarded');
+
+        }));
+      });
+    });
+  });
+});
+
+interface TestRun {
+  testRunId: string;
+  status: 'pending' | 'running' | 'done';
+  tree: TestResult;
+}


### PR DESCRIPTION
> depends on #223 #224 

Motivation
----------

While the agent supports running tests and streaming results back to the server, we don't currently have a way to interface with those results via the GraphQL API. In our planned scenario, you will issue a `run` mutation and then subscribe to the results of that run.

Approach
----------

Whenever a run command is issued to the command processor, we fork an _entire effection tree_ corresponding to the test hierarchy. This allows us to set up a process to track _each_ result, be it step, test, or assertion. If a step fails, we throw an exception which causes every subsequent step and assertion to be disregarded.

Screenshots
------------

![2020-04-03 12 33 57](https://user-images.githubusercontent.com/4205/78389007-994a6800-75a7-11ea-95ef-16ffd51da8c7.gif)

