### PR TITLE
Unifying typescript configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "packages/parcel",
       "packages/todomvc",
       "packages/suite",
-      "packages/*"
+      "packages/*",
+      "packages/tsconfig"
     ],
     "nohoist": [
       "@bigtest/server/@types/node"

--- a/packages/agent/app/parent-frame.ts
+++ b/packages/agent/app/parent-frame.ts
@@ -10,7 +10,7 @@ export class ParentFrame {
 
   constructor(private mailbox: Mailbox) {}
 
-  send(message) {
+  send(message: unknown) {
     window.parent.postMessage(JSON.stringify(message), "*");
   }
 

--- a/packages/agent/app/query-params.ts
+++ b/packages/agent/app/query-params.ts
@@ -1,9 +1,9 @@
-function parseQueryParams(params) {
+function parseQueryParams(params: string) {
   return params
     .replace(/^\?/, "")
     .split("&")
     .map((line) => line.split("=", 2).map(decodeURIComponent))
-    .reduce((agg, [key, value]) => {
+    .reduce<{[key: string]: string}>((agg, [key, value]) => {
       agg[key] = value
       return agg
     }, {});

--- a/packages/agent/app/test-frame.ts
+++ b/packages/agent/app/test-frame.ts
@@ -12,7 +12,7 @@ export class TestFrame {
 
   constructor(private element: HTMLIFrameElement, private mailbox: Mailbox) {}
 
-  load(url): Operation {
+  load(url: string): Operation {
     return ({ resume, ensure }) => {
       this.element.src = url;
       this.element.addEventListener('load', resume);
@@ -20,8 +20,10 @@ export class TestFrame {
     }
   }
 
-  send(message) {
-    this.element.contentWindow.postMessage(message, '*');
+  send(message: unknown) {
+    if (this.element.contentWindow) {
+      this.element.contentWindow.postMessage(message, '*');
+    }
   }
 
   *receive(): Operation {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -16,12 +16,12 @@
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register",
     "start": "parcel serve --out-dir dist/app app/index.html app/harness.ts",
-    "bundle": "parcel watch --out-dir dist/app app/index.html app/harness.ts",
-    "prepack": "tsc --outdir dist --declaration --sourcemap && tsc --project tsconfig.app.json --noEmit && parcel build --no-minify --out-dir dist/app app/index.html app/harness.ts",
+    "prepack": "tsc --outdir dist --declaration --sourcemap && parcel build --no-minify --out-dir dist/app app/index.html app/harness.ts",
     "manifest:build": "parcel build test/fixtures/manifest.src.js --out-dir test/fixtures --out-file manifest.js --global __bigtestManifest"
   },
   "devDependencies": {
     "@bigtest/webdriver": "^0.1.0",
+    "@frontside/tsconfig": "*",
     "@types/express": "^4.17.2",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
@@ -36,7 +36,8 @@
     "parcel-bundler": "^1.12.4",
     "regenerator-runtime": "^0.13.3",
     "ts-node": "*",
-    "typescript": "^3.7.0"
+    "typescript": "^3.7.0",
+    "@bigtest/suite": "0.1.0"
   },
   "peerDependencies": {
     "effection": "^0.6.2"

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -6,47 +6,47 @@ export interface AgentProtocol {
   receive(): Operation<Command>;
 }
 
-interface Connect {
+export interface Connect {
   type: 'connected';
   agentId?: string;
   data: unknown;
 }
 
-interface RunBegin {
+export interface RunBegin {
   type: 'run:begin';
   testRunId: string;
 }
 
-interface RunEnd {
+export interface RunEnd {
   type: 'run:end';
   testRunId: string;
 }
 
-interface LaneBegin {
+export interface LaneBegin {
   type: 'lane:begin';
   testRunId: string;
   path: string[];
 }
 
-interface LaneEnd {
+export interface LaneEnd {
   type: 'lane:end';
   testRunId: string;
   path: string[];
 }
 
-interface TestRunning {
+export interface TestRunning {
   type: 'test:running';
   testRunId: string;
   path: string[];
 }
 
-interface StepRunning {
+export interface StepRunning {
   type: 'step:running';
   testRunId: string;
   path: string[];
 }
 
-interface StepResult {
+export interface StepResult {
   type: 'step:result';
   status: ResultStatus;
   testRunId: string;
@@ -54,13 +54,13 @@ interface StepResult {
   error?: ErrorDetails;
 }
 
-interface AssertionRunning {
+export interface AssertionRunning {
   type: 'assertion:running';
   testRunId: string;
   path: string[];
 }
 
-interface AssertionResult {
+export interface AssertionResult {
   type: 'assertion:result';
   status: ResultStatus;
   testRunId: string;

--- a/packages/agent/src/client.ts
+++ b/packages/agent/src/client.ts
@@ -43,14 +43,14 @@ let ids = 1;
 function* acceptConnections(server: WebSocketServer, inbox: Mailbox, delegate: Mailbox): Operation {
   while (true) {
     let [request]: [Request] = yield once(server, "request");
-    let connection = request.accept(null, request.origin);
-    let sendData = promisify<string, void>(connection.send.bind(connection));
+    let connection = request.accept(undefined, request.origin);
+    let sendData = promisify<string>(connection.send.bind(connection));
     let agentId = `agent.${ids++}`;
 
     let handler = yield fork(function* setupConnection() {
       let halt = () => handler.halt();
-      let fail = (error: Error) => {
-        if(error["code"] === 'ECONNRESET') {
+      let fail = (error: NodeJS.ErrnoException) => {
+        if(error.code === 'ECONNRESET') {
           handler.halt();
         } else {
           handler.fail(error);

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -58,7 +58,7 @@ class HttpAgentServer extends AgentServer {
     return ({ resume, ensure }) => {
       if (this.http) {
         this.http.on('close', resume);
-        ensure(() => this.http.off('close', resume));
+        ensure(() => this.http && this.http.off('close', resume));
       } else {
         throw new Error('cannot join a server that is not already listening');
       }
@@ -69,8 +69,9 @@ class HttpAgentServer extends AgentServer {
 
 function listen(app: xp.Express, port?: number): Operation {
   return ({ resume, fail }) => {
-    let server = app.listen(port, (err) => {
-      if (err) {
+    let server = app.listen(port, (...args: unknown[]) => {
+      let [err] = args;
+      if (err instanceof Error) {
         fail(err);
       } else {
         resume(server);

--- a/packages/agent/test/fixtures/manifest.src.d.ts
+++ b/packages/agent/test/fixtures/manifest.src.d.ts
@@ -1,0 +1,3 @@
+import { TestImplementation } from '@bigtest/suite';
+
+export declare const test: TestImplementation;

--- a/packages/agent/test/helpers.ts
+++ b/packages/agent/test/helpers.ts
@@ -1,0 +1,17 @@
+import { Context, Operation, main } from 'effection';
+
+type World = Context & { spawn<T>(operation: Operation<T>): Promise<T> };
+
+let currentWorld: World;
+
+beforeEach(() => {
+  currentWorld = main(undefined) as World;
+});
+
+afterEach(() => {
+  currentWorld.halt();
+});
+
+export function spawn<T>(operation: Operation<T>): Promise<T> {
+  return currentWorld.spawn(operation);
+}

--- a/packages/agent/tsconfig.app.json
+++ b/packages/agent/tsconfig.app.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "lib": ["esnext", "dom"]
-  },
-  "include": [
-    "app/**/*.ts"
-  ]
-}

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -1,16 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
+    "app/**/*.ts",
     "shared/**/*.ts",
-    "src/**/*.ts"
-  ]
+    "src/**/*.ts",
+  ],
+  "compilerOptions": {
+    "target": "esnext"
+  }
 }

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -17,6 +17,7 @@
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "@types/ramda": "types/npm-ramda#dist",

--- a/packages/atom/src/slice.ts
+++ b/packages/atom/src/slice.ts
@@ -53,11 +53,11 @@ export class Slice<T, S> {
       let [property] = this.path.slice(-1);
       this.atom.update((state) => {
         return (set(
-          parentLens,
-          dissoc(property, parent),
+          parentLens, 
+          dissoc(property, parent as object),
           state
         ) as unknown) as S;
-      });
+      }); 
     }
   }
 }

--- a/packages/atom/tsconfig.json
+++ b/packages/atom/tsconfig.json
@@ -1,14 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts",
     "bin/*.ts"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,6 +21,8 @@
     "bigtest": "./bin/bigtest"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
+    "@types/capture-console": "1.0.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "@types/yargs": "^15.0.3",

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,4 +1,4 @@
-import { main, Context, Operation } from 'effection';
+import { main, Context, Operation, Controls } from 'effection';
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
 import * as process from 'process'
@@ -6,16 +6,18 @@ import * as capcon from 'capture-console'
 
 import { CLI } from '../src/cli';
 
+type World<T> = Context<T> & Controls<T>;
+
 describe("@bigtest/cli", () => {
   let stdout: string;
-  let World: Context;
-  async function spawn<T>(operation: Operation<T>): Promise<T> {
-    return World["spawn"](operation);
+  let World: World<unknown>;
+  async function spawn<T>(operation: Operation): Promise<T> {
+    return World.spawn(operation);
   }
 
   async function capture(operation: Operation): Promise<string> {
     let result = "";
-    capcon.startIntercept(process.stdout, (output) => result += output);
+    capcon.startCapture(process.stdout, (output: string) => result += output);
     await spawn(operation);
     capcon.stopIntercept(process.stdout);
     return result;
@@ -23,7 +25,7 @@ describe("@bigtest/cli", () => {
 
 
   beforeEach(async () => {
-    World = main(undefined);
+    World = main(undefined) as World<unknown>;
   });
 
   afterEach(() => {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,14 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": ".",
-    "skipLibCheck": true
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/*.ts"
   ]

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -18,6 +18,7 @@
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "effection": "^0.6.2",

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -1,6 +1,6 @@
 import { Operation, resource } from 'effection';
 import * as actualExpress from 'express';
-import { Express as ActualExpress } from 'express';
+import { Express as ActualExpress, RequestHandler } from 'express';
 import { Server } from 'http';
 
 import { throwOnErrorEvent, once } from '@effection/events';
@@ -8,14 +8,14 @@ import { ensure } from '@bigtest/effection';
 
 export class Express {
   private inner: ActualExpress;
-  private server: Server;
+  private server?: Server;
 
-  constructor(inner) {
+  constructor(inner: ActualExpress) {
     this.inner = inner;
   }
 
-  use(middleware) {
-    this.inner.use(middleware);
+  use(...handlers: RequestHandler[]) {
+    this.inner.use(...handlers);
   }
 
   *listen(port: number): Operation<Server> {

--- a/packages/effection-express/tsconfig.json
+++ b/packages/effection-express/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts",
     "bin/*.ts"

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -15,9 +15,10 @@
     "lint": "eslint '{src,test}/**/*.ts'",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register",
-    "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
+    "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "effection": "^0.6.0",

--- a/packages/effection/src/deferred.ts
+++ b/packages/effection/src/deferred.ts
@@ -1,0 +1,21 @@
+export function Deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => { return };
+  let reject: (error: Error) => void = () => {return };
+
+  let promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  }) ;
+
+  return {
+    resolve,
+    reject,
+    promise
+  }
+}
+
+export interface Deferred<T> {
+  resolve(value: T): void;
+  reject(error: Error): void;
+  promise: Promise<T>;
+}

--- a/packages/effection/src/index.ts
+++ b/packages/effection/src/index.ts
@@ -1,3 +1,4 @@
+export { Deferred } from './deferred';
 export { Mailbox, SubscriptionMessage, subscribe } from './mailbox';
 export { any } from './pattern';
 export { ensure } from './ensure';

--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -59,7 +59,7 @@ export class Mailbox<T = any> {
 
   *pipe(other: Mailbox<T>) {
     let that = this; // eslint-disable-line @typescript-eslint/no-this-alias
-    return yield spawn(function*() {
+    return yield spawn(function*(): Operation<unknown> {
       while(true) {
         let message = yield that.receive();
         other.send(message);
@@ -85,7 +85,7 @@ export function *subscribe(
   events: string | string[],
 ): Operation {
   return yield spawn(function*() {
-    for (let name of [].concat(events)) {
+    for (let name of typeof events === 'string' ? [events] : events) {
       yield fork(function*() {
         let events = yield on(source, name);
         while(true) {

--- a/packages/effection/src/pattern.ts
+++ b/packages/effection/src/pattern.ts
@@ -5,7 +5,7 @@ export function compile(pattern: unknown): (target: unknown) => boolean {
     } else if(Array.isArray(pattern)) {
       return Array.isArray(target) && pattern.every((value, index) => compile(value)(target[index]));
     } else if(typeof(pattern) === "object") {
-      return typeof(target) === 'object' && Object.entries(pattern).every(([key, value]) => compile(value)(target[key]));
+      return typeof(target) === 'object' && pattern !== null && Object.entries(pattern).every(([key, value]) => compile(value)(target && (target as Record<string, unknown>)[key]));
     } else if(typeof(pattern) === "function") {
       return pattern(target);
     } else {

--- a/packages/effection/test/ensure.test.ts
+++ b/packages/effection/test/ensure.test.ts
@@ -38,7 +38,7 @@ describe("ensure()", () => {
   });
 
   describe('with successful context', () => {
-    let result;
+    let result: number;
 
     beforeEach(async () => {
       result = await spawn(function*() {
@@ -54,7 +54,7 @@ describe("ensure()", () => {
   });
 
   describe('with failed context', () => {
-    let error;
+    let error: Error;
 
     beforeEach(async () => {
       try {

--- a/packages/effection/test/fake-event-target.ts
+++ b/packages/effection/test/fake-event-target.ts
@@ -23,10 +23,10 @@ export class FakeEvent implements Event {
   }
 
   composedPath(): EventTarget[] { return [] }
-  initEvent(): void { return null; }
-  preventDefault(): void { return null; }
-  stopImmediatePropagation(): void { return null; }
-  stopPropagation(): void { return null; }
+  initEvent(): void { return; }
+  preventDefault(): void { return; }
+  stopImmediatePropagation(): void { return; }
+  stopPropagation(): void { return; }
 
   readonly AT_TARGET: number = 0;
   readonly BUBBLING_PHASE: number = 1;
@@ -38,12 +38,12 @@ export class FakeEvent implements Event {
 export class FakeEventEmitter implements EventTarget {
   private emitter = new EventEmitter();
 
-  addEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
-    this.emitter.on(type, listener as (...args) => void);
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    this.emitter.on(type, listener as (...args: unknown[]) => void);
   }
 
-  removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null): void {
-    this.emitter.off(type, listener as (...args) => void);
+  removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+    this.emitter.off(type, listener as (...args: unknown[]) => void);
   }
 
   dispatchEvent(event: Event): boolean {

--- a/packages/effection/test/helpers.ts
+++ b/packages/effection/test/helpers.ts
@@ -1,27 +1,16 @@
-import { main, Context, Operation } from 'effection';
+import { main, Context, Operation, Controls } from 'effection';
 
-class World {
-  static current: World;
+type World<T = unknown> = Context<T> & Controls<T>;
 
-  context: Context = main(undefined);
-
-  spawn<T>(operation: Operation): Context & PromiseLike<T>{
-    return this.context['spawn'](operation);
-  }
-
-  halt() {
-    this.context.halt();
-  }
-}
-
-export function spawn<T>(operation: Operation): Context & PromiseLike<T> {
-  return World.current.spawn(operation);
+let World: World;
+export function spawn<T>(operation: Operation) {
+  return World.spawn<T>(operation);
 }
 
 beforeEach(() => {
-  World.current = new World();
+  World = main(undefined) as World<unknown>;
 });
 
 afterEach(() => {
-  World.current.halt();
-})
+  World.halt();
+});

--- a/packages/effection/test/mailbox.test.ts
+++ b/packages/effection/test/mailbox.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
 
-import { Context } from 'effection';
+import { Context, Operation } from 'effection';
 import { EventEmitter } from 'events';
 
 import { spawn } from './helpers';
@@ -178,14 +178,14 @@ describe("Mailbox", () => {
     beforeEach(() => {
       source = new Mailbox();
       destination = new Mailbox();
-      spawn(function*() {
+      spawn(function*(): Operation<void> {
         yield source.pipe(destination);
         yield;
       });
     });
 
     describe('forwards messages from the source mailbox to the destination', () => {
-      let message;
+      let message: string;
 
       beforeEach(async () => {
         source.send("hello");
@@ -211,7 +211,7 @@ describe("Mailbox", () => {
     });
 
     describe('applies mapping function to source mailbox', () => {
-      let message;
+      let message: string;
 
       beforeEach(async () => {
         source.send("hello");

--- a/packages/effection/tsconfig.json
+++ b/packages/effection/tsconfig.json
@@ -1,16 +1,10 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "skipLibCheck": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts",
     "bin/*.ts"
+  ],
+  "exclude": [
+    "../../node_modules"
   ]
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^13.13.4",
+    "@frontside/tsconfig": "*",
     "ts-node": "*"
   },
   "volta": {

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,3 +1,5 @@
+export type Levels = "debug" | "info" | "warn" | "error";
+
 const HIDDEN_LOGS = {
   debug: [],
   info: ["debug"],
@@ -14,10 +16,10 @@ export function resetLogLevel() {
   console.error = error
 }
 
-export function setLogLevel(level) {
+export function setLogLevel(level: Levels) {
   resetLogLevel();
   HIDDEN_LOGS[level].forEach((level) => {
-    console[level] = function() {
+    console[level as Levels] = function() {
       // do nothing
     }
   });

--- a/packages/logging/tsconfig.json
+++ b/packages/logging/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts",
     "bin/*.ts"

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -32,6 +32,7 @@
     "yarn": "1.19.1"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/node": "^13.13.4",
     "@types/parcel-bundler": "^1.12.1",
     "effection": "^0.6.2",

--- a/packages/parcel/src/parcel-process.ts
+++ b/packages/parcel/src/parcel-process.ts
@@ -24,7 +24,7 @@ export class ParcelProcess {
     let stdioMode = options.stdio || 'pipe';
     let parcelProcess = new ParcelProcess();
 
-    let entries = [].concat(options.sourceEntries);
+    let entries = typeof options.sourceEntries === 'string' ? [options.sourceEntries] : options.sourceEntries;
     let runParcel = Path.join(__dirname, 'parcel-run');
     let child: ChildProcess = forkProcess(
       runParcel,
@@ -39,7 +39,7 @@ export class ParcelProcess {
 
     let readiness = new Mailbox();
 
-    let res = yield resource(parcelProcess, function* supervise() {
+    let res = yield resource(parcelProcess, function* supervise(): Operation<void> {
       // Killing all child processes started by this command is surprisingly
       // tricky. If a process spawns another processes and we kill the parent,
       // then the child process is NOT automatically killed. Instead we're using
@@ -60,7 +60,7 @@ export class ParcelProcess {
         readiness.send("ready");
 
         // deliver "update" messages to the main parcel process object
-        yield monitor(function* () {
+        yield monitor(function* (): Operation<void> {
           while (true) {
             let message = yield messages.receive();
             parcelProcess.mailbox.send(message);

--- a/packages/parcel/src/parcel-server.ts
+++ b/packages/parcel/src/parcel-server.ts
@@ -36,7 +36,9 @@ export function* createParcelServer(entryPoints: string[], options: ParcelServer
     while(true) {
       yield events.receive({ event: "buildEnd" });
 
-      process.send({ type: "update" });
+      if (process.send) {
+        process.send({ type: "update" });
+      }
     }
   } finally {
     bundler.stop();

--- a/packages/parcel/tsconfig.json
+++ b/packages/parcel/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "bin/**/*.ts",
     "src/**/*.ts"

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -17,6 +17,7 @@
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "effection": "^0.6.2",

--- a/packages/project/tsconfig.json
+++ b/packages/project/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts",
     "bin/*.ts"

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -2,11 +2,11 @@ import { fork } from 'effection';
 import { main } from '@effection/node';
 import { Mailbox } from '@bigtest/effection';
 import * as tempy from 'tempy';
-import { setLogLevel } from '@bigtest/logging';
+import { setLogLevel, Levels } from '@bigtest/logging';
 
 import { createOrchestrator, createOrchestratorAtom } from '../src/index';
 
-setLogLevel(process.env.LOG_LEVEL || 'info');
+setLogLevel(process.env.LOG_LEVEL as Levels || 'info');
 
 main(function*() {
   let delegate = new Mailbox();

--- a/packages/server/bin/todomvc.ts
+++ b/packages/server/bin/todomvc.ts
@@ -13,7 +13,7 @@ main(function* start() {
   yield app.join();
 });
 
-function findPort(): number | undefined {
+function findPort(): number {
   let [,, second ] = process.argv;
   if (second) {
     return parseInt(second);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,7 +16,7 @@
     "mocha": "mocha ./test/setup",
     "test:app:start": "ts-node ./bin/todomvc.ts",
     "generate:schema": "BIGTEST_GENERATE_SCHEMA=true ts-node ./src/schema.ts",
-    "prepack": "yarn generate:schema && tsc --outdir dist --module commonjs --sourcemap --declaration"
+    "prepack": "yarn generate:schema && tsc --outdir dist"
   },
   "files": [
     "README.md",
@@ -24,6 +24,7 @@
   ],
   "devDependencies": {
     "@bigtest/todomvc": "^0.1.0",
+    "@frontside/tsconfig": "*",
     "@effection/node": "^0.6.1",
     "@types/express": "^4.17.3",
     "@types/graphql": "^14.5.0",
@@ -31,6 +32,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^13.13.4",
     "@types/node-fetch": "^2.5.3",
+    "@types/rimraf": "3.0.0",
     "@types/websocket": "^1.0.0",
     "abort-controller": "^3.0.0",
     "effection": "^0.6.2",
@@ -59,7 +61,7 @@
     "chokidar": "^3.3.1",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
-    "fprint": "^1.0.0",
+    "fprint": "^2.0.1",
     "glob": "^7.1.6",
     "graphql": "^14.5.8",
     "http-proxy": "^1.18.0",

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -19,7 +19,7 @@ export class Client {
     let client = new Client(socket);
     let res = yield resource(client, function*() {
       yield ensure(() => socket.close());
-      yield spawn(function* () {
+      yield spawn(function* (): Operation<void> {
         let [event] = yield once(socket, 'close');
         if(event.code !== 1000) {
           throw new Error(`Socket closed on the remote end: [${event.code}] ${event.reason}`);
@@ -42,7 +42,7 @@ export class Client {
     let mailbox = new Mailbox();
     let { socket } = this;
 
-    return yield resource(mailbox, function*() {
+    return yield resource(mailbox, function*(): Operation<void> {
       let messages = yield on(socket, "message");
 
       let responseId = `${responseIds++}`; //we'd want a UUID to avoid hijacking?

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -59,7 +59,7 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
 
   runStatus.set('ok');
 
-  function* runTest(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]) {
+  function* runTest(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<void> {
     let testStatus = result.slice<ResultStatus>(['status']);
 
     yield monitor(function* () {
@@ -82,7 +82,7 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
     }
   }
 
-  function* collectTestResult(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]) {
+  function* collectTestResult(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<void> {
     for (let [index, child] of result.get().children.entries()) {
       yield fork(runTest(agentId, result.slice<TestResult>(['children', index]), path.concat(child.description)));
     }

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -53,7 +53,7 @@ let testRunIds = (function * () {
  * because the express graphql server calls the `graphql` function for
  * you based on the .
  */
-export function graphqlOptions(delegate: Mailbox, state: OrchestratorState): graphqlHTTP.OptionsData {
+export function graphqlOptions(delegate: Mailbox, state: OrchestratorState) {
   return {
     schema,
     rootValue: state,

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -28,7 +28,11 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
 
     messages = yield messages.map(({ args }) => {
       let [message] = args as IMessage[];
-      return JSON.parse(message.utf8Data);
+      if (message.utf8Data) {
+        return JSON.parse(message.utf8Data)
+      } else {
+        return {};
+      }
     });
 
     let { data, agentId } = yield messages.receive({ type: 'connected' });

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -2,10 +2,10 @@ import { Operation } from 'effection';
 import { Mailbox } from '@bigtest/effection';
 import { ParcelProcess } from '@bigtest/parcel';
 import { Atom } from '@bigtest/atom';
+import { createFingerprint } from 'fprint';
 
 import * as path from 'path';
 import * as fs from 'fs';
-import * as fprint from 'fprint';
 
 import { Test } from '@bigtest/suite';
 
@@ -23,7 +23,7 @@ interface ManifestBuilderOptions {
 
 function* processManifest(options: ManifestBuilderOptions): Operation {
   let buildDir = path.resolve(options.buildDir, 'manifest.js');
-  let fingerprint = yield fprint(buildDir, 'sha256');
+  let fingerprint = yield createFingerprint(buildDir, 'sha256');
   let fileName = `manifest-${fingerprint}.js`;
   let distPath = path.resolve(options.distDir, fileName);
 

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -1,5 +1,9 @@
 export interface Message {
   responseId?: string;
+  query?: string;
+  mutation?: string;
+  data?: unknown;
+  errors?: Array<{ message: string }>;
 }
 
 export interface QueryMessage extends Message {

--- a/packages/server/src/util.ts
+++ b/packages/server/src/util.ts
@@ -8,7 +8,7 @@ import { Operation } from 'effection';
 export function resumeOnCb(fn: (cb: (error?: Error) => void) => void): Operation {
   return (execution) => {
     let iCare = true;
-    fn((error: Error) => {
+    fn((error?: Error) => {
       if (iCare) {
         if (error) {
           execution.fail(error);

--- a/packages/server/src/ws.ts
+++ b/packages/server/src/ws.ts
@@ -37,11 +37,11 @@ export function* listenWS(server: Server, handler: ConnectionHandler): Operation
   try {
     while (true) {
       let [request]: [Request] = yield once(socket, "request");
-      let connection = request.accept(null, request.origin);
+      let connection = request.accept(undefined, request.origin);
 
       let handle = yield fork(function* setupConnection() {
         let halt = () => handle.halt();
-        let fail = (error: Error) => {
+        let fail = (error: NodeJS.ErrnoException) => {
           if(error["code"] === 'ECONNRESET' || error["code"] === 'ERR_STREAM_WRITE_AFTER_END') {
             handle.halt();
           } else {

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -40,29 +40,29 @@ describe('command server', () => {
     });
 
     it('contains an empty list', () => {
-      expect(result).toEqual({ "data": { "agents": [] } });
+      expect(result).toEqual({ 'data': { 'agents': [] } });
     });
   });
 
   describe('running the entire suite', () => {
-    let result: unknown;
+    let result: GraphQLPayload<{run: {}}>;
     beforeEach(async () => {
       result = await mutation('run');
     });
 
     it('returns a test run id', () => {
-      expect(result['data'].run).toMatch('TestRun');
+      expect(result.data.run).toMatch('TestRun');
     });
 
     it('sends a message to the orchestrator telling it to start the test run', async () => {
       let message = await actions.receive(delegate, { type: "run" });
       expect(message['type']).toEqual("run")
-      expect(message['id']).toEqual(result['data'].run)
+      expect(message['id']).toEqual(result.data.run)
     });
   });
 
   describe('querying connected agents', () => {
-    let result: unknown;
+    let result: GraphQLPayload;
     beforeEach(async () => {
       agents.set({
         safari: {
@@ -103,7 +103,7 @@ describe('command server', () => {
     });
 
     describe('over websockets', () => {
-      let wsResult: unknown;
+      let wsResult: GraphQLPayload;
       beforeEach(async () => {
         wsResult = await websocketQuery('{agents { browser { name } os { name } platform { type }}}');
       });
@@ -242,12 +242,16 @@ describe('command server', () => {
   });
 });
 
-async function query(text: string): Promise<unknown> {
+interface GraphQLPayload<T = unknown> {
+  data: T;
+}
+
+async function query<T>(text: string): Promise<GraphQLPayload<T>> {
   let response = await actions.fetch(`http://localhost:${COMMAND_PORT}?query={${encodeURIComponent(text)}}`);
   return await response.json();
 }
 
-async function mutation(text: string): Promise<unknown> {
+async function mutation<T>(text: string): Promise<GraphQLPayload<T>> {
   let body = `mutation { ${text} }`
   let response = await actions.fetch(`http://localhost:${COMMAND_PORT}`, {
     method: "POST",

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -4,34 +4,25 @@ import { Mailbox } from '@bigtest/effection';
 import { beforeEach, afterEach } from 'mocha';
 import { w3cwebsocket } from 'websocket';
 import { Agent } from '@bigtest/agent';
-import { Atom } from '@bigtest/atom';
+// import { Atom } from '@bigtest/atom';
 
 import { World } from './helpers/world';
 
 import { createOrchestrator } from '../src/index';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
-import { Manifest, OrchestratorState } from '../src/orchestrator/state';
-
-interface Actions {
-  atom: Atom<OrchestratorState>;
-  fork<Result>(operation: Operation<Result>): Context<Result>;
-  receive(mailbox: Mailbox, pattern: unknown): PromiseLike<unknown>;
-  fetch(resource: RequestInfo, init?: RequestInit): PromiseLike<Response>;
-  createAgent(): PromiseLike<Agent>;
-  startOrchestrator(): PromiseLike<Context>;
-}
+import { Manifest } from '../src/orchestrator/state';
 
 let orchestratorPromise: Context;
 let manifest: Manifest;
 
-export const actions: Actions = {
+export const actions = {
   atom: createOrchestratorAtom(),
 
   fork(operation: Operation): Context {
     return currentWorld.fork(operation);
   },
 
-  receive(mailbox: Mailbox, pattern): PromiseLike<unknown> {
+  receive(mailbox: Mailbox, pattern: unknown) {
     return actions.fork(mailbox.receive(pattern));
   },
 

--- a/packages/server/test/helpers/world.ts
+++ b/packages/server/test/helpers/world.ts
@@ -1,11 +1,11 @@
-import { main, Context, Operation } from 'effection';
+import { main, Context, Operation, Controls } from 'effection';
 import fetch, { Response, RequestInfo, RequestInit } from 'node-fetch';
 import { AbortController } from 'abort-controller';
 
 export class World {
-  execution: Context;
+  execution: Context & Controls;
   constructor() {
-    this.execution = main(function*() { yield; });
+    this.execution = main(function*() { yield; }) as Context & Controls;
   }
 
   destroy() {
@@ -13,11 +13,11 @@ export class World {
   }
 
   ensure(hook: () => void) {
-    this.execution['ensure'](hook);
+    this.execution.ensure(hook);
   }
 
   fork(operation: Operation): Context {
-    return this.execution['spawn'](operation);
+    return this.execution.spawn(operation);
   }
 
   fetch(resource: RequestInfo, init: RequestInit = {}): Promise<Response> {

--- a/packages/server/test/manifest-generator.test.ts
+++ b/packages/server/test/manifest-generator.test.ts
@@ -23,7 +23,7 @@ async function loadManifest() {
 }
 
 describe('manifest-generator', () => {
-  let delegate;
+  let delegate: Mailbox;
 
   beforeEach((done) => rmrf(TEST_DIR, done));
   beforeEach(async () => {

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -1,14 +1,7 @@
 {
+  "extends": "@frontside/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "module": "commonjs",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types",
-      "./typings"
-    ],
-    "baseUrl": "."
+    "typeRoots" : ["./node_modules/@types", "./typings"]
   },
   "include": [
     "src/**/*.ts",

--- a/packages/server/typings/trumpet/index.d.ts
+++ b/packages/server/typings/trumpet/index.d.ts
@@ -1,0 +1,142 @@
+/**
+ * @source: https://github.com/coolreader18/palooza/blob/master/src/types.d.ts#L16
+ */
+declare module "trumpet" {
+  import { Duplex } from "stream";
+
+  namespace Trumpet {
+    export interface Attributes {
+      [name: string]: string;
+    }
+
+    export interface AsyncElement {
+      /**
+       * The element name as a lower-case string.
+       * @example 'div'
+       */
+      name: string;
+
+      /**
+       * When the selector for elem matches, query the case-insensitive
+       * attribute called name with `cb(value)`.
+       * @returns itself.
+       */
+      getAttribute(name: string, cb: (value: string) => void): AsyncElement;
+
+      /**
+       * Get all the attributes in `cb(attributes)` as an object `attributes` with
+       * lower-case keys
+       * @returns itself;
+       */
+      getAttributes(cb: (attrs: Attributes) => void): AsyncElement;
+
+      /**
+       * When the selector for elem matches, replace the case-insensitive
+       * attribute called name with value. If the attribute doesn't exist,
+       * it will be created in the output stream.
+       * @returns itself.
+       */
+      setAttribute(name: string, value: string): AsyncElement;
+
+      /**
+       * When the selector for elem matches, remove the attribute called name if
+       * it exists.
+       * @returns itself.
+       */
+      removeAttribute(name: string): AsyncElement;
+
+      /**
+       * Create a new readable stream with the html content under `elem`.
+       */
+      createReadStream(): NodeJS.ReadableStream;
+
+      /**
+       * Create a new write stream to replace the html content under `elem`.
+       */
+      createWriteStream(): NodeJS.WritableStream;
+
+      /**
+       * Create a new readable writable stream that outputs the content under
+       * `elem` and replaces the content with the data written to it.
+       */
+      createStream(): NodeJS.ReadWriteStream;
+    }
+
+    export interface Element {
+      /**
+       * The element name as a lower-case string.
+       * @example 'div'
+       */
+      name: string;
+
+      /**
+       * Get the value of the attribute `name` as a string.
+       */
+      getAttribute(name: string, cb?: (value: string) => void): string;
+
+      /**
+       * Get all the attributes as an object `attributes` with lower-case keys
+       */
+      getAttributes(cb?: (attrs: Attributes) => void): Attributes;
+
+      /**
+       * Replace the case-insensitive attribute called name with value. If the
+       * attribute doesn't exist, it will be created in the output stream.
+       */
+      setAttribute(name: string, value: string): void;
+
+      /**
+       * Remove the attribute called name if it exists.
+       */
+      removeAttribute(name: string): void;
+
+      /**
+       * Create a new readable stream with the html content under `elem`.
+       */
+      createReadStream(): NodeJS.ReadableStream;
+
+      /**
+       * Create a new write stream to replace the html content under `elem`.
+       */
+      createWriteStream(): NodeJS.WritableStream;
+
+      /**
+       * Create a new readable writable stream that outputs the content under
+       * `elem` and replaces the content with the data written to it.
+       */
+      createStream(): NodeJS.ReadWriteStream;
+    }
+  }
+
+  import AsyncElement = Trumpet.AsyncElement;
+  import Element = Trumpet.Element;
+
+  class Trumpet extends Duplex {
+    /**
+     * Return a result object `elem` for the first element matching `selector`.
+     */
+    select(selector: string, cb?: (elem: Element) => void): AsyncElement;
+
+    /**
+     * Get a result object `elem` for every element matching `selector`.
+     */
+    selectAll(selector: string, cb?: (elem: Element) => void): AsyncElement;
+
+    /**
+     * Short-hand for `tr.select(sel).createStream(opts)`.
+     */
+    createStream(selector: string): NodeJS.ReadWriteStream;
+
+    /**
+     * Short-hand for `tr.select(sel).createReadStream(opts)`.
+     */
+    createReadStream(selector: string): NodeJS.ReadableStream;
+
+    /**
+     * Short-hand for `tr.select(sel).createWriteStream(opts)`.
+     */
+    createWriteStream(selector: string): NodeJS.WritableStream;
+  }
+
+  export = Trumpet;
+}

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -16,6 +16,9 @@
     "test": "echo success",
     "prepack": "tsc --outDir dist --declaration"
   },
+  "devDependencies": {
+    "@frontside/tsconfig": "*"
+  },
   "volta": {
     "node": "12.16.0",
     "yarn": "1.19.1"

--- a/packages/suite/tsconfig.json
+++ b/packages/suite/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "index.ts"
   ]

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -22,6 +22,7 @@
     "bigtest-todomvc": "dist/start.js"
   },
   "devDependencies": {
+    "@frontside/tsconfig": "*",
     "@types/express": "^4.17.2",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",

--- a/packages/todomvc/src/start.ts
+++ b/packages/todomvc/src/start.ts
@@ -15,7 +15,7 @@ main(function* start() {
   yield app.join();
 });
 
-function findPort(): number | undefined {
+function findPort(): number {
   let [,, second ] = process.argv;
   if (second) {
     return parseInt(second);

--- a/packages/todomvc/test/todomvc-react.test.ts
+++ b/packages/todomvc/test/todomvc-react.test.ts
@@ -1,18 +1,20 @@
-import { main, Operation, Context } from 'effection';
+import { main, Operation, Context, Controls } from 'effection';
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
 import fetch, { Response } from 'node-fetch';
 import { todomvc } from '../dist/index';
 
+type World<T> = Context<T> & Controls<T>;
+
 describe("@bigtest/todomvc", () => {
 
-  let World: Context;
+  let World: World<unknown>;
   async function spawn<T>(operation: Operation): Promise<T> {
-    return World["spawn"](operation);
+    return World.spawn(operation);
   }
 
   beforeEach(() => {
-    World = main(undefined);
+    World = main(undefined) as World<unknown>;
   });
 
   afterEach(() => {

--- a/packages/todomvc/tsconfig.json
+++ b/packages/todomvc/tsconfig.json
@@ -1,13 +1,5 @@
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": false,
-    "typeRoots": [
-      "./node_modules/@types"
-    ],
-    "baseUrl": "."
-  },
+  "extends": "@frontside/tsconfig",
   "include": [
     "src/**/*.ts"
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,6 +1136,11 @@
   resolved "https://registry.yarnpkg.com/@frontside/eslint-config/-/eslint-config-1.0.0.tgz#d4db29f1cceafc6ad3735d339964160c96e19b3d"
   integrity sha512-R3Wu9zVb34GaeDB1AKf1MulnkI+HKdejr0dGLPkWhD5dpwo4FJyDESmil1Bc5/uSn1Gq0zBWzM2QzjmvhLydlA==
 
+"@frontside/tsconfig@*":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-0.0.1.tgz#f7481d8681fed3d2274991271e6f36fa5e3ed32f"
+  integrity sha512-BQyLcpBIV9WQsBFQQqK/SIoEeKImWYMmu7kqLYpE3SCbCjY6ZN/yBpY63AMCCrv7V70Z5itATHTWvMAlkzkJPQ==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1563,6 +1568,13 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/capture-console@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/capture-console/-/capture-console-1.0.0.tgz#8730d90248d862c4ccdaf5a623bfee0272d9a934"
+  integrity sha512-v6XDGk++qgUNmL5oqjmrK/tYIRmekq9FO8vgVv4xAx9frJYTwWUI+iOa+2z48zw+ZHfVVTNxL1qT9wuZZUrDVg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1603,7 +1615,7 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/glob@^7.1.1":
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -1714,6 +1726,14 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/rimraf@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.0.tgz#b9d03f090ece263671898d57bb7bb007023ac19f"
+  integrity sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.13.3"
@@ -2630,7 +2650,7 @@ bluebird@3.4.6:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.6.tgz#01da8d821d87813d158967e743d5fe6c62cf8c0f"
   integrity sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=
 
-bluebird@^3.0.6, bluebird@^3.5.5:
+bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -5243,12 +5263,11 @@ forwarded@~0.1.2:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
   integrity sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
 
-fprint@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fprint/-/fprint-1.0.0.tgz#5751aa98bae3c17c7393791b530ea08c066629ed"
-  integrity sha1-V1GqmLrjwXxzk3kbUw6gjAZmKe0=
+fprint@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fprint/-/fprint-2.0.1.tgz#1bc89a557a1bb9fc8ab9c84813f6d389b288b8f0"
+  integrity sha512-hYQ/ueyP3aEArTiNivCZnmy91STMetHh9zNujOwpb0c+N1M98dPoRKakuIbOnedZHBVHuHL+Il6sBAHwmqo04w==
   dependencies:
-    bluebird "^3.0.6"
     callsite "^1.0.0"
     isstream "^0.1.2"
 


### PR DESCRIPTION
## Motivation
Many packages = many typescript configurations. So the plan is the unify all the configurations and put it inside `@bigtest/tsconfig` package. This resolves #234.

## Approach
- Skipped `convergence` and `interactor` because they're on they way [out](https://github.com/thefrontside/bigtest/pull/238).
- Skipped `website` too.
- Put most of the overlapping `tsconfig` of packages and put them inside `packages/tsconfig/tsconfig.json`.
- Using strict mode on all of them so now we have a whole batch of errors to go over.