### PR TITLE
Upgrade effection, improve linkability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "eslint": "^6.6.0",
     "eslint-plugin-prefer-let": "^1.0.1",
     "typescript": "^3.7.0"
+  },
+  "resolutions": {
+    "**/effection": "0.6.2"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -27,6 +27,7 @@
     "@types/node-fetch": "^2.5.4",
     "@types/websocket": "^1.0.0",
     "classnames": "^2.2.5",
+    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "node-fetch": "^2.6.0",
@@ -37,10 +38,12 @@
     "ts-node": "*",
     "typescript": "^3.7.0"
   },
+  "peerDependencies": {
+    "effection": "^0.6.2"
+  },
   "dependencies": {
     "@bigtest/effection": "*",
     "bowser": "^2.9.0",
-    "effection": "^0.6.0",
     "express": "^4.17.1",
     "websocket": "^1.0.31"
   },

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -19,13 +19,15 @@
   "devDependencies": {
     "@types/mocha": "^7.0.1",
     "@types/node": "^12.7.11",
+    "@types/ramda": "types/npm-ramda#dist",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
+  "peerDependencies": {
+    "effection": "^0.6.0"
+  },
   "dependencies": {
-    "@types/ramda": "types/npm-ramda#dist",
-    "effection": "^0.6.0",
     "ramda": "0.27.0"
   },
   "volta": {

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -25,7 +25,7 @@
     "ts-node": "*"
   },
   "peerDependencies": {
-    "effection": "^0.6.0"
+    "effection": "^0.6.2"
   },
   "dependencies": {
     "ramda": "0.27.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,8 +34,8 @@
     "typescript": "^3.7.0"
   },
   "dependencies": {
-    "capture-console": "^1.0.1",
-    "effection": "^0.6.0"
+    "effection": "^0.6.2",
+    "capture-console": "^1.0.1"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -20,13 +20,15 @@
   "devDependencies": {
     "@types/mocha": "^7.0.1",
     "@types/node": "^12.7.11",
+    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
+  "peerDependencies": {
+    "effection": "^0.6.2"
+  },
   "dependencies": {
-    "@types/node": "^12.7.11",
-    "effection": "^0.6.0",
     "express": "^4.17.1"
   },
   "volta": {

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -20,12 +20,12 @@
   "devDependencies": {
     "@types/mocha": "^7.0.1",
     "@types/node": "^12.7.11",
+    "effection": "^0.6.0",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "dependencies": {
-    "@types/node": "^12.7.11",
+  "peerDependencies": {
     "effection": "^0.6.0"
   },
   "volta": {

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -20,9 +20,11 @@
   "dependencies": {
     "@bigtest/effection": "^0.1.1",
     "@effection/node": "^0.6.0",
-    "effection": "^0.6.0",
     "parcel": "^1.12.4",
     "parcel-bundler": "^1.12.4"
+  },
+  "peerDependencies": {
+    "effection": "^0.6.2"
   },
   "volta": {
     "node": "12.16.0",
@@ -31,6 +33,7 @@
   "devDependencies": {
     "@types/node": "^13.9.0",
     "@types/parcel-bundler": "^1.12.1",
+    "effection": "^0.6.2",
     "expect": "^25.1.0",
     "yargs": "^15.3.0"
   }

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -19,12 +19,13 @@
   "devDependencies": {
     "@types/mocha": "^7.0.1",
     "@types/node": "^12.7.11",
+    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "dependencies": {
-    "effection": "^0.6.0"
+  "peerDependencies": {
+    "effection": "^0.6.2"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -33,9 +33,13 @@
     "@types/node-fetch": "^2.5.3",
     "@types/websocket": "^1.0.0",
     "abort-controller": "^3.0.0",
+    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "node-fetch": "^2.6.0"
+  },
+  "peerDependencies": {
+    "effection": "^0.6.2"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-0",
@@ -50,7 +54,6 @@
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",
     "chokidar": "^3.3.1",
-    "effection": "^0.6.0",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
     "fprint": "^1.0.0",

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -38,7 +38,7 @@
     "webpack": "4.41.2"
   },
   "dependencies": {
-    "effection": "^0.6.0",
+    "effection": "^0.6.2",
     "express": "^4.17.1"
   },
   "volta": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5722,10 +5722,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.0.tgz#c74c4500bbaf3c3ec637a55b16750d39b9908ef7"
-  integrity sha512-osJtyJo5Z9QgO6oPHr2nJqf+InoTOxxBIavajIBvC1SAPZKJg/l5CDJugZgNDXd2A0J49SkCh/Y1jK9j985fwg==
+effection@0.6.2, effection@^0.6.0, effection@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.2.tgz#4b64f3538c777f044df954cffdacb15db636f501"
+  integrity sha512-Ba7lPfh0X1RE83LpwGHlqPymxVezOi72bkaZFnyGVic4O8o2HXfOto9BIBZ8UwNNe+lhEqjbz0IW7KkklQrzig==
 
 electron-to-chromium@^1.3.341, electron-to-chromium@^1.3.47:
   version "1.3.345"


### PR DESCRIPTION
Motivation
----------

One of the challenges of working with effection inside the bigtest repo has been trying to use a linked version or a preview version and not have things go terribly awry. This is because each package has it listed as a runtime dependency. However, most packages don't actually care that there be a particular version of effection installed, merely that _somme_ version is available. [I _think_ that this is why you want to have peer dependencies.][1]

Throughout our tree, we want to make sure that everyone is handed the same copy of effection (in this case 0.6.2) and the only way to guarantee that is via a peer dependency.

Approach
----------

By using peer dependency everywhere there is a reference to effection, every library will get the same version of effection that is loaded by the root level require. 

This is a bit annoying because we have to include effection twice: once in `devDependencies` and once in `peerDependencies`, but the payoff is that if I link effection inside the `@bigtest/server` package, and import from `@bigtest/agent`, because `@bigtest/agent` is required from `@bigtest/server` it will defer the version of the library to its parent with is the version in the devDependencies of `@bigtest/server`

[1]: https://classic.yarnpkg.com/blog/2018/04/18/dependencies-done-right/