### PR TITLE
Suppress warning for non-accessible link

### DIFF
--- a/packages/todomvc/app/src/components/Footer.js
+++ b/packages/todomvc/app/src/components/Footer.js
@@ -34,6 +34,7 @@ export default class Footer extends Component {
     const {filter: selectedFilter, onShow} = this.props
 
     return (
+      //eslint-disable-next-line jsx-a11y/anchor-is-valid
       <a
         className={classnames({ selected: filter === selectedFilter })}
         style={{cursor: 'pointer' }}


### PR DESCRIPTION
Motivation
----------

The vendored TodoMVC app has the following linting warning:

```
./src/components/Footer.js
  Line 38:7:  The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
```

This hasn't been a problem up until now, but suddenly builds started failing for packages in CI because it looks like linting errors are now [magically being treated as errors][1]. This is because github actions were not setting the `CI=true` environment variable, and now they are, which triggers [this dubious behavior in Create React App][2].

Approach
--------

I tried actually fixing the `jsx-ally` warning, but that caused a bunch of cascading weirdness that actually broke the app. Absent a quick-fix, this opts to just disable the rule for that line, since this is a 3rd party app and we want its source code to diverge as little as possible from the upstream. If it is ever fixed there, we can bring that change in.

[1]: https://github.com/thefrontside/bigtest/pull/226/checks?check_run_id=571828791#step:5:17
[2]: https://github.com/facebook/create-react-app/issues/3657