### PR TITLE
make @bigtest/project a dependency (not peer) of server

### DIFF
--- a/.changeset/fix-server-deps.md
+++ b/.changeset/fix-server-deps.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+make @bigtest/project a dependency, not peer dependency

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -42,8 +42,7 @@
     "typescript": "^3.6.3"
   },
   "peerDependencies": {
-    "effection": "^0.6.2",
-    "@bigtest/project": "^0.4.0"
+    "effection": "^0.6.2"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-0",
@@ -56,6 +55,7 @@
     "@bigtest/effection-express": "^0.4.0",
     "@bigtest/logging": "^0.4.0",
     "@bigtest/parcel": "^0.4.0",
+    "@bigtest/project": "^0.4.0",
     "@bigtest/suite": "^0.4.0",
     "@bigtest/webdriver": "^0.4.0",
     "@effection/events": "^0.7.1",


### PR DESCRIPTION
@bigtest/server only uses the `ProjectOptions` interface from `@bigtest/project` and so it doesn't even have any runtime consequences.

This moves the dependency to be a hard dependency (since server does
re-export the ProjectOptions interface)