### PR TITLE
upgrade @effection/events

### DIFF
--- a/.changeset/upgrade-agent-events.md
+++ b/.changeset/upgrade-agent-events.md
@@ -1,0 +1,9 @@
+---
+"@bigtest/agent": patch
+"@bigtest/cli": patch
+"@bigtest/effection-express": patch
+"@bigtest/parcel": patch
+"@bigtest/server": patch
+---
+
+upgrade version of @effection/events to 0.7.1

--- a/.changeset/upgrade-agent-events.md
+++ b/.changeset/upgrade-agent-events.md
@@ -1,4 +1,5 @@
 ---
+"@bigtest/atom": patch
 "@bigtest/agent": patch
 "@bigtest/cli": patch
 "@bigtest/effection-express": patch

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@bigtest/effection": "^0.4.0",
     "@bigtest/effection-express": "^0.4.1",
-    "@effection/events": "^0.6.1",
+    "@effection/events": "^0.7.1",
     "bowser": "^2.9.0"
   },
   "volta": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@bigtest/todomvc": "^0.1.1",
+    "@effection/events": "^0.7.1",
     "@frontside/tsconfig": "*",
     "@types/capture-console": "1.0.0",
     "@types/json5": "^0.0.30",
@@ -42,7 +43,6 @@
     "@bigtest/effection": "^0.4.0",
     "@bigtest/project": "^0.4.0",
     "@bigtest/server": "^0.4.0",
-    "@effection/events": "^0.6.0",
     "@effection/node": "^0.6.2",
     "capture-console": "^1.0.1",
     "deepmerge": "^4.2.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "bigtest": "dist/bin/bigtest.js"
   },
   "devDependencies": {
-    "@bigtest/todomvc": "^0.1.1",
+    "@bigtest/todomvc": "^0.4.1",
     "@effection/events": "^0.7.1",
     "@frontside/tsconfig": "*",
     "@types/capture-console": "1.0.0",

--- a/packages/cli/test/helpers/stream.ts
+++ b/packages/cli/test/helpers/stream.ts
@@ -15,7 +15,7 @@ export class Stream {
   *run() {
     let events = yield on(this.stream, "data");
     while(true) {
-      let chunk = yield events.next();
+      let { value: chunk } = yield events.next();
       this.output += chunk;
       if(this.verbose) {
         console.debug(chunk.toString());

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -30,7 +30,7 @@
     "effection": "^0.6.2"
   },
   "dependencies": {
-    "@effection/events": "^0.6.1",
+    "@effection/events": "^0.7.1",
     "@types/express-ws": "^3.0.0",
     "@types/node": "^13.13.4",
     "express": "^4.17.1",

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -28,7 +28,7 @@ export class Socket {
       let subscription = yield on(raw, 'message');
 
       while(true) {
-        let [message] = yield subscription.next();
+        let { value: [message] } = yield subscription.next();
         mailbox.send(JSON.parse(message.data));
       }
     });

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@bigtest/effection": "^0.4.0",
-    "@effection/events": "^0.6.1",
+    "@effection/events": "^0.7.1",
     "@effection/node": "^0.6.2",
     "parcel": "^1.12.4",
     "parcel-bundler": "^1.12.4"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -59,7 +59,7 @@
     "@bigtest/parcel": "^0.4.0",
     "@bigtest/suite": "^0.4.0",
     "@bigtest/webdriver": "^0.4.0",
-    "@effection/events": "^0.6.1",
+    "@effection/events": "^0.7.1",
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",
     "chokidar": "^3.3.1",

--- a/packages/server/src/client.ts
+++ b/packages/server/src/client.ts
@@ -57,7 +57,7 @@ export class Client {
       socket.send(JSON.stringify({ [type]: source, live, responseId}));
 
       while (true) {
-        let [event] = yield messages.next();
+        let { value: [event] } = yield messages.next();
         let message: Message = JSON.parse(event.data);
 
         if(message.responseId === responseId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,7 +1341,7 @@
     tar "^2.2.2"
     tar-stream "1.6.2"
 
-"@effection/events@^0.6.0", "@effection/events@^0.6.1":
+"@effection/events@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.6.1.tgz#839aad2303f4c95cf70092bbc62d5992f72e1a26"
   integrity sha512-IdJO10dxoPYtZHAAefEsQ4sXT5jF4gZ+CI/HBPHPVFih2+OJZaNbTg2s5uwufkSk2Kma1jsXl1JaXZ0ruDLIFQ==
@@ -4891,7 +4891,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@^0.6.0, effection@^0.6.2, effection@^0.6.3:
+effection@0.6.4, effection@^0.6.0, effection@^0.6.2, effection@^0.6.3:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.4.tgz#590cbe6c40357acf6c185940fbae2b1434fafcc4"
   integrity sha512-ZzACE6YjtMbM0t0/fov2LkpCDdZffQ0eVI8qdaygQCtYEErVc4VT55AArGKCovQpyevmY5sdMnR9K/rB1wkAwQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,14 +1108,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@bigtest/todomvc@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@bigtest/todomvc/-/todomvc-0.1.1.tgz#a457f8e97babe5c038c183311f59e775af493f89"
-  integrity sha512-CJyzji58rphcxLOxdaWSn/tqykIInj+reiegxuEr+oC0iwe5WWgHTGIitgDbrgnltkyyJ/VP1750SJnSIimNbA==
-  dependencies:
-    effection "^0.6.0"
-    express "^4.17.1"
-
 "@changesets/apply-release-plan@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-3.1.0.tgz#f0d8c4bd45cc65838be2c145186b137fae1d0842"


### PR DESCRIPTION
Motivation
-----------
There was a breaking change between 0.6.4 and 0.7.1 in @effection/events with the `on()` method which meant that we could no longer install these packages outside the monorepo.

Approach
----------
This upgrades all packages to use the same compatible version of @ffection/events and paves the way for a release of packages that's deployable.