### PR TITLE
Add DSL for writing test suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
       "packages/project",
       "packages/todomvc",
       "packages/suite",
+      "packages/dsl",
       "packages/agent",
       "packages/convergence",
       "packages/interactor",

--- a/packages/dsl/.gitignore
+++ b/packages/dsl/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/dsl/README.md
+++ b/packages/dsl/README.md
@@ -1,0 +1,9 @@
+# @bigtest/dsl
+
+A DSL for writing bigtest test suites
+
+To run the tests:
+
+``` sh
+$ yarn test
+```

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@bigtest/dsl",
+  "version": "0.1.0",
+  "description": "DSL for writing bigtest test suites",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.js",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.io>",
+  "license": "MIT",
+  "files": [
+    "dist/*",
+    "README.md"
+  ],
+  "scripts": {
+    "lint": "eslint '{src,test}/**/*.ts'",
+    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "prepack": "tsc --outdir dist --declaration --sourcemap"
+  },
+  "devDependencies": {
+    "@frontside/tsconfig": "*",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.13.4",
+    "expect": "^24.9.0",
+    "mocha": "^6.2.2",
+    "ts-node": "*"
+  },
+  "peerDependencies": {
+    "effection": "^0.6.2"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
+  },
+  "dependencies": {
+    "@bigtest/suite": "^0.1.0"
+  }
+}

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -1,0 +1,62 @@
+export { strict as assert } from 'assert';
+import { TestImplementation, Context, Step, Assertion, Check, Action } from '@bigtest/suite';
+
+export function test<C extends Context>(description: string): TestBuilder<C> {
+  return new TestBuilder<C>({
+    description,
+    steps: [],
+    assertions: [],
+    children: []
+  });
+}
+
+class TestBuilder<C extends Context> implements TestImplementation {
+  public description: string;
+  public steps: Step[];
+  public assertions: Assertion[];
+  public children: TestImplementation[];
+
+  constructor(test: TestImplementation) {
+    this.description = test.description;
+    this.steps = test.steps;
+    this.assertions = test.assertions;
+    this.children = test.children;
+  }
+
+  step<R extends Context | void>(description: string, action: (context: C) => PromiseLike<R>): TestBuilder<R extends void ? C : C & R> {
+    let implementation = {
+      description: this.description,
+      steps: this.steps.concat({
+        description,
+        action: action as Action
+      }),
+      assertions: this.assertions,
+      children: this.children
+    }
+    return new TestBuilder(implementation);
+  }
+
+  assertion<R extends Context | void>(description: string, check: (context: C) => R): TestBuilder<R extends void ? C : C & R> {
+    let implementation = {
+      description: this.description,
+      steps: this.steps,
+      assertions: this.assertions.concat({
+        description,
+        check: check as Check
+      }),
+      children: this.children
+    }
+    return new TestBuilder(implementation);
+  }
+
+  child(description: string, childFn: (inner: TestBuilder<C>) => TestBuilder<Context>): TestBuilder<C> {
+    let child = childFn(test(description));
+    let implementation = {
+      description: this.description,
+      steps: this.steps,
+      assertions: this.assertions,
+      children: this.children.concat(child)
+    }
+    return new TestBuilder(implementation);
+  }
+}

--- a/packages/dsl/src/index.ts
+++ b/packages/dsl/src/index.ts
@@ -24,39 +24,30 @@ class TestBuilder<C extends Context> implements TestImplementation {
   }
 
   step<R extends Context | void>(description: string, action: (context: C) => PromiseLike<R>): TestBuilder<R extends void ? C : C & R> {
-    let implementation = {
-      description: this.description,
+    return new TestBuilder({
+      ...this,
       steps: this.steps.concat({
         description,
         action: action as Action
       }),
-      assertions: this.assertions,
-      children: this.children
-    }
-    return new TestBuilder(implementation);
+    });
   }
 
   assertion<R extends Context | void>(description: string, check: (context: C) => R): TestBuilder<R extends void ? C : C & R> {
-    let implementation = {
-      description: this.description,
-      steps: this.steps,
+    return new TestBuilder({
+      ...this,
       assertions: this.assertions.concat({
         description,
         check: check as Check
       }),
-      children: this.children
-    }
-    return new TestBuilder(implementation);
+    });
   }
 
   child(description: string, childFn: (inner: TestBuilder<C>) => TestBuilder<Context>): TestBuilder<C> {
     let child = childFn(test(description));
-    let implementation = {
-      description: this.description,
-      steps: this.steps,
-      assertions: this.assertions,
+    return new TestBuilder({
+      ...this,
       children: this.children.concat(child)
-    }
-    return new TestBuilder(implementation);
+    });
   }
 }

--- a/packages/dsl/test/dsl.test.ts
+++ b/packages/dsl/test/dsl.test.ts
@@ -1,0 +1,8 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+describe("@bigtest/atom", () => {
+  it('works', () => {
+    expect(1).toEqual(1);
+  });
+})

