### PR TITLE
Create @bigtest/webdriver

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
     needs: prepack
     strategy:
       matrix:
-        package: [agent, cli, effection, logging, parcel, project, server, suite, todomvc, atom]
+        package: [agent, cli, effection, logging, parcel, project, server, suite, todomvc, atom, webdriver]
     steps:
-      - uses: actions/checkout@v1 
+      - uses: actions/checkout@v1
       - uses: actions/cache@v1
         with:
           path: /home/runner/.cache/yarn/v6

--- a/packages/webdriver/.gitignore
+++ b/packages/webdriver/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/webdriver/README.md
+++ b/packages/webdriver/README.md
@@ -1,0 +1,40 @@
+# @bigtest/webdriver
+
+Connect and Control webdrivers for BigTest
+
+BigTest needs a way to automatically start and stop web browsers and
+connect them to the orchestrator as agents. It does this my getting
+references to `WebDriver` instances that can be used to control a
+browser.
+
+`WebDriver` instances are implemented as effection resources, and so
+they will automatically be shut down whenever the operation of which
+they are a part passes out of scope.
+
+In order to start a local webdriver on the current computer:
+
+``` typescript
+import { Operation } from 'effection';
+import { WebDriver, Local } from '@bigtest/webdriver';
+
+export function* connect(url: string): Operation<WebDriver> {
+  // get the instance of the driver
+  let driver: WebDriver = yield Local('chromedriver', { headless: true });
+
+  // use it to got to a web page
+  yield driver.navigateTo('https://frontside.com');
+
+  // pass the driver resource to the caller
+  return driver;
+}
+```
+
+> Currently, only _local_ webdriver instances of `chromedriver` and
+> `geckodriver` are supported and so in order to use them you must
+> have Chrome and Firefox installed locally.
+
+To run the tests:
+
+``` sh
+$ yarn test
+```

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@bigtest/webdriver",
+  "version": "0.1.0",
+  "description": "Control Webdriver instances",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": [
+    "dist/*",
+    "README.md"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,test}/**/*.ts'",
+    "test": "mocha --timeout 60000 -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsc --outdir dist --declaration --sourcemap"
+  },
+  "devDependencies": {
+    "@bigtest/effection-express": "^0.1.1",
+    "@types/express": "^4.17.6",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^12.7.11",
+    "expect": "^24.9.0",
+    "mocha": "^6.2.2",
+    "ts-node": "*"
+  },
+  "peerDependencies": {
+    "effection": "^0.6.2"
+  },
+  "dependencies": {
+    "@bigtest/atom": "^0.1.0",
+    "@effection/node": "^0.6.1",
+    "abort-controller": "^3.0.0",
+    "chromedriver": "~80.0.0",
+    "geckodriver": "^1.19.1",
+    "node-fetch": "^2.6.0"
+  }
+}

--- a/packages/webdriver/src/fetch.ts
+++ b/packages/webdriver/src/fetch.ts
@@ -1,0 +1,31 @@
+import { Operation } from 'effection';
+import
+{ fetch as nativeFetch,
+  AbortController,
+  RequestInfo,
+  RequestInit,
+  Response
+} from './native-fetch';
+
+export { AbortController, RequestInfo, RequestInit, Response };
+
+/**
+ * Use `fetch` as an effection operation.
+ *
+ * This implements the `fetch` api exactly as it appears in the
+ * JavaScript spec. However, an abort signal is automatically connected
+ * to the underlying call so that whenever the `fetch` operation
+ * passes out of scope, it is automatically cancelled. That way, it is
+ * impossible to leave an http request dangling. E.g.
+ *
+ *   let response = yield fetch('https://bigtestjs.io');
+ */
+export function* fetch(resource: RequestInfo, init: RequestInit = {}): Operation<Response> {
+  let controller = new AbortController();
+  init.signal = controller.signal;
+  try {
+    return yield nativeFetch(resource, init);
+  } finally {
+    controller.abort();
+  }
+}

