### PR TITLE
Percolate failures upwards

### DIFF
--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -84,7 +84,7 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
     }
   }
 
-  function* runTest(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<void> {
+  function* runTest(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<ResultStatus> {
     let testStatus = result.slice<ResultStatus>(['status']);
 
     yield spawn(function* () {
@@ -108,8 +108,8 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
     }
   }
 
-  function* collectTestResult(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<void> {
-    let status = 'ok';
+  function* collectTestResult(agentId: string, result: Slice<TestResult, OrchestratorState>, path: string[]): Operation<ResultStatus> {
+    let status: ResultStatus = 'ok';
     let forks = [];
 
     for (let [index, step] of result.get().steps.entries()) {


### PR DESCRIPTION
If a test has steps, assertions or even children that fail, the test itself should also be marked as failed. This way, we report the status up the tree and are able to report an aggregate status for the entire suite.

It is worth noting that in a user interface, we are most likely interested in mainly showing the status of the *assertions*, not the tests, so while at first glance this might generate a lot of "failure-noise", in practice it probably won't even be visible to the user in most cases, but it will make it much easier to report on the aggregate result of test runs.
