### PR TITLE
Update sync action to v1.6 and reintroduce interactor & convergence to deprecate

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         before_all: yarn prepack
         npm_publish: yarn publish
-        ignore: packages/website
+        ignore: packages/website packages/interactor packages/convergence
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.5
+      uses: thefrontside/actions/synchronize-with-npm@v1.6
       with:
         before_all: yarn prepack
         npm_publish: yarn publish
-        ignore: packages/website
+        ignore: packages/website packages/interactor packages/convergence
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@bigtest/convergence",
+  "deprecate": true
+}

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@bigtest/interactor",
+  "deprecate": true
+}


### PR DESCRIPTION
## Motivation
To update the release workflow with the latest `synchronize-with-npm` action from [this](https://github.com/thefrontside/actions/pull/58) pull request which introduces the functionality to deprecate packages.

## Approach
- Added `convergence` and `interactor` directories inside `packages/` with the `"deprecate": true` flag in its respective `package.json`.
- Added `packages/convergence` and `packages/interactor` to the ignore arg for both `preview` and `release` workflows (because we don't need to publish them).
- Updated `synchronize-with-npm` to `v1.6`.

## TODO
After we merge this pull request, we'll let it deprecate the two packages we already removed from the monorepo. Afterwards I'll create a new pull request to remove those packages once again.