--- a/packages/webdriver/src/find-available-port-number.ts
+++ b/packages/webdriver/src/find-available-port-number.ts
@@ -1,0 +1,27 @@
+import { createServer, AddressInfo } from 'net';
+import { Operation } from 'effection';
+import { once, throwOnErrorEvent } from '@effection/events';
+
+/**
+ * Find a TCP port from the local operating system that is available
+ * to connect to.
+ *
+ * Note that there is a potential for a race condition if another
+ * operation (or process on the same machine) binds to the returned
+ * port number before you can.
+ */
+export function* findAvailablePortNumber(): Operation<number> {
+  let server = createServer();
+  yield throwOnErrorEvent(server);
+
+  server.listen()
+
+  try {
+    yield once(server, 'listening');
+
+    let address =  server.address() as AddressInfo;
+    return address.port;
+  } finally {
+    server.close();
+  }
+}

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -1,0 +1,2 @@
+export { WebDriver, Options } from './web-driver';
+export { Local } from './local';

--- a/packages/webdriver/src/local.ts
+++ b/packages/webdriver/src/local.ts
@@ -1,0 +1,42 @@
+import 'chromedriver';
+import 'geckodriver';
+
+import { Operation, resource } from 'effection';
+import { ChildProcess } from '@effection/node';
+import { once } from '@effection/events';
+
+import { findAvailablePortNumber } from './find-available-port-number';
+import { untilURLAvailable } from './until-url-available';
+import { WebDriver, Options, connect } from './web-driver';
+
+type LocalDriverName = 'chromedriver' | 'geckodriver';
+
+/**
+ * Create a local `WebDriver` resource based on `driverName` (either 'geckodriver' or
+ * 'chromedriver').
+ *
+ * In order to function, the local executables for `Chrome` and
+ * `Firefox` must be separately installed onto the machine. So in CI
+ * for example, you would need to make sure that the browsers are
+ * present on your container.
+ *
+ * In order to keep things simple, and because the geckodriver only
+ * suopports a single Firefox session per driver process, we spawn a
+ * new process for each local driver.
+ */
+export function * Local(driverName: LocalDriverName, options: Options): Operation<WebDriver> {
+
+  let port: number = yield findAvailablePortNumber();
+  let driverURL = `http://localhost:${port}`;
+
+  let driver = yield resource(new WebDriver(driverURL), function*() {
+    let child = yield ChildProcess.spawn(driverName, [`--port=${port}`]);
+    yield once(child, 'exit');
+  });
+
+  yield untilURLAvailable(`${driverURL}/status`, 1000);
+
+  yield connect(driver, options);
+
+  return driver;
+}

--- a/packages/webdriver/src/native-fetch.ts
+++ b/packages/webdriver/src/native-fetch.ts
@@ -1,0 +1,6 @@
+export { RequestInfo, RequestInit, Response } from 'node-fetch'
+export { AbortController } from 'abort-controller';
+
+import fetch from 'node-fetch';
+
+export { fetch };

