### PR TITLE
Use invite from our branded bot instead of from Taras.

### DIFF
--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -62,7 +62,7 @@ const Header = () => (
       >
         Github
       </IconLink>
-      <IconLink icon={discordIconSVG} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
+      <IconLink icon={discordIconSVG} href="https://discord.gg/RR6wfCr" title="Discord community" target="_blank">
         Discord
       </IconLink>
       <LegacyLink href="http://v1.bigtestjs.io/">v1.x Docs &#8594;</LegacyLink>

--- a/packages/website/src/components/ReachOut.tsx
+++ b/packages/website/src/components/ReachOut.tsx
@@ -29,7 +29,7 @@ const ReachOut: React.FC = () => {
       <ReachLink icon={emailIconSVG} href="mailto:bigtest@frontside.com" title="Email Us" target="_blank">
         bigtest@frontside.com
       </ReachLink>
-      <ReachLink icon={discordIconSVG} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
+      <ReachLink icon={discordIconSVG} href="https://discord.gg/RR6wfCr" title="Discord community" target="_blank">
         Join our Discord!
       </ReachLink>
     </>


### PR DESCRIPTION
Motivation
----------

As handsome and pleasant to look at as @taras is, his face is not branded with Frontside. So until he decides to go "all in" and get our logo as a face-tat, let's use a branded gatekeeper to our community that says "welcome to a frontside community, you're in the right place. Also, those willing to create a robotic butler to open the door are pretty awesome". 😉 

Approach
--------

This updates the discord invites with invites issued from the bot.

Screenshots
-------------

#### Before

<img width="805" alt="A Discord Invite showing Taras's personal avatar" src="https://user-images.githubusercontent.com/4205/79604775-5367c680-80b4-11ea-9d43-66c9b10e7d4d.png">

#### After
<img width="743" alt="A Discord Invite showing the illustration of the Frontside branded Bot" src="https://user-images.githubusercontent.com/4205/79604798-5cf12e80-80b4-11ea-8cf2-69a01416bc5c.png">

