### PR TITLE
Remove interactor & convergence and update workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         before_all: yarn prepack
         npm_publish: yarn publish
-        ignore: packages/website packages/interactor packages/convergence
+        ignore: packages/website
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         before_all: yarn prepack
         npm_publish: yarn publish
-        ignore: packages/website packages/interactor packages/convergence
+        ignore: packages/website
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/packages/convergence/package.json
+++ b/packages/convergence/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@bigtest/convergence",
-  "deprecate": true
-}

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@bigtest/interactor",
-  "deprecate": true
-}


### PR DESCRIPTION
## Motivation
Part 2 of [this](https://github.com/thefrontside/bigtest/pull/249) pull request and you can see the success of the new action [here](https://github.com/thefrontside/bigtest/runs/613006915).

Both [@bigtest/interactor](https://www.npmjs.com/package/@bigtest/interactor) and [@bigtest/convergence](https://www.npmjs.com/package/@bigtest/convergence) has been deprecated on npmjs.

## Approach
- Removed `./packages/convergence/package.json` and `./packages/interactor/package.json`.
- Removed `interactor` and `convergence` from the ignore argument of both `release` and `preview` workflows.