--- a/packages/webdriver/src/until-url-available.ts
+++ b/packages/webdriver/src/until-url-available.ts
@@ -1,0 +1,26 @@
+import { Operation, spawn, timeout } from 'effection';
+import { fetch, Response } from './fetch';
+
+/**
+ * An operation that completes when the server at `url` begins
+ * returning successful responses to an HTTP GET request.
+ */
+export function* untilURLAvailable(url: string, maxWait: number): Operation<void> {
+  yield spawn(function* () {
+    yield timeout(maxWait);
+    throw new Error(`timed out waiting ${maxWait}ms for ${url} to become available`)
+  });
+  while (true) {
+    try {
+      let response: Response = yield fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch (error) {
+      /* FetchError is ok. Sever may not yet be accepting connections */
+      if (error.name !== 'FetchError') {
+        throw error;
+      }
+    }
+  }
+}

--- a/packages/webdriver/src/web-driver.ts
+++ b/packages/webdriver/src/web-driver.ts
@@ -1,0 +1,79 @@
+import { Operation } from 'effection';
+import { Atom } from '@bigtest/atom';
+import { fetch, RequestInit } from './fetch';
+
+export class WebDriver {
+  session: { sessionId: string } = { sessionId: '' };
+
+  constructor(public serverURL: string) {}
+
+  *navigateTo(url: string): Operation<void> {
+    yield request(`${this.serverURL}/session/${this.session.sessionId}/url`, {
+      method: 'post',
+      body: JSON.stringify({ url })
+    });
+  }
+}
+
+/**
+ * Creates a webdriver session and attaches it to `driver`. This should be
+ * called by either the `Remote()` or `Local()` operations internally before
+ * handing out a `WebDriver` resource to the public.
+ */
+export function* connect(driver: WebDriver, options: Options): Operation<void> {
+
+  let capabilities = new Atom(Capabilities);
+
+  if (options.headless) {
+    capabilities.slice<string[]>(['alwaysMatch', 'goog:chromeOptions', 'args'])
+      .over(args => args.concat(['--headless']))
+    capabilities.slice<string[]>(['alwaysMatch', 'moz:firefoxOptions', 'args'])
+      .over(args => args.concat(['--headless']))
+  }
+
+  driver.session = yield request(`${driver.serverURL}/session`, {
+    method: 'post',
+    body: JSON.stringify({
+      capabilities: capabilities.get()
+    })
+  });
+}
+
+function* request(url: string, init: RequestInit): Operation<WDResponse> {
+  let response: Response = yield fetch(url, init);
+
+  if (!response.ok) {
+    let details: WDResponse;
+    try {
+      details = yield response.json();
+    } catch (e) { /* ok, no json details*/}
+    if (details && details.value && details.value) {
+      throw new Error(details.value.message);
+    } else {
+      throw new Error(`RequestError: ${response.status} ${response.statusText}`)
+    }
+  }
+  let json = yield response.json();
+  return json.value;
+}
+
+export interface Options {
+  headless: boolean;
+}
+
+interface WDResponse {
+  value: {
+    message?: string;
+  };
+}
+
+const Capabilities = {
+  alwaysMatch: {
+    'goog:chromeOptions': {
+      args: []
+    },
+    'moz:firefoxOptions': {
+      args: []
+    }
+  }
+};

--- a/packages/webdriver/test/helpers.ts
+++ b/packages/webdriver/test/helpers.ts
@@ -1,0 +1,17 @@
+import { Context, Operation, main } from 'effection';
+
+type World = Context & { spawn<T>(operation: Operation<T>): Promise<T> };
+
+let currentWorld: World;
+
+beforeEach(() => {
+  currentWorld = main(undefined) as World;
+});
+
+afterEach(() => {
+  currentWorld.halt();
+});
+
+export function spawn<T>(operation: Operation<T>): Promise<T> {
+  return currentWorld.spawn(operation);
+}

--- a/packages/webdriver/test/local.test.ts
+++ b/packages/webdriver/test/local.test.ts
@@ -1,0 +1,56 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { express } from '@bigtest/effection-express';
+import { Request, Response } from 'express';
+import { spawn } from './helpers';
+
+import { Local, WebDriver } from '../src/index';
+import { findAvailablePortNumber } from '../src/find-available-port-number';
+
+describe("Running a local wedriver", () => {
+  let driver: WebDriver;
+  let server = express();
+  let latestRequest: Request;
+  server.use(function(request: Request, response: Response) {
+    latestRequest = request;
+    response.write("thank you");
+    response.end();
+  });
+
+  let serverURL: string;
+
+  beforeEach(async () => {
+    latestRequest = undefined;
+
+    let port = await spawn(findAvailablePortNumber());
+
+    serverURL = `http://localhost:${port}`;
+
+    await spawn(server.listen(port));
+
+  });
+
+  describe('with chromedriver', () => {
+    beforeEach(async () => {
+      driver = await spawn(Local('chromedriver', { headless: true }));
+      await spawn(driver.navigateTo(serverURL));
+    });
+
+    it('can navigate to a url', () => {
+      expect(latestRequest).toBeDefined();
+      expect(latestRequest.headers['user-agent']).toMatch('Chrome');
+    });
+  });
+
+  describe('with geckodriver', () => {
+    beforeEach(async () => {
+      driver = await spawn(Local('geckodriver', { headless: true }));
+      await spawn(driver.navigateTo(serverURL));
+    });
+    it('can navigate to a url', () => {
+      expect(latestRequest).toBeDefined();
+      expect(latestRequest.headers['user-agent']).toMatch('Firefox');
+    });
+  });
+})

--- a/packages/webdriver/tsconfig.json
+++ b/packages/webdriver/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ],
+    "baseUrl": "."
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2069,6 +2069,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testim/chrome-version@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
+  integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
+
 "@types/babel__core@^7.1.0":
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
@@ -2150,7 +2155,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@^4.17.2", "@types/express@^4.17.3":
+"@types/express@^4.17.2", "@types/express@^4.17.3", "@types/express@^4.17.6":
   version "4.17.6"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.6.tgz#6bce49e49570507b86ea1b07b806f04697fac45e"
   integrity sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==
