### PR TITLE
Only generate schema artifacts explicitly

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -15,8 +15,8 @@
     "test": "mocha ./test/setup test/**/*.test.ts",
     "mocha": "mocha ./test/setup",
     "test:app:start": "ts-node ./bin/todomvc.ts",
-    "generate:schema": "ts-node ./src/schema.ts",
-    "prepack": "ts-node ./src/schema.ts && tsc --outdir dist --module commonjs --sourcemap --declaration"
+    "generate:schema": "BIGTEST_GENERATE_SCHEMA=true ts-node ./src/schema.ts",
+    "prepack": "yarn generate:schema && tsc --outdir dist --module commonjs --sourcemap --declaration"
   },
   "files": [
     "README.md",

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -19,6 +19,7 @@ export const schema = makeSchema({
     schema: path.join(__dirname, 'schema', 'schema.graphql'),
     typegen: path.join(__dirname, 'schema', 'schema.types.d.ts')
   },
+  shouldGenerateArtifacts: process.env['BIGTEST_GENERATE_SCHEMA'] === 'true',
   types: [
     queryType({
       rootTyping: {


### PR DESCRIPTION
> closes #244 

Motivation
-----------
By default, nexus _always_ tries to generate schema artifacts like the `.graphql` schemafile and the typings. However, [this fails in production][1] because it tries to load typescript modules which have long since been compiled into javascript and are not shipped with the distribution.

Approach
----------
Nexus provides a flag to prevent schema generation presumably for cases precisely such as this one. We use this flag here to stop generation unless the `BIGTEST_GENERATE_SCHEMA` environment variable is explicitly set which is done only from the `yarn generate:schema` step.

While this feels a bit awkward and hackish, it's the only workaround that I've been able to find.

[1]: https://github.com/thefrontside/bigtest/issues/244