### PR TITLE
Fix inter-package dependencies

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -8,7 +8,7 @@
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
-    "dist/*",
+    "dist/**/*",
     "README.md"
   ],
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "files": [
     "bin/*",
-    "dist/*",
+    "dist/**/*",
     "README.md"
   ],
   "scripts": {
@@ -39,6 +39,8 @@
   },
   "dependencies": {
     "@bigtest/effection": "^0.1.1",
+    "@bigtest/project": "^0.1.0",
+    "@bigtest/server": "^0.1.0",
     "@bigtest/todomvc": "^0.1.1",
     "@effection/events": "^0.6.0",
     "@effection/node": "^0.6.2",

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -8,7 +8,7 @@
   "author": "Frontside Engineering <engineering@frontside.io>",
   "license": "MIT",
   "files": [
-    "dist/*",
+    "dist/**/*",
     "README.md"
   ],
   "scripts": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -26,7 +26,8 @@
     "ts-node": "*"
   },
   "peerDependencies": {
-    "effection": "^0.6.2"
+    "effection": "^0.6.2",
+    "@bigtest/webdriver": "^0.1.0"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
   },
   "files": [
     "README.md",
-    "dist/*"
+    "dist/**/*"
   ],
   "devDependencies": {
     "@bigtest/todomvc": "^0.1.0",
@@ -43,7 +43,8 @@
     "typescript": "^3.6.3"
   },
   "peerDependencies": {
-    "effection": "^0.6.2"
+    "effection": "^0.6.2",
+    "@bigtest/project": "^0.1.0"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-0",
@@ -52,9 +53,11 @@
     "@bigtest/agent": "^0.1.0",
     "@bigtest/atom": "*",
     "@bigtest/effection": "^0.1.1",
+    "@bigtest/effection-express": "^0.1.0",
     "@bigtest/logging": "^0.1.0",
     "@bigtest/parcel": "^0.1.0",
     "@bigtest/suite": "^0.1.0",
+    "@bigtest/webdriver": "^0.1.0",
     "@effection/events": "^0.6.1",
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "effection": "^0.6.2",
+    "@bigtest/effection-express": "^0.1.0",
     "@effection/node": "^0.6.2",
     "express": "^4.17.1"
   },


### PR DESCRIPTION
We want to release a public version of bigtest that will actually link-up and run properly in the wild. This means a couple of things:

1. all of the package dependencies need to be there for the package to work IRL.
2. The tarball needs to properly contain the files that will be distributed.

Ran the [knit][1] linter against this repo and it found that in many cases the `files` property of package.json was too conservative and did not select resources into the tarball that were in subdirectories. Also, there were flat-out a lot of dependencies that just weren't specified because they were being implicitly found inside a mono-repo. To be quite honest, I wish `yarn` did not do that.

[1]: https://github.com/knitjs/knit