@@ -2439,6 +2444,13 @@
   integrity sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==
   dependencies:
     "@types/yargs-parser" "*"
+
+"@types/yauzl@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
+  integrity sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/yoga-layout@1.9.1":
   version "1.9.1"
@@ -2874,6 +2886,11 @@ adjust-sourcemap-loader@2.0.0:
     loader-utils "1.2.3"
     object-path "0.11.4"
     regex-parser "2.2.10"
+
+adm-zip@0.4.11:
+  version "0.4.11"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
+  integrity sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==
 
 after@0.8.2:
   version "0.8.2"
@@ -3754,6 +3771,11 @@ blob@0.0.5:
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.5.tgz#d680eeef25f8cd91ad533f5b01eed48e64caf683"
   integrity sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==
 
+bluebird@3.4.6:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.6.tgz#01da8d821d87813d158967e743d5fe6c62cf8c0f"
+  integrity sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=
+
 bluebird@^3.0.6, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -4304,6 +4326,11 @@ capture-exit@^2.0.0:
   dependencies:
     rsvp "^4.8.4"
 
+capture-stack-trace@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
+  integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
+
 case-sensitive-paths-webpack-plugin@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz#23ac613cc9a856e4f88ff8bb73bbb5e989825cf7"
@@ -4446,7 +4473,7 @@ chokidar@^2.0.4, chokidar@^2.1.5, chokidar@^2.1.8:
   optionalDependencies:
     fsevents "^1.2.7"
 
-chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.3:
+chownr@^1.0.1, chownr@^1.1.1, chownr@^1.1.2, chownr@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
@@ -4457,6 +4484,18 @@ chrome-trace-event@^1.0.2:
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
   dependencies:
     tslib "^1.9.0"
+
+chromedriver@~80.0.0:
+  version "80.0.2"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-80.0.2.tgz#005b9bf19abebf678b5d5670a9f16605c437a154"
+  integrity sha512-MKrTzBtykWuIswRYgUw9dHXr96BShQYSy8NdLlo2LN1mZ17A9nxtz9v0h9z1zKWTVaxT7e0qvo41rSY5BL1i+Q==
+  dependencies:
+    "@testim/chrome-version" "^1.0.7"
+    axios "^0.19.2"
+    del "^5.1.0"
+    extract-zip "^2.0.0"
+    mkdirp "^1.0.4"
+    tcp-port-used "^1.0.1"
 
 ci-info@2.0.0, ci-info@^2.0.0:
   version "2.0.0"
@@ -5025,6 +5064,13 @@ create-ecdh@^4.0.0:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
 
+create-error-class@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
+  dependencies:
+    capture-stack-trace "^1.0.0"
+
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.2.0.tgz#889078af11a63756bcfb59bd221996be3a9ef196"
@@ -5492,6 +5538,13 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.
   dependencies:
     ms "^2.1.1"
 
+debug@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 debug@=3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -5608,7 +5661,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -6048,19 +6101,19 @@ download@^7.1.0:
     p-event "^2.1.0"
     pify "^3.0.0"
 
+duplexer2@^0.1.4, duplexer2@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
+  dependencies:
+    readable-stream "^2.0.2"
+
 duplexer2@~0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
   integrity sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=
   dependencies:
     readable-stream "~1.1.9"
-
-duplexer2@~0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
-  dependencies:
-    readable-stream "^2.0.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -6968,6 +7021,17 @@ extract-zip@^1.6.6:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
+extract-zip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.0.tgz#f53b71d44f4ff5a4527a2259ade000fb8b303492"
+  integrity sha512-i42GQ498yibjdvIhivUsRslx608whtGoFIhF26Z7O4MYncBxp8CwalOs1lnHy21A9sIohWO2+uiE4SRtC9JXDg==
+  dependencies:
+    debug "^4.1.1"
+    get-stream "^5.1.0"
+    yauzl "^2.10.0"
+  optionalDependencies:
+    "@types/yauzl" "^2.9.1"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -7476,6 +7540,13 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-minipass@^1.2.5:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -8012,6 +8083,17 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+geckodriver@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/geckodriver/-/geckodriver-1.19.1.tgz#556f95fd6451b553cec89f81f81abbefce10d6e5"
+  integrity sha512-xWL/+eEhQ6+t98rc1c+xVM3hshDJibXtZf9WJA3sshxq4k5L1PBwfmswyBmmlKUfBr4xuC256gLVC2RxFhiCsQ==
+  dependencies:
+    adm-zip "0.4.11"
+    bluebird "3.4.6"
+    got "5.6.0"
+    https-proxy-agent "3.0.0"
+    tar "4.4.2"
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -8282,6 +8364,28 @@ gonzales-pe@^4.3.0:
   integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
   dependencies:
     minimist "^1.2.5"
