### PR TITLE
Modify prepack script for website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
   base = "packages/website/"
   publish = "public/"
+  command = "gatsby build"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,3 @@
 [build]
   base = "packages/website/"
   publish = "public/"
-  command = "npm run prepack"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -49,7 +49,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "prepack": "gatsby build",
+    "prepack": "echo Skipping prepack for packages/website...",
     "develop": "gatsby develop",
     "format:ts": "prettier --write '**/*.{json,ts,tsx}'",
     "lint:ts": "eslint '**/*.{ts,tsx}'",


### PR DESCRIPTION
## Motivation
To resolve #259: `yarn workspaces run prepack` was building the website unnecessarily and using up resources.

## Approach
Gatsby workflow does not rely on any `prepack` script and the current `prepack` script is set to `gatsby build`.
- ~~Removed the `command` field in `netlify.toml` so it will just default to `gatsby build`.~~
  - Changed the `command` in `netlify.toml` to `gatsby build`.
- Modified the `prepack` script to `echo Skipping prepack for packages/website...`.
  - We still need to provide it a `prepack` script or `yarn workspaces` will return an error.

## Test
- [x] Make sure Netlify is able to build preview with the new settings: [Success](https://deploy-preview-260--bigtest.netlify.app/)