### PR TITLE
Convert `yarn subscribe` utility to use new client API

### DIFF
--- a/packages/server/bin/subscribe.ts
+++ b/packages/server/bin/subscribe.ts
@@ -6,8 +6,11 @@ main(function* main() {
 
   let [ source ]  = process.argv.slice(2);
 
-  yield client.subscribe(source, function*(data) {
+  let subscription = yield client.subscribe(source);
+
+  while (true) {
+    let data = yield subscription.receive();
     console.log('==== new subscription result ==== ');
     console.log(JSON.stringify(data, null, 2));
-  });
-})
+  }
+});


### PR DESCRIPTION
Motivation
-----------

In order to make working with client subscriptions more friendly to actual clients, [`Client.subscribe` was converted to external iteration][1]. However, the `bin/subscribe.ts` utility was not updated to the new API, which is now [breaking newer builds][2]

Approach
----------

Update the `bin/subscribe` utility to use the new api.

> Note: we did not catch this before because subscribe.ts was not in the tsconfig, and so we were only catching it at runtime when compiling with ts-node. It's debatable whether this should be in the distribution (probably not) but at least we're getting a failure when something breaks about it.

[1]: https://github.com/thefrontside/bigtest/pull/230
[2]: https://github.com/thefrontside/bigtest/pull/236/checks?check_run_id=595782649#step:5:90