### PR TITLE
Symmetric setup and teardown of Agent WebSocket

### DIFF
--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -11,7 +11,9 @@ export function* createAgent(connectTo: string) {
   console.log('[agent] connecting to', connectTo);
 
   let testFrame = yield TestFrame.start();
-  let agent: Agent = yield Agent.start(new WebSocket(connectTo));
+
+  let createSocket = () => new WebSocket(connectTo);
+  let agent: Agent = yield Agent.start(createSocket);
 
   agent.send({
     type: 'connected',

--- a/packages/agent/shared/agent.ts
+++ b/packages/agent/shared/agent.ts
@@ -7,9 +7,10 @@ export * from './protocol';
 export class Agent implements AgentProtocol {
   constructor(private socket: Socket, private mailbox: Mailbox) {}
 
-  static *start(socket: Socket): Operation<Agent> {
+  static *start(createSocket: () => Socket): Operation<Agent> {
     let mailbox = new Mailbox();
 
+    let socket = createSocket();
     let res = yield resource(new Agent(socket, mailbox), function*() {
       yield subscribe(mailbox, socket, 'message');
       yield ensure(() => socket.close());

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -76,9 +76,9 @@ export const actions: Actions = {
     // _is_ in fact an EventTarget, but it is not declared as such. So we have
     // to dynamically cast it.
     type W3CWebSocket = w3cwebsocket & EventTarget;
-    let socket = new w3cwebsocket(`http://localhost:24103`) as W3CWebSocket;
+    let createSocket = () => new w3cwebsocket(`http://localhost:24103`) as W3CWebSocket;
 
-    return actions.fork(Agent.start(socket));
+    return actions.fork(Agent.start(createSocket));
   },
 
   async startOrchestrator() {


### PR DESCRIPTION
Motivation
----------

As [noted in the pull request that introduced the agent][1], the agent takes responsibility for closing a websocket that was passed into it which is error prone, and likely not composable. Genenally, resources should be setup and torn down by the same locality.

Approach
--------

There were really two options available to us that align ownership of the socket: Either we push the responsibility of destroying of the socket into the outer context, or pull the responsibility for constructing the socket inside the agent context.

If we went with the first option, then it would transfer the burden of maintaining the socket resource to the enclosing scope. In practice, that means needing to have an extra `try/catch/finally` block around the code spanning the lifecycle of the agent. Thus:

```typescript
let socket = new WebSocket(url);
let agent: Agent = yield Agent.start(socket);

while (true) {
  let command = yield agent.receive();
  yield handleCommand(command);
}
```

becomes:

```typescript
let socket = new WebSocket(url);
try {
  let agent: Agent = yield Agent.start(socket);

  while (true) {
    let command = yield agent.receive();
    yield handleCommand(command);
  }
} finally {
  socket.close()
}
```

And if you forget to wrap the agent in that construct every time, then you might leak the socket. 👎🏼

The other option is to pass the means to create the socket to agent, which allows the agent to construct the socket when it needs to, and then tear it down also when it needs to. The previous codeblock then becomes:

```typescript
let createSocket = () => new WebSocket(url);

let agent: Agent = yield Agent.start(createSocket);
while (true) {
  let command = yield agent.receive();
  yield handleCommand(command);
}
```

Not only is this less intrusive, it is in keeping with the direction of the project which is to protect the setup and teardown of persistent contexts that are passed around as resources.

This PR just makes the agent.start method accept a socket factory instead of a socket.

[1]: https://github.com/thefrontside/bigtest/pull/224#issuecomment-609890667