### PR TITLE
Mute warning about event listener leak

### DIFF
--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -26,6 +26,10 @@ export class Mailbox<T = any> {
     return yield resource(mailbox, subscribe(mailbox, source, events));
   }
 
+  setMaxListeners(value: number) {
+    this.subscriptions.setMaxListeners(value);
+  }
+
   send(message: T) {
     this.messages.add(message);
     setTimeout(() => this.subscriptions.emit('message', message), 0);

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -154,6 +154,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
   options.delegate.send({ status: 'ready' });
 
   let commandProcessorInbox = new Mailbox();
+  commandProcessorInbox.setMaxListeners(100000);
   yield connectionServerDelegate.pipe(commandProcessorInbox);
   yield commandServerDelegate.pipe(commandProcessorInbox);
 


### PR DESCRIPTION
In the command processor, we subscribe to the same mailbox many, many times. The underlying EventEmitter complains if there are more than 10 listeners, since it suspects a memory leak. However, in our case, this is expected behaviour, so we should just increase this limit.