### PR TITLE
remove explicit as casts from Interactor

### DIFF
--- a/packages/interactor/src/define-interactor.ts
+++ b/packages/interactor/src/define-interactor.ts
@@ -29,7 +29,7 @@ export function defineInteractor<E extends Element>(interactorName: string) {
 
     let result = function(value: string) {
       let locator = new Locator(fullSpecification.defaultLocator, value);
-      let interactor = new InteractorClass(interactorName, fullSpecification, locator as Locator<Element>);
+      let interactor = new InteractorClass(interactorName, fullSpecification, locator);
       return interactor;
     }
 

--- a/packages/interactor/src/define-interactor.ts
+++ b/packages/interactor/src/define-interactor.ts
@@ -9,7 +9,7 @@ export function defineInteractor<E extends Element>(interactorName: string) {
   return function<S extends InteractorSpecification<E>>(specification: Partial<S>) {
     let fullSpecification: InteractorSpecification<Element> = Object.assign({ selector: interactorName }, defaultSpecification, specification);
 
-    let InteractorClass = class extends Interactor<E> {};
+    let InteractorClass = class extends Interactor {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {

--- a/packages/interactor/src/define-interactor.ts
+++ b/packages/interactor/src/define-interactor.ts
@@ -6,10 +6,10 @@ import { converge } from './converge';
 import { defaultOptions } from './options';
 
 export function defineInteractor<E extends Element>(interactorName: string) {
-  return function<S extends InteractorSpecification<E>>(specification: Partial<S>): InteractorType<E, S> {
+  return function<S extends InteractorSpecification<E>>(specification: Partial<S>) {
     let fullSpecification: InteractorSpecification<Element> = Object.assign({ selector: interactorName }, defaultSpecification, specification);
 
-    let InteractorClass = class extends Interactor {};
+    let InteractorClass = class extends Interactor<E> {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {
@@ -27,10 +27,10 @@ export function defineInteractor<E extends Element>(interactorName: string) {
       });
     }
 
-    let result = function(value: string): InteractorInstance<E, S> {
+    let result = function(value: string) {
       let locator = new Locator(fullSpecification.defaultLocator, value);
       let interactor = new InteractorClass(interactorName, fullSpecification, locator as Locator<Element>);
-      return interactor as InteractorInstance<E, S>;
+      return interactor;
     }
 
     for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
@@ -38,7 +38,7 @@ export function defineInteractor<E extends Element>(interactorName: string) {
         value: function(value: string) {
           let locator = new Locator(locatorFn, value, locatorName);
           let interactor = new InteractorClass(interactorName, fullSpecification, locator as Locator<Element>);
-          return interactor as InteractorInstance<E, S>;
+          return interactor;
         },
         configurable: true,
         writable: true,

--- a/packages/interactor/src/define-interactor.ts
+++ b/packages/interactor/src/define-interactor.ts
@@ -1,4 +1,4 @@
-import { defaultSpecification, InteractorSpecification, InteractorInstance, InteractorType } from './specification';
+import { defaultSpecification, InteractorSpecification, InteractorType } from './specification';
 import { Locator } from './locator';
 import { Interactor } from './interactor';
 import { interaction } from './interaction';

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -3,10 +3,10 @@ import { InteractorSpecification } from './specification';
 import { Locator } from './locator';
 import { defaultOptions } from './options';
 import { NoSuchElementError, AmbigousElementError, NotAbsentError } from './errors';
-import { interaction, Interaction } from './interaction';
+import { interaction } from './interaction';
 
-export class Interactor {
-  private ancestors: Interactor[] = [];
+export class Interactor<E extends Element> {
+  private ancestors: Interactor<E>[] = [];
 
   constructor(
     public name: string,
@@ -14,7 +14,7 @@ export class Interactor {
     private locator: Locator<Element>
   ) {}
 
-  find<T extends Interactor>(interactor: T): T {
+  find<T extends Interactor<E>>(interactor: T): T {
     return Object.create(interactor, {
       ancestors: {
         value: [...this.ancestors, this, ...interactor.ancestors]
@@ -28,7 +28,7 @@ export class Interactor {
     }, `${this.name} ${this.locator.description}`);
   }
 
-  private unsafeSyncResolve() {
+  private unsafeSyncResolve(): Element {
     let root = defaultOptions.document?.documentElement;
 
     if(!root) {
@@ -49,13 +49,13 @@ export class Interactor {
     }, root);
   }
 
-  resolve(): Interaction<Element> {
+  resolve(){
     return interaction(`${this.description} resolves`, () => {
       return converge(defaultOptions.timeout, this.unsafeSyncResolve.bind(this));
     });
   }
 
-  exists(): Interaction<true> {
+  exists() {
     return interaction(`${this.description} exists`, () => {
       return converge(defaultOptions.timeout, () => {
         this.unsafeSyncResolve();
@@ -64,7 +64,7 @@ export class Interactor {
     });
   }
 
-  absent(): Interaction<true> {
+  absent() {
     return interaction(`${this.description} does not exist`, () => {
       return converge(defaultOptions.timeout, () => {
         try {

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -14,7 +14,7 @@ export class Interactor<E extends Element> {
     private locator: Locator<Element>
   ) {}
 
-  find<T extends Interactor<E>>(interactor: T): T {
+  find<T extends Interactor<Element>>(interactor: T): T {
     return Object.create(interactor, {
       ancestors: {
         value: [...this.ancestors, this, ...interactor.ancestors]

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -5,8 +5,8 @@ import { defaultOptions } from './options';
 import { NoSuchElementError, AmbigousElementError, NotAbsentError } from './errors';
 import { interaction } from './interaction';
 
-export class Interactor<E extends Element> {
-  private ancestors: Interactor<E>[] = [];
+export class Interactor {
+  private ancestors: Interactor[] = [];
 
   constructor(
     public name: string,
@@ -14,7 +14,7 @@ export class Interactor<E extends Element> {
     private locator: Locator<Element>
   ) {}
 
-  find<T extends Interactor<Element>>(interactor: T): T {
+  find<T extends Interactor>(interactor: T): T {
     return Object.create(interactor, {
       ancestors: {
         value: [...this.ancestors, this, ...interactor.ancestors]

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -24,7 +24,7 @@ export type LocatorImplementation<E extends Element, S extends InteractorSpecifi
   [P in keyof S['locators']]: (value: string) => InteractorInstance<E, S>
 }
 
-export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor & ActionImplementation<E, S>;
+export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E> & ActionImplementation<E, S>;
 
 export type InteractorType<E extends Element, S extends InteractorSpecification<E>> =
   ((value: string) => InteractorInstance<E, S>) &

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -24,7 +24,7 @@ export type LocatorImplementation<E extends Element, S extends InteractorSpecifi
   [P in keyof S['locators']]: (value: string) => InteractorInstance<E, S>
 }
 
-export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E> & ActionImplementation<E, S>;
+export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor & ActionImplementation<E, S>;
 
 export type InteractorType<E extends Element, S extends InteractorSpecification<E>> =
   ((value: string) => InteractorInstance<E, S>) &


### PR DESCRIPTION
Typescript is not a sound type system unfortunately but I generally feel more confident about the code if I can at least satisfy the compiler without explicit casts.  Sometimes you need to but if you can avoid it, you should.

This PR tries to remove as many as possible with my limited knowledge of the code at this time.