### PR TITLE
Turn CLI inside out

### DIFF
--- a/packages/cli/bigtest.json
+++ b/packages/cli/bigtest.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "command": "yarn bigtest-todomvc 36000",
+    "command": "bigtest-todomvc 36000",
     "port": 36000
   },
   "testFiles": ["./test/fixtures/*.test.{ts,js}"],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,128 +8,128 @@ import { setLogLevel, Levels } from '@bigtest/logging';
 import { loadConfig } from './config';
 import * as query from './query';
 
-export function CLI(argv: string[]): Operation {
-  return ({ fork, resume }) => {
-    yargs({})
-      .scriptName('bigtest')
-      .command('server', 'start a bigtest server', (yargs) => {
-        yargs
-          .option('launch', {
-            describe: 'launch specified driver at server startup',
-            type: 'array',
-            default: []
-          })
-      }, (options) => {
-        setLogLevel(options.logLevel as Levels);
+export function * CLI(argv: string[]): Operation {
+  let config: ProjectOptions = yield loadConfig();
 
-        fork(function* server() {
-          let config: ProjectOptions = yield loadConfig(options.configFile as string | undefined);
+  let options = parseOptions(config, argv);
 
-          let launch = options.launch as string[];
-          if (launch.length > 0) {
-            config.launch = launch;
-          }
+  setLogLevel(options.logLevel);
 
-          for (let key of config.launch) {
-            if (!config.drivers[key]) {
-              throw new Error(`Could not find launch key ${key} in the set of drivers: ${JSON.stringify(Object.keys(config.drivers))}`);
-            }
-          }
+  if (options.command === 'server') {
+    let launch = options.launch;
+    if (launch.length > 0) {
+      config.launch = launch;
+    }
 
-          yield createServer(config);
-        });
-      })
+    for (let key of config.launch) {
+      if (!config.drivers[key]) {
+        throw new Error(`Could not find launch key ${key} in the set of drivers: ${JSON.stringify(Object.keys(config.drivers))}`);
+      }
+    }
 
-      .command('test', 'run tests against server', (yargs) => yargs, (options) => {
-        setLogLevel(options.logLevel as Levels);
+    yield createServer(config);
 
-        fork(function* server() {
-          let config = yield loadConfig(options.configFile as string | undefined);
-          let client: Client = yield Client.create(`ws://localhost:${config.port}`);
+  } else if (options.command === 'test') {
+    let client: Client = yield Client.create(`ws://localhost:${config.port}`);
 
-          let { run: testRunId } = yield client.query(query.run());
+    let { run: testRunId } = yield client.query(query.run());
 
-          console.log('Starting test run:', testRunId);
+    console.log('Starting test run:', testRunId);
 
-          let subscription = yield client.subscribe(query.testRunResults(testRunId));
+    let subscription = yield client.subscribe(query.testRunResults(testRunId));
 
-          while(true) {
-            let { testRun } = yield subscription.receive();
-            if(testRun.status === 'ok') {
-              console.log('SUCCESS');
-              break;
-            }
-            if(testRun.status === 'failed') {
-              console.log('FAILED');
-              break;
-            }
-          };
-        });
-      })
-      .command('ci', 'start a server and run the test suite', (yargs) => {
-        yargs
-          .option('launch', {
-            describe: 'launch specified driver at server startup',
-            type: 'array',
-            default: []
-          })
-      }, (options) => {
-        setLogLevel(options.logLevel as Levels);
+    while(true) {
+      let { testRun } = yield subscription.receive();
+      if(testRun.status === 'ok') {
+        console.log('SUCCESS');
+        break;
+      }
+      if(testRun.status === 'failed') {
+        console.log('FAILED');
+        break;
+      }
+    }
+  } else {
+    let launch = options.launch as string[];
+    if (launch.length > 0) {
+      config.launch = launch;
+    }
 
-        fork(function* server() {
-          let config: ProjectOptions = yield loadConfig(options.configFile as string | undefined);
+    for (let key of config.launch) {
+      if (!config.drivers[key]) {
+        throw new Error(`Could not find launch key ${key} in the set of drivers: ${JSON.stringify(Object.keys(config.drivers))}`);
+      }
+    }
 
-          let launch = options.launch as string[];
-          if (launch.length > 0) {
-            config.launch = launch;
-          }
+    let delegate = new Mailbox();
+    let atom = createOrchestratorAtom();
+    yield spawn(createOrchestrator({ atom, delegate, project: config }));
 
-          for (let key of config.launch) {
-            if (!config.drivers[key]) {
-              throw new Error(`Could not find launch key ${key} in the set of drivers: ${JSON.stringify(Object.keys(config.drivers))}`);
-            }
-          }
+    yield delegate.receive({ status: 'ready' });
 
-          let delegate = new Mailbox();
-          let atom = createOrchestratorAtom();
-          yield spawn(createOrchestrator({ atom, delegate, project: config }));
+    let client: Client = yield Client.create(`ws://localhost:${config.port}`);
 
-          yield delegate.receive({ status: 'ready' });
+    let { run: testRunId } = yield client.query(query.run());
 
-          let client: Client = yield Client.create(`ws://localhost:${config.port}`);
+    console.log('Starting test run:', testRunId);
 
-          let { run: testRunId } = yield client.query(query.run());
+    let subscription = yield client.subscribe(query.testRunResults(testRunId));
 
-          console.log('Starting test run:', testRunId);
+    while(true) {
+      let { testRun } = yield subscription.receive();
+      if(testRun.status === 'ok') {
+        console.log('SUCCESS');
+        break;
+      }
+      if(testRun.status === 'failed') {
+        console.log('FAILED');
+        break;
+      }
+    }
+  }
+}
 
-          let subscription = yield client.subscribe(query.testRunResults(testRunId));
+function parseOptions(config: ProjectOptions, argv: readonly string[]): CLIOptions {
+  let rawOptions = yargs({})
+    .scriptName('bigtest')
+    .command('server', 'start a bigtest server', (yargs) => {
+      yargs
+        .option('launch', {
+          describe: 'launch specified driver at server startup',
+          type: 'array',
+          choices: Object.keys(config.drivers),
+          default: config.launch,
+        })
+    })
+    .command('test', 'run tests against server')
+    .option('log-level', {
+      default: 'info',
+      global: true,
+      choices: ['debug', 'info', 'warn', 'error'],
+      desc: 'increase or decrease the amount of logging information printed to the console'
+    })
+    .command('ci', 'start a server and run the test suite', (yargs) => {
+      yargs
+        .option('launch', {
+          describe: 'launch specified driver at server startup',
+          type: 'array',
+          choices: Object.keys(config.drivers),
+          default: config.launch
+        })
+    })
+    .demandCommand()
+    .help()
+    .parse(argv);
 
-          while(true) {
-            let { testRun } = yield subscription.receive();
-            if(testRun.status === 'ok') {
-              console.log('SUCCESS');
-              break;
-            }
-            if(testRun.status === 'failed') {
-              console.log('FAILED');
-              break;
-            }
-          };
-        });
-      })
-      .option('log-level', {
-        default: 'info',
-        global: true,
-        choices: ['debug', 'info', 'warn', 'error'],
-        desc: 'increase or decrease the amount of logging information printed to the console'
-      })
-      .option('config-file', {
-        global: true,
-        desc: 'path to the config file'
-      })
-      .demandCommand()
-      .help()
-      .parse(argv);
-    resume({})
-  };
+  return {
+    command: rawOptions._[0] as CLIOptions["command"],
+    logLevel: rawOptions['log-level'] as Levels,
+    launch: rawOptions.launch as string[] || []
+  }
+}
+
+interface CLIOptions {
+  command: 'server' | 'test' | 'ci';
+  launch: string[];
+  logLevel: Levels;
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,8 +2,8 @@ import { Operation } from 'effection';
 import { defaultConfig, getConfigFilePath, loadConfigFile, ProjectOptions } from '@bigtest/project';
 import * as merge from 'deepmerge';
 
-export function *loadConfig(configFilePath: string | undefined): Operation<ProjectOptions> {
-  configFilePath = configFilePath || getConfigFilePath();
+export function *loadConfig(): Operation<ProjectOptions> {
+  let configFilePath = getConfigFilePath();
   if(!configFilePath) { throw new Error("config file not found"); }
 
   let projectConfig: ProjectOptions = yield loadConfigFile(configFilePath);


### PR DESCRIPTION
Motivation
-----------

Adding commands and sharing code is difficult with the current CLI because it's driven through callbacks via yargs. That means we have to explicitly enter an effection context any time that we want to use an operation. What we'd like is to always be in effection from the get-go.

Approach
----------
This makes the yargs parsing, which is synchronous, a simple function that returns a data structure which can then be used to run the CLI. 

One thing is that there is a chicken and the egg problem with loading the config because we don't know what the config file is until we parse the options and we don't know the all the options until we parse the config. This temporarily punts on this by removing the `config-file` option. What we get in return is better validation of the options because the choices and defaults are all drawn from the config.