### PR TITLE
Fix @bigtest/project deps

### DIFF
--- a/.changeset/fix-project-deps.md
+++ b/.changeset/fix-project-deps.md
@@ -1,0 +1,9 @@
+---
+"@bigtest/project": minor
+---
+
+`@bigtest/project` used to have a peer dependency on
+`@bigtest/webdriver` in order to import some interfaces. We maybe
+shouldn't have used peer dependency in the first place, but now that
+the interfaces have been extracted into `@bigtest/driver` we move the
+dependency there.

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -16,6 +16,9 @@
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
   },
+  "dependencies": {
+    "@bigtest/driver": "^0.4.0"
+  },
   "devDependencies": {
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
@@ -26,8 +29,7 @@
     "ts-node": "*"
   },
   "peerDependencies": {
-    "effection": "^0.6.2",
-    "@bigtest/webdriver": "^0.4.0"
+    "effection": "^0.6.2"
   },
   "volta": {
     "node": "12.16.0",


### PR DESCRIPTION
`@bigtest/project` used to have a peer dependency on `@bigtest/webdriver` in order to import some interfaces. We maybe shouldn't have used peer dependency in the first place, but now that the interfaces have been extracted into `@bigtest/driver` there is no dependency at all on webdriver, so let's make it a hard dependency on just the abstract package.