### PR TITLE
Add/update Discord links and update package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
+[![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/4PyXfb)
+
 ## Development
 
 ### Installation
 
-1. Clone this repository `git clone git@github.com:bigtestjs/bigtest.git`
+1. Clone this repository `git clone git@github.com:thefrontside/bigtest.git`
 2. Run `yarn`
 
 ### Building

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/4PyXfb)
+[![Chat on Discord](https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/r6AvtnU)
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "bigtest",
   "version": "0.0.0-monorepo",
   "description": "Tests that speed up development ",
-  "repository": "git@github.com:bigtestjs/bigtest.git",
-  "author": "Taras Mankovski <taras@frontside.io>",
+  "repository": "git@github.com:thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "private": true,
   "workspaces": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,7 @@
   "description": "BigTest Server",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
-  "repository": "https://github.com/bigtestjs/server.git",
+  "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "scripts": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bigtestjs.io",
   "private": true,
-  "description": "Website for BigtestJS",
+  "description": "Bigtest Website",
   "version": "0.1.0",
   "author": "Frontside Inc. <contact@frontside.com>",
   "dependencies": {
@@ -62,6 +62,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bigtestjs/bigtest"
+    "url": "https://github.com/thefrontside/bigtest"
   }
 }

--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -62,7 +62,7 @@ const Header = () => (
       >
         Github
       </IconLink>
-      <IconLink icon={discordIconSVG} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
+      <IconLink icon={discordIconSVG} href="https://discord.gg/r6AvtnU" title="Discord community" target="_blank">
         Discord
       </IconLink>
       <LegacyLink href="http://v1.bigtestjs.io/">v1.x Docs &#8594;</LegacyLink>

--- a/packages/website/src/components/ReachOut.tsx
+++ b/packages/website/src/components/ReachOut.tsx
@@ -29,7 +29,7 @@ const ReachOut: React.FC = () => {
       <ReachLink icon={emailIconSVG} href="mailto:bigtest@frontside.com" title="Email Us" target="_blank">
         bigtest@frontside.com
       </ReachLink>
-      <ReachLink icon={discordIconSVG} href="https://discord.gg/W7r24Aa" title="Discord community" target="_blank">
+      <ReachLink icon={discordIconSVG} href="https://discord.gg/r6AvtnU" title="Discord community" target="_blank">
         Join our Discord!
       </ReachLink>
     </>


### PR DESCRIPTION
## Motivation
We have a new Discord channel for BigTest within the Frontside server and needed to update the Bigtest website and readme of this monorepo.

## Approach
- Update README
  - Discord link up top
  - Setup instructions updated
- Update package.json of monorepo (author and repository properties to Frontside engineering and frontside/bigtest respectively)
- Update package.json of `packages/server` and `packages/website`
- Update href property of discord links in the website 

## Test
- See readme preview [here](https://github.com/thefrontside/bigtest/blob/mk/update-info/README.md)
- Test the new discord links in the website preview [here](https://deploy-preview-242--bigtest.netlify.app/)