### PR TITLE
New interactors generic elements

### DIFF
--- a/packages/interactor/src/action.ts
+++ b/packages/interactor/src/action.ts
@@ -1,5 +1,5 @@
-export type ActionSpecification = Record<string, (element: HTMLElement) => unknown>
+export type ActionSpecification<E extends HTMLElement> = Record<string, (element: E) => unknown>
 
-export type ActionImplementation<T extends ActionSpecification> = {
-  [P in keyof T]: T[P] extends ((element: HTMLElement, ...args: infer TArgs) => infer TReturn) ? ((...args: TArgs) => Promise<TReturn>) : never;
+export type ActionImplementation<E extends HTMLElement, T extends ActionSpecification<E>> = {
+  [P in keyof T]: T[P] extends ((element: E, ...args: infer TArgs) => infer TReturn) ? ((...args: TArgs) => Promise<TReturn>) : never;
 }

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -10,6 +10,13 @@ export interface InteractorSpecification<L extends LocatorSpecification> {
   locators: L;
 }
 
+const defaultSpecification: InteractorSpecification<{}> = {
+  name: 'interactor',
+  selector: 'div',
+  defaultLocator: (element) => element.textContent || "",
+  locators: {},
+}
+
 export class Interactor {
   protected parent?: Interactor;
 
@@ -80,11 +87,12 @@ export class Interactor {
 }
 
 export function interactor<A extends ActionSpecification, L extends LocatorSpecification>(
-  specification: InteractorSpecification<L> & { actions?: A }
+  specification: Partial<InteractorSpecification<L>> & { actions?: A }
 ): (...locatorArgs: LocatorArguments<L>) => Interactor & ActionImplementation<A> {
   return function(...locatorArgs) {
-    let locator = new Locator(specification.defaultLocator, specification.locators, locatorArgs);
-    let interactor = new Interactor(specification, locator as unknown as Locator);
+    let fullSpecification = Object.assign({}, defaultSpecification, specification);
+    let locator = new Locator(fullSpecification.defaultLocator, fullSpecification.locators, locatorArgs);
+    let interactor = new Interactor(fullSpecification, locator as unknown as Locator);
 
     for(let [name, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(interactor, name, {

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,14 +1,14 @@
-export type LocatorFn = (element: HTMLElement) => string;
+export type LocatorFn<E extends HTMLElement> = (element: E) => string;
 
-export type LocatorSpecification = Record<string, LocatorFn>;
+export type LocatorSpecification<E extends HTMLElement> = Record<string, LocatorFn<E>>;
 
-export type LocatorArguments<L extends LocatorSpecification> = [string] | [keyof L, string];
+export type LocatorArguments<E extends HTMLElement, L extends LocatorSpecification<E>> = [string] | [keyof L, string];
 
-export class Locator<L extends LocatorSpecification = LocatorSpecification> {
+export class Locator<E extends HTMLElement, L extends LocatorSpecification<E> = LocatorSpecification<E>> {
   public name?: keyof L;
   public value: string;
 
-  constructor(public defaultLocator: LocatorFn, public specification: L, locator: LocatorArguments<L>) {
+  constructor(public defaultLocator: LocatorFn<E>, public specification: L, locator: LocatorArguments<E, L>) {
     if(locator.length === 2) {
       this.name = locator[0];
       this.value = locator[1];
@@ -25,7 +25,7 @@ export class Locator<L extends LocatorSpecification = LocatorSpecification> {
     }
   }
 
-  matches(element: HTMLElement): boolean {
+  matches(element: E): boolean {
     if(this.name) {
       let locator = this.specification[this.name];
 

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -11,9 +11,8 @@ process.on('unhandledRejection', () => {
 const Link = interactor({
   name: 'link',
   selector: 'a',
-  defaultLocator: (element) => element.textContent || "",
   locators: {
-    id: (element) => element.id,
+    href: (element) => element.id,
     title: (element) => element.title
   },
   actions: {
@@ -24,15 +23,12 @@ const Link = interactor({
 const Header = interactor({
   name: 'header',
   selector: 'h1,h2,h3,h4,h5,h6',
-  defaultLocator: (element) => element.textContent || "",
-  locators: {}
 });
 
 const Div = interactor({
   name: 'div',
   selector: 'div',
   defaultLocator: (element) => element.id || "",
-  locators: {}
 });
 
 function dom(html: string) {

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -8,11 +8,10 @@ process.on('unhandledRejection', () => {
   // do nothing
 });
 
-const Link = interactor({
-  name: 'link',
+const Link = interactor('link')({
   selector: 'a',
   locators: {
-    href: (element) => element.id,
+    id: (element) => element.id,
     title: (element) => element.title
   },
   actions: {
@@ -20,14 +19,11 @@ const Link = interactor({
   }
 });
 
-const Header = interactor({
-  name: 'header',
+const Header = interactor('header')({
   selector: 'h1,h2,h3,h4,h5,h6',
 });
 
-const Div = interactor({
-  name: 'div',
-  selector: 'div',
+const Div = interactor('div')({
   defaultLocator: (element) => element.id || "",
 });
 

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -120,6 +120,26 @@ describe('@bigtest/interactor', () => {
 
       await expect(Div("blah").find(Link("Foo")).exists()).rejects.toHaveProperty('message', 'div "blah" does not exist');
     });
+
+    it('is composable', async () => {
+      dom(`
+        <div id="test">
+          <div id="foo">
+            <a href="/foo">Foo</a>
+          </div>
+          <div id="bar">
+            <a href="/Bar">Bar</a>
+          </div>
+        </div>
+        <a href="/foo">Foo</a>
+      `);
+
+      await expect(Div("test").find(Div("foo").find(Link("Foo"))).exists()).resolves.toEqual(true);
+      await expect(Div("test").find(Div("foo").find(Link("Bar"))).exists()).rejects.toHaveProperty('message', 'link "Bar" within div "foo" within div "test" does not exist');
+
+      await expect(Div("test").find(Div("foo")).find(Link("Foo")).exists()).resolves.toEqual(true);
+      await expect(Div("test").find(Div("foo")).find(Link("Bar")).exists()).rejects.toHaveProperty('message', 'link "Bar" within div "foo" within div "test" does not exist');
+    });
   });
 
   describe('actions', () => {

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -8,10 +8,10 @@ process.on('unhandledRejection', () => {
   // do nothing
 });
 
-const Link = interactor('link')({
+const Link = interactor<HTMLLinkElement>('link')({
   selector: 'a',
   locators: {
-    id: (element) => element.id,
+    href: (element) => element.href,
     title: (element) => element.title
   },
   actions: {


### PR DESCRIPTION
This is an implementation of making the element of an interactor generic, so that we can use a subclass of `HTMLElement`, if we know that we're working exclusively with a certain type of element. This means we can use all of the nice helper methods and properties provided in the DOM API, rather than being restricted to just what is available on `HTMLElement`.

Unfortunately it does make the types a lot more complicated, and it also necessitates a change of the `interactor` function so that it becomes a curried function, due to inference issues. Since we want the type of the generic type parameters `A` and `L` to be inferred, but `E` to be explicitly given, we need to do this currying trick, since TypeScript currently [does not support](https://github.com/microsoft/TypeScript/issues/26242) partial inference of types.

It's a bit unfortunate to have to do this workaround, especially since it is completely unnecessary when using vanilla JS, but if we want to specify the type of the element, I think this is what we have to do. I've been unable to find any other workaround which is reasonably ergonomic.