### PR TITLE
Update release workflow to push git tags for individual packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - mk/tags-test
+      - master
 
 jobs:
   publish-releases:
@@ -12,8 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      # uses: thefrontside/actions/synchronize-with-npm@v1.4
-      uses: thefrontside/actions/synchronize-with-npm@mk/tags
+      uses: thefrontside/actions/synchronize-with-npm@v1.5
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - mk/tags-test
 
 jobs:
   publish-releases:
@@ -12,7 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.4
+      # uses: thefrontside/actions/synchronize-with-npm@v1.4
+      uses: thefrontside/actions/synchronize-with-npm@mk/tags
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/todomvc",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Quickly run Todo MVC apps from different frameworks",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Motivation
From [@thefrontside/actions PR #56](https://github.com/thefrontside/actions/pull/56): Need a way to push tags for individual packages within a monorepo (like bigtest) when a pull request gets merged to the master branch.

## Approach
- What I didn't mention in the pull request I linked above is if someone forgets to bump the version in package.json of the package they worked on, the action will skip the publishing process and still allow the rest of the workflow to continue.
  - You can see that [here](https://github.com/thefrontside/bigtest/runs/593032699?check_suite_focus=true).
  - This means we never have to worry about accidentally pushing the same tag twice (which would result in an error) unless someone manually pushes tags onto the repository.
- [Example](https://github.com/thefrontside/bigtest/runs/592488800?check_suite_focus=true) of this action... in action. And the result:

![79471507-baac4a80-7fd0-11ea-92bf-e1d7fead986c](https://user-images.githubusercontent.com/29791650/79496712-86e31c00-7ff4-11ea-82a9-81247533bc9f.png)

## Notes
- To test run the new v1.5 of `synchronize-with-npm` action, I had it publish and push tags of `@bigtest/todomvc-v0.1.1` which is why this pull request has the todomvc's modified `package.json` file. That's a done deal. Can't go back.