### PR TITLE
Rename subscribe -> liveQuery for live queries

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,7 +36,7 @@ export function * CLI(argv: string[]): Operation {
 
     console.log('Starting test run:', testRunId);
 
-    let subscription = yield client.subscribe(query.testRunResults(testRunId));
+    let subscription = yield client.liveQuery(query.testRunResults(testRunId));
 
     while(true) {
       let { testRun } = yield subscription.receive();
@@ -73,7 +73,7 @@ export function * CLI(argv: string[]): Operation {
 
     console.log('Starting test run:', testRunId);
 
-    let subscription = yield client.subscribe(query.testRunResults(testRunId));
+    let subscription = yield client.liveQuery(query.testRunResults(testRunId));
 
     while(true) {
       let { testRun } = yield subscription.receive();

--- a/packages/server/bin/live-query.ts
+++ b/packages/server/bin/live-query.ts
@@ -6,7 +6,7 @@ main(function* main() {
 
   let [ source ]  = process.argv.slice(2);
 
-  let subscription = yield client.subscribe(source);
+  let subscription = yield client.liveQuery(source);
 
   while (true) {
     let data = yield subscription.receive();

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "ts-node bin/start.ts",
     "query": "ts-node bin/query.ts",
-    "subscribe": "ts-node bin/subscribe.ts",
+    "query:live": "ts-node bin/live-query.ts",
     "lint": "eslint '{src,bin,test}/**/*.ts'",
     "test": "mocha ./test/setup test/**/*.test.ts",
     "mocha": "mocha ./test/setup",

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -32,11 +32,20 @@ export class Client {
   }
 
   *query(source: string): Operation {
-    let subscription = yield this.subscribe(source, false);
+    let subscription = yield this.send("query", source, false);
     return yield subscription.receive();
   }
 
-  *subscribe(source: string, live = true): Operation<Mailbox> {
+  *liveQuery(source: string): Operation {
+    return yield this.send("query", source, true);
+  }
+
+  *mutation(source: string): Operation {
+    let subscription = yield this.send("mutation", source);
+    return yield subscription.receive();
+  }
+
+  private *send(type: string, source: string, live = false): Operation<Mailbox> {
     let mailbox = new Mailbox();
     let { socket } = this;
 
@@ -45,7 +54,7 @@ export class Client {
 
       let responseId = `${responseIds++}`; //we'd want a UUID to avoid hijacking?
 
-      socket.send(JSON.stringify({ query: source, live, responseId}));
+      socket.send(JSON.stringify({ [type]: source, live, responseId}));
 
       while (true) {
         let [event] = yield messages.next();

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -184,14 +184,14 @@ describe('command server', () => {
     });
   });
 
-  describe('subscribing to a query', () => {
+  describe('subscribing to a live query', () => {
     let client: Client;
     let subscription: Mailbox;
     let initial: unknown;
 
     beforeEach(async () => {
       client = await actions.fork(Client.create(`ws://localhost:${COMMAND_PORT}`));
-      subscription = await actions.fork(client.subscribe('{ agents { browser { name } } }'));
+      subscription = await actions.fork(client.liveQuery('{ agents { browser { name } } }'));
       initial = await actions.fork(subscription.receive());
     });
 

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -92,7 +92,7 @@ describe('running tests on an agent', () => {
 
     agent.send({ type: 'connected', agentId, data: {} });
 
-    agentsSubscription = await actions.fork(client.subscribe(`{ agents { agentId } }`));
+    agentsSubscription = await actions.fork(client.liveQuery(`{ agents { agentId } }`));
 
     let match: (params: AgentsQuery) => boolean = ({ agents }) => agents && agents.length === 1;
 
@@ -107,7 +107,7 @@ describe('running tests on an agent', () => {
       await actions.fork(client.query(`mutation { run }`));
 
       runCommand = await actions.fork(agent.receive());
-      results = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, agentId)));
+      results = await actions.fork(client.liveQuery(resultsQuery(runCommand.testRunId, agentId)));
     });
 
     it('receives a run event on the agent', () => {
@@ -411,8 +411,8 @@ describe('running tests on an agent', () => {
       await actions.fork(client.query(`mutation { run }`));
 
       let runCommand: Command = await actions.fork(agent.receive());
-      agentResults = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, agentId)));
-      secondAgentResults = await actions.fork(client.subscribe(resultsQuery(runCommand.testRunId, secondAgentId)));
+      agentResults = await actions.fork(client.liveQuery(resultsQuery(runCommand.testRunId, agentId)));
+      secondAgentResults = await actions.fork(client.liveQuery(resultsQuery(runCommand.testRunId, secondAgentId)));
 
       secondAgent.send({
         type: 'step:result',


### PR DESCRIPTION
We will want to use the subscribe/subscription terminology for actual GraphQL subscriptions.

Extracted from #299 