### PR TITLE
Fix interactor version to so it doesn't collide with existing versions

### DIFF
--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/interactor",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "description": "Interactors for working with applications",
   "main": "dist/index.js",
   "typings": "dist/index.d.js",


### PR DESCRIPTION
## Motivation

The latest version of `@bigtest/interactor` that is already published is 0.9.3, but we currently have 0.4.1 in the package.json, which collides with an old version. This is preventing us from publishing this new version.

## Approach

Change the version to 0.10.0.