### PR TITLE
Make atom subcribable

### DIFF
--- a/.changeset/subscribable-atom.md
+++ b/.changeset/subscribable-atom.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": minor
+---
+Make the atom subscribable so that it can be consumed and transformed
+in a regular fashion.

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -29,7 +29,7 @@
     "effection": "^0.6.2"
   },
   "dependencies": {
-    "@effection/events": "^0.6.1",
+    "@effection/events": "^0.7.1",
     "ramda": "0.27.0"
   },
   "volta": {

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@effection/events": "^0.7.1",
+    "@effection/subscription": "^0.7.1",
     "ramda": "0.27.0"
   },
   "volta": {

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -85,8 +85,8 @@ export function handleMessage(delegate: Mailbox, atom: Atom<OrchestratorState>):
     yield socket.send(result);
   }
 
-  function* subscribe(message: QueryMessage, socket: Socket) {
-    yield atom.each(state => publishQueryResult(message, state, socket));
+  function subscribe(message: QueryMessage, socket: Socket): Operation<void> {
+    return atom.each(state => publishQueryResult(message, state, socket));
   }
 
   return function*(socket) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4891,7 +4891,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@0.6.4, effection@^0.6.0, effection@^0.6.2, effection@^0.6.3:
+effection@^0.6.0, effection@^0.6.2, effection@^0.6.3:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.4.tgz#590cbe6c40357acf6c185940fbae2b1434fafcc4"
   integrity sha512-ZzACE6YjtMbM0t0/fov2LkpCDdZffQ0eVI8qdaygQCtYEErVc4VT55AArGKCovQpyevmY5sdMnR9K/rB1wkAwQ==


### PR DESCRIPTION
Motivation
-----------
It's easier to implement the `once` and `each` method using subscriptions.


Approach
----------
This just makes `Atom` subscribable, and then refactors current Atom operations to consume itself as a subscription.

Follow-on Work
--------------

- The `each` method is no longer even needed since it is really just a
  wrapper around `forEach`. It should be deprecated and removed.