+
+got@5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-5.6.0.tgz#bb1d7ee163b78082bbc8eb836f3f395004ea6fbf"
+  integrity sha1-ux1+4WO3gIK7yOuDbz85UATqb78=
+  dependencies:
+    create-error-class "^3.0.1"
+    duplexer2 "^0.1.4"
+    is-plain-obj "^1.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    node-status-codes "^1.0.0"
+    object-assign "^4.0.1"
+    parse-json "^2.1.0"
+    pinkie-promise "^2.0.0"
+    read-all-stream "^3.0.0"
+    readable-stream "^2.0.5"
+    timed-out "^2.0.0"
+    unzip-response "^1.0.0"
+    url-parse-lax "^1.0.0"
 
 got@8.3.2, got@^8.3.1, got@^8.3.2:
   version "8.3.2"
@@ -8963,6 +9067,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
+
+https-proxy-agent@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz#0106efa5d63d6d6f3ab87c999fa4877a3fd1ff97"
+  integrity sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
 
 https-proxy-agent@^3.0.0:
   version "3.0.1"
@@ -9808,6 +9920,11 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
 is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
@@ -9958,6 +10075,15 @@ is-yarn-global@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.3.0.tgz#d502d3382590ea3004893746754c89139973e232"
   integrity sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+
+is2@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is2/-/is2-2.0.1.tgz#8ac355644840921ce435d94f05d3a94634d3481a"
+  integrity sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==
+  dependencies:
+    deep-is "^0.1.3"
+    ip-regex "^2.1.0"
+    is-url "^1.2.2"
 
 isarray@0.0.1, isarray@~0.0.1:
   version "0.0.1"
@@ -11644,12 +11770,27 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass@^2.2.4, minipass@^2.6.0, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   integrity sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==
   dependencies:
     yallist "^4.0.0"
+
+minizlib@^1.1.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
 
 minizlib@^2.1.0:
   version "2.1.0"
@@ -11708,14 +11849,14 @@ mkdirp@0.5.4:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.3:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -12012,6 +12153,11 @@ node-releases@^1.1.29, node-releases@^1.1.52, node-releases@^1.1.53:
   version "1.1.53"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.53.tgz#2d821bfa499ed7c5dffc5e2f28c88e78a08ee3f4"
   integrity sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ==
+
+node-status-codes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
+  integrity sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=
 
 noms@0.0.0:
   version "0.0.0"
@@ -12812,7 +12958,7 @@ parse-headers@^2.0.0:
   resolved "https://registry.yarnpkg.com/parse-headers/-/parse-headers-2.0.3.tgz#5e8e7512383d140ba02f0c7aa9f49b4399c92515"
   integrity sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==
 
-parse-json@^2.2.0:
+parse-json@^2.1.0, parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
@@ -14714,6 +14860,14 @@ react@^16.13.0, react@^16.8.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+read-all-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
+  integrity sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=
+  dependencies:
+    pinkie-promise "^2.0.0"
+    readable-stream "^2.0.0"
+
 read-chunk@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/read-chunk/-/read-chunk-3.2.0.tgz#2984afe78ca9bfbbdb74b19387bf9e86289c16ca"
@@ -14799,7 +14953,7 @@ read@^1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.3, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -16875,6 +17029,19 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
+tar@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.2.tgz#60685211ba46b38847b1ae7ee1a24d744a2cd462"
+  integrity sha512-BfkE9CciGGgDsATqkikUHrQrraBCO+ke/1f6SFAEMnxyyfN9lxC+nW1NFWMpqH865DhHIy9vQi682gk1X7friw==
+  dependencies:
+    chownr "^1.0.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.2.4"
+    minizlib "^1.1.0"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.2"
+
 tar@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.1.tgz#7b3bd6c313cb6e0153770108f8d70ac298607efa"