--- a/packages/dsl/test/dsl.test.ts
+++ b/packages/dsl/test/dsl.test.ts
@@ -1,8 +1,20 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
 
-describe("@bigtest/atom", () => {
-  it('works', () => {
-    expect(1).toEqual(1);
+import example from './fixtures/example';
+
+describe('@bigtest/dsl', () => {
+  it('returns a serialized test suite', async () => {
+    expect(example.description).toEqual('a test');
+    expect(example.steps[0].description).toEqual('some step');
+    expect(example.steps[1].description).toEqual('this does nothing');
+    expect(example.steps[2].description).toEqual('another step');
+    expect(example.assertions[0].description).toEqual('this is an assertion');
+    expect(example.assertions[1].description).toEqual('this is another assertion');
+    expect(example.children[0].description).toEqual('a child test');
+    expect(example.children[0].steps[0].description).toEqual('a child step');
+    expect(example.children[0].assertions[0].description).toEqual('a child assertion');
+
+    await expect(example.steps[0].action({})).resolves.toHaveProperty('foo', 'foo');
   });
 })

--- a/packages/dsl/test/fixtures/example.ts
+++ b/packages/dsl/test/fixtures/example.ts
@@ -1,0 +1,27 @@
+import { test, assert } from '../../src/index';
+
+export default test("a test")
+  .step("some step", async () => {
+    return { foo: "foo" }
+  })
+  .step("this does nothing", async() => {
+
+  })
+  .step("another step", async ({ foo }) => {
+    return { bar: foo.toUpperCase() + "bar" }
+  })
+  .assertion("this is an assertion", ({ foo }) => {
+    assert.equal(foo, "foo");
+  })
+  .assertion("this is another assertion", ({ bar }) => {
+    assert.equal(bar, "foobar");
+  })
+  .child("a child test", (test) => (
+    test
+      .step("a child step", async ({ foo }) => {
+        return { quox: foo.toUpperCase() + "blah" }
+      })
+      .assertion("a child assertion", ({ quox }) => {
+        assert.equal(quox, "FOOblah");
+      })
+  ))

--- a/packages/dsl/test/fixtures/example.ts
+++ b/packages/dsl/test/fixtures/example.ts
@@ -1,27 +1,26 @@
 import { test, assert } from '../../src/index';
 
-export default test("a test")
-  .step("some step", async () => {
-    return { foo: "foo" }
+export default test('a test')
+  .step('some step', async () => {
+    return { foo: 'foo' }
   })
-  .step("this does nothing", async() => {
-
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  .step('this does nothing', async() => {})
+  .step('another step', async ({ foo }) => {
+    return { bar: foo.toUpperCase() + 'bar' }
   })
-  .step("another step", async ({ foo }) => {
-    return { bar: foo.toUpperCase() + "bar" }
+  .assertion('this is an assertion', ({ foo }) => {
+    assert.equal(foo, 'foo');
   })
-  .assertion("this is an assertion", ({ foo }) => {
-    assert.equal(foo, "foo");
+  .assertion('this is another assertion', ({ bar }) => {
+    assert.equal(bar, 'foobar');
   })
-  .assertion("this is another assertion", ({ bar }) => {
-    assert.equal(bar, "foobar");
-  })
-  .child("a child test", (test) => (
+  .child('a child test', (test) => (
     test
-      .step("a child step", async ({ foo }) => {
-        return { quox: foo.toUpperCase() + "blah" }
+      .step('a child step', async ({ foo }) => {
+        return { quox: foo.toUpperCase() + 'blah' }
       })
-      .assertion("a child assertion", ({ quox }) => {
-        assert.equal(quox, "FOOblah");
+      .assertion('a child assertion', ({ quox }) => {
+        assert.equal(quox, 'FOOblah');
       })
   ))

--- a/packages/dsl/tsconfig.json
+++ b/packages/dsl/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@frontside/tsconfig",
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts"
+  ]
+}

--- a/packages/suite/index.ts
+++ b/packages/suite/index.ts
@@ -30,6 +30,8 @@ export interface TestImplementation extends Test {
   children: TestImplementation[];
 }
 
+export type Action = (context: Context) => Promise<Context | void>;
+
 /**
  * A single operation that is part of the test. It contains an Action
  * which is an `async` function that accepts the current test
@@ -39,8 +41,10 @@ export interface TestImplementation extends Test {
  */
 export interface Step extends Node {
   description: string;
-  action: (context: Context) => Promise<Context | void>;
+  action: Action;
 }
+
+export type Check = (context: Context) => void;
 
 /**
  * A single assertion that is part of a test case. It accepts the
@@ -50,7 +54,7 @@ export interface Step extends Node {
  */
 export interface Assertion extends Node {
   description: string;
-  check: (context: Context) => void;
+  check: Check;
 }
 
 /**


### PR DESCRIPTION
This is a DSL which builds the datastructure needed for our test suites, but in a more convenient and less verbose way.

It is built to be typescript friendly.