### PR TITLE
🐛Never miss an atom state

### DIFF
--- a/packages/server/src/command-server/websocket.ts
+++ b/packages/server/src/command-server/websocket.ts
@@ -32,11 +32,7 @@ export function handleMessage(delegate: Mailbox, atom: Atom): (connection: Conne
   }
 
   function* subscribe(message: QueryMessage, connection: Connection) {
-    while (true) {
-      let state: OrchestratorState = yield atom.next();
-
-      yield publishQueryResult(message, state, connection);
-    }
+    yield atom.each(state => publishQueryResult(message, state, connection));
   }
 
   return function*(connection) {
@@ -58,4 +54,3 @@ export function handleMessage(delegate: Mailbox, atom: Atom): (connection: Conne
     }
   }
 }
-

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -1,8 +1,8 @@
 import * as R from 'ramda';
 
 import { EventEmitter } from 'events';
-import { Operation, timeout } from 'effection';
-import { once, Mailbox } from '@bigtest/effection';
+import { Operation } from 'effection';
+import { Mailbox } from '@bigtest/effection';
 
 import { OrchestratorState } from './state';
 


### PR DESCRIPTION
Motivation
----------

When runing tests, we noticed that the publication of query results was actually missing results. Meaning that the atom was getting update correctly, and if we queried it in the GraphQL interface after the complete test run, the state was correct, but the individual subscription results were not all there. The problem was that because `atom.update` is synchronous it was immediately resuming contexts that were yielded to `atom.next()`, but then dispatching the next state before those contexts could start listening to the new state. As a result, states that were being streamed with `atom.next` were getting dropped on the floor. We need a way to publish _every_ subscription result

Approach
--------

For now, we need to keep `atom.set()` synchronous since we don't have the capability to execute operations inside of a `finally {}` block. Instead, what we can do is "buffer" each change inside of a mailbox, and then drain that mailbox whenever the next tick of the run loop happens.

This lends itself to a cleaner interface anyhow since we don't need to explicitly loop, and instead pass the loop operation to an `each` function.