@@ -16891,6 +17058,14 @@ tcomb@^3.2.21:
   version "3.2.29"
   resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.29.tgz#32404fe9456d90c2cf4798682d37439f1ccc386c"
   integrity sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ==
+
+tcp-port-used@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tcp-port-used/-/tcp-port-used-1.0.1.tgz#46061078e2d38c73979a2c2c12b5a674e6689d70"
+  integrity sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==
+  dependencies:
+    debug "4.1.0"
+    is2 "2.0.1"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -17035,6 +17210,11 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+timed-out@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-2.0.0.tgz#f38b0ae81d3747d628001f41dafc652ace671c0a"
+  integrity sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=
 
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
@@ -17601,6 +17781,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzip-response@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
+  integrity sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=
 
 upath@^1.1.1:
   version "1.2.0"
@@ -18560,7 +18745,7 @@ yallist@^2.0.0, yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==


### PR DESCRIPTION
Motivation
----------

BigTest needs to be able to start and stop browsers automatically in order to create the browser agents that will be part of a test run. So, if we want to run our test suite on Firefox _and_ Chrome within the single test run, we'll need to be able to start thosebrowsers, and then direct them at the agent server.

Approach
--------

All the major browsers support the [webdriver protocol][1], both to startup and to control a browser over a series of HTTP requests. Rather than try and implement our own control mechanisms, this uses webdriver to launch a managed browser and have it navigate to a url.

This arrangement is ideal because most of the actual direction of the test happens within the browser itself as part of the agent/harness combination found in the `@bigtest/agent` package. In fact, the only operation that we need currently beyond starting and stopping is the `WebDriver#navigateTo()` which loads a url inside of the browser under control.

In this change, we introduce the subset of webdriver functionality that we need in order to get a bigtest running. This can be found in the `WebDriver` interface. Then, we provide a `Local()` operation to create a `WebDriver` that uses a locally installed Chrome or a Firefox to actually run the session.

For example:

```typescript
import { Operation } from 'effection';
import { WebDriver, Local } from '@bigtest/webdriver';

export function* connect(url: string): Operation<WebDriver> {
  // get the instance of the driver
  let driver: WebDriver = yield Local('chromedriver', { headless: true });

  // use it to got to a web page
  yield driver.navigateTo('https://frontside.com');

  // pass the driver resource to the caller
  return driver;
}
```

Screenshots
-------------

Using the local chrome driver to navigate to the bigtest and frontside websites:

![Using the local chrome driver to navigate to the bigtest and frontside websites](https://user-images.githubusercontent.com/4205/80530301-6b660280-895e-11ea-94ba-02e8c3ba69c4.gif)


Questions
---------

**Q:** Does this use Selenium?

**A:** No. This implementation does not use [Selenium][5]. It uses the webdriver protocol *directly* over HTTP.  As a result, it is much faster, and more tightly integrated with the [`effection`][4] paradigm which makes it more robust to extremely rapid setup and teardown.

**Q:** What about remote browsers launched from a cloud service?

**A:** While the scope of this change only includes launching local browser processes and not connecting to remote webdriver servers such as [BrowserStack][2] or [Sauce Labs][3], the implementation should be relatively straightforward, since even communication with the local processes happens over HTTP using webdriver REST calls.

**Q:** What about browsers and devices that don't support webdriver?
**A:** Between all the various cloud services it is actually quite difficult to find a browser that cannot be launched via webdriver. For those that don't, our useage of the protocol is very slim. In fact, it is limited to three REST calls: `POST /session`, `DELETE /session/${id}`, and `POST /session/${id}/url`. In the event that a device does not support webdriver, emulating those three calls should be within the realm of possibility. Finally, remember that BigTest does not require that it be the one to launch a browser in order for that browser to be an agent, only that the browser connect to the agent server url. It will always support just opening a browser and entering in the agent connect url.

[1]: https://w3c.github.io/webdriver/
[2]: https://www.browserstack.com
[3]: https://saucelabs.com
[4]: https://github.com/thefrontside/effection
[5]: https://www.selenium.dev