### PR TITLE
Calibrate and fix typings in test run for schema

### DIFF
--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -8,6 +8,7 @@ export interface AgentProtocol {
 
 interface Connect {
   type: 'connected';
+  agentId?: string;
   data: unknown;
 }
 

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -54,7 +54,6 @@ let testRunIds = (function * () {
  * you based on the .
  */
 export function graphqlOptions(delegate: Mailbox, state: OrchestratorState): graphqlHTTP.OptionsData {
-
   return {
     schema,
     rootValue: state,

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -16,6 +16,10 @@ interface ConnectionServerOptions {
 
 let counter = 1;
 
+export function generateAgentId(): string {
+  return `agent.${counter++}`;
+}
+
 export function* createConnectionServer(options: ConnectionServerOptions): Operation {
   function* handleConnection(connection: Connection): Operation {
     console.debug('[connection] connected');
@@ -27,9 +31,9 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
       return JSON.parse(message.utf8Data);
     });
 
-    let { data  } = yield messages.receive({ type: 'connected' });
+    let { data, agentId } = yield messages.receive({ type: 'connected' });
 
-    let agentId = `agent.${counter++}`;
+    agentId = agentId || generateAgentId();
 
     let agent = options.atom.slice<AgentState>(['agents', agentId]);
 

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -1,4 +1,4 @@
-import { Test, TestResult } from '@bigtest/suite';
+import { Test, TestResult, ResultStatus } from '@bigtest/suite';
 
 export type AgentState = {
   agentId: string;
@@ -23,9 +23,14 @@ export type AgentState = {
 
 export type TestRunState = {
   testRunId: string;
-  status: "pending" | "running" | "done";
-  tree: TestResult;
+  status: ResultStatus;
+  agents: Record<string, TestRunAgentState>;
+}
+
+export type TestRunAgentState = {
+  status: ResultStatus;
   agent: AgentState;
+  result: TestResult;
 }
 
 export type OrchestratorState = {

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -160,19 +160,28 @@ export const schema = makeSchema({
     }),
     objectType({
       name: "TestRun",
+      rootTyping: {
+        name: "TestRunState",
+        path: path.join(__dirname, 'orchestrator', 'state.ts')
+      },
       definition(t) {
         t.id("testRunId");
         t.string("status");
         t.list.field("agents", {
           type: "TestRunAgent",
-          resolve: (testRun) => Object.values(testRun.agents)
+          resolve: testRun => Object.values(testRun.agents).map(agent => Object.assign({}, agent, {
+            testRunId: testRun.testRunId
+          }))
         });
         t.field("agent", {
           type: "TestRunAgent",
           args: {
             id: stringArg({ required: true }),
           },
-          resolve: (testRun, { id }) => testRun.agents[id]
+          resolve: (testRun, { id }) => ({
+            ...testRun.agents[id],
+            testRunId: testRun.testRunId
+          })
         });
       }
     }),

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -163,10 +163,28 @@ export const schema = makeSchema({
       definition(t) {
         t.id("testRunId");
         t.string("status");
+        t.list.field("agents", {
+          type: "TestRunAgent",
+          resolve: (testRun) => Object.values(testRun.agents)
+        });
+        t.field("agent", {
+          type: "TestRunAgent",
+          args: {
+            id: stringArg({ required: true }),
+          },
+          resolve: (testRun, { id }) => testRun.agents[id]
+        });
+      }
+    }),
+    objectType({
+      name: "TestRunAgent",
+      definition(t) {
+        t.id("testRunId");
+        t.string("status");
         t.field("agent", {
           type: "Agent"
         });
-        t.field("tree", {
+        t.field("result", {
           type: "TestResult"
         });
       }

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -71,8 +71,9 @@ describe('command server', () => {
 
     it('adds agent and test tree to manifest', () => {
       let testRun = atom.slice<TestRunState>(['testRuns', 'test-id-1']).get();
-      expect(testRun.agent.agentId).toEqual('agent-1');
-      expect(testRun.tree.description).toEqual('the manifest');
+      expect(Object.values(testRun.agents).length).toEqual(1);
+      expect(testRun.agents['agent-1'].agent.agentId).toEqual('agent-1');
+      expect(testRun.agents['agent-1'].result.description).toEqual('the manifest');
     });
   });
 });

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -4,68 +4,73 @@ import { Agent, Command } from '@bigtest/agent';
 import { TestResult } from '@bigtest/suite';
 import { actions } from './helpers';
 import { Client } from '../src/client';
+import { generateAgentId } from '../src/connection-server';
+
+function resultsQuery(testRunId, agentId) {
+  return `
+    fragment results on TestResult {
+      description
+      status
+      steps {
+        description
+        status
+      }
+      assertions {
+        description
+        status
+      }
+    }
+
+    {
+      testRun(id: "${testRunId}") {
+        testRunId
+        status
+        agent(id: "${agentId}") {
+          status
+          agent {
+            agentId
+          }
+          result {
+            ...results
+            children {
+              ...results
+              children {
+                ...results
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+}
 
 describe('running tests on an agent', () => {
   let client: Client;
   let agent: Agent;
+  let agentId = generateAgentId();
+  let agentsSubscription: Mailbox;
 
   beforeEach(async () => {
     await actions.startOrchestrator();
     agent = await actions.createAgent();
     client = await actions.fork(Client.create(`http://localhost:24102`));
 
-    agent.send({
-      type: 'connected',
-      data: {
-        platform: {
-          type: 'tests',
-          vendor: 'Frontside'
-        }
-      }
-    });
+    agent.send({ type: 'connected', agentId, data: {} });
 
-    let agents = await actions.fork(client.subscribe(`{ agents { agentId } }`));
-    await actions.fork(agents.receive(({ agents }) => agents && agents.length > 0));
+    agentsSubscription = await actions.fork(client.subscribe(`{ agents { agentId } }`));
+    await actions.fork(agentsSubscription.receive(({ agents }) => agents && agents.length === 1));
   });
 
   describe('with the fixture tree', () => {
-    let subscription: Mailbox;
+    let results: Mailbox;
     let runCommand: Command;
 
     beforeEach(async () => {
       await actions.fork(client.query(`mutation { run }`));
 
       runCommand = await actions.fork(agent.receive());
-      subscription = await actions.fork(client.subscribe(`
-fragment results on TestResult {
-  description
-  status
-  steps {
-    description
-    status
-  }
-  assertions {
-    description
-    status
-  }
-}
-
-{
-  testRun(id: "${runCommand.testRunId}") {
-    testRunId
-    status
-    tree {
-      ...results
-      children {
-        ...results
-        children {
-          ...results
-        }
-      }
-    }
-  }
-}
-`));
+      results = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, agentId)));
     });
 
     it('receives a run event on the agent', () => {
@@ -83,7 +88,7 @@ fragment results on TestResult {
       });
 
       it('is marks the run as running', async () => {
-        await actions.fork(subscription.receive({ testRun: { status: 'running' }}));
+        await actions.fork(results.receive({ testRun: { status: 'running' }}));
       });
     });
 
@@ -96,8 +101,12 @@ fragment results on TestResult {
         });
       });
 
+      it('marks that particular agent as running', async () => {
+        await actions.fork(results.receive({ testRun: { agent: { status: 'running' } } }));
+      });
+
       it('marks that particular test as running', async () => {
-        await actions.fork(subscription.receive({ testRun: { tree: { status: 'running' } } }));
+        await actions.fork(results.receive({ testRun: { agent: { result: { status: 'running' } } } }));
       });
     });
 
@@ -119,25 +128,74 @@ fragment results on TestResult {
       });
 
       it('marks that step as failed', async () => {
-        await actions.fork(subscription.receive(({ testRun }) => {
-          return testRun.tree.children
+        await actions.fork(results.receive(({ testRun }) => {
+          return testRun.agent.result.children
             .find(child => child.description === "Signing In" ).steps
             .find(child => child.description === "when I fill in the login form").status === 'failed';
         }));
       });
 
       it('disregards the remaining steps, and remaining children', async() => {
-        await actions.fork(subscription.receive(({ testRun }) => {
-          let tree = testRun.tree.children
+        await actions.fork(results.receive(({ testRun }) => {
+          let results = testRun.agent.result.children
             .find(child => child.description === "Signing In" )
 
-          let { assertions, children } = tree;
+          let { assertions, children } = results;
 
           return assertions.every(assertion => assertion.status === 'disregarded')
             && children.every(child => child.status === 'disregarded');
 
         }));
       });
+    });
+  });
+
+  describe('with multiple agents', function() {
+    let secondAgentId = generateAgentId();
+    let secondAgent: Agent;
+    let agentResults: Mailbox;
+    let secondAgentResults: Mailbox;
+
+    beforeEach(async () => {
+      secondAgent = await actions.createAgent();
+
+      secondAgent.send({ type: 'connected', agentId: secondAgentId, data: {} });
+
+      await actions.fork(agentsSubscription.receive(({ agents }) => agents && agents.length === 2));
+
+      await actions.fork(client.query(`mutation { run }`));
+
+      let runCommand: Command = await actions.fork(agent.receive());
+      agentResults = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, agentId)));
+      secondAgentResults = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, secondAgentId)));
+
+      secondAgent.send({
+        type: 'step:result',
+        status: 'ok',
+        testRunId: runCommand.testRunId,
+        path: ['All tests', "Signing In", "when I fill in the login form"]
+      });
+
+      agent.send({
+        type: 'step:result',
+        status: 'failed',
+        testRunId: runCommand.testRunId,
+        path: ['All tests', "Signing In", "when I fill in the login form"],
+        error: { message: "this step failed", fileName: 'here.js', lineNumber: 5, columnNumber: 10, stack: ['here.js', 'there.js'] }
+      });
+    });
+
+    it('tracks results for all agents separately', async () => {
+      await actions.fork(agentResults.receive(({ testRun }) => {
+        return testRun.agent.result.children
+          .find(child => child.description === "Signing In" ).steps
+          .find(child => child.description === "when I fill in the login form").status === 'failed';
+      }));
+      await actions.fork(secondAgentResults.receive(({ testRun }) => {
+        return testRun.agent.result.children
+          .find(child => child.description === "Signing In" ).steps
+          .find(child => child.description === "when I fill in the login form").status === 'ok';
+      }));
     });
   });
 });


### PR DESCRIPTION
It appears that nexus determines the type of the "source" object in its graphql resolvers by default as the union of all the "primitive" fields in type definition. So in the case of "TestRun", it sees that it has an `id("testRunId")` and `string("status")` fields, and expects the source value to be just an object with the `{ testRunId, status }` structure. This was causing errors, because in reality we have a`TestRunState` off of which we want to get the `agents` field.

You can set the type of the source object in a resolver using the `rootTyping` field, so this change sets the root typing for a test run to `TestRunState`. Upon setting this, it caught a type error, where we were not returning the `testRunId` for a `TestRunAgent`. This also fixes that type error.

> Note: I tried to use `{...agent, testRunId: testRun.testRunId }` to assign the test run id, but it caused a type error "Typescript: Spread types may only be created from object types" which felt wrong, but 🤷🏼