### PR TITLE
Convert the agent test suite to use `test` macro

### DIFF
--- a/packages/agent/test/fixtures/manifest.src.js
+++ b/packages/agent/test/fixtures/manifest.src.js
@@ -1,27 +1,8 @@
-module.exports = {
-  description: "tests",
-  steps: [],
-  assertions: [],
-  children: [
-    {
-      description: "test with failing assertion",
-      steps: [
-        {
-          description: "successful step",
-          action: async () => {}
-        },
-      ],
-      assertions: [
-        {
-          description: "failing assertion",
-          check: () => { throw new Error("boom") }
-        },
-        {
-          description: "successful assertion",
-          check: () => true
-        }
-      ],
-      children: []
-    }
-  ]
-}
+const { test } = require('@bigtest/suite');
+
+module.exports = test("tests")
+  .child(
+    "test with failing assertion", test => test
+      .step("successful step", async () => {})
+      .assertion("failing assertion", () => { throw new Error("boom!"); })
+      .assertion("successful assertion", () => true))

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -2,6 +2,7 @@
   "name": "@bigtest/suite",
   "version": "0.4.1",
   "description": "Test data structures ",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/bigtest.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,7 +4447,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@^0.6.0, effection@^0.6.2:
+effection@0.6.2, effection@^0.6.0, effection@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.2.tgz#4b64f3538c777f044df954cffdacb15db636f501"
   integrity sha512-Ba7lPfh0X1RE83LpwGHlqPymxVezOi72bkaZFnyGVic4O8o2HXfOto9BIBZ8UwNNe+lhEqjbz0IW7KkklQrzig==


### PR DESCRIPTION
In preparation for threading the test context, we need to extend the set of test fixtures for the agent, but using the wire format is tedious.

This updates it to use the `test` macro so that we can easily add new steps and assertions