### PR TITLE
upgrade effection

### DIFF
--- a/.changeset/upgrade-effection.md
+++ b/.changeset/upgrade-effection.md
@@ -1,0 +1,18 @@
+---
+"@bigtest/agent": patch
+"@bigtest/atom": patch
+"@bigtest/cli": patch
+"@bigtest/fetch": patch
+"@bigtest/effection": patch
+"@bigtest/effection-express": patch
+"@bigtest/interactor": patch
+"@bigtest/logging": patch
+"@bigtest/parcel": patch
+"@bigtest/project": patch
+"@bigtest/server": patch
+"@bigtest/suite": patch
+"@bigtest/todomvc": patch
+"@bigtest/webdriver": patch
+---
+
+upgrade effection

--- a/package.json
+++ b/package.json
@@ -46,8 +46,5 @@
     "eslint": "^6.6.0",
     "eslint-plugin-prefer-let": "^1.0.1",
     "typescript": "^3.7.0"
-  },
-  "resolutions": {
-    "**/effection": "0.6.4"
   }
 }

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -30,7 +30,6 @@
     "@types/node-fetch": "^2.5.4",
     "assert": "^2.0.0",
     "classnames": "^2.2.5",
-    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "express": "^4.17.1",
     "mocha": "^6.2.2",
@@ -41,13 +40,11 @@
     "ts-node": "*",
     "typescript": "^3.7.0"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
-  },
   "dependencies": {
+    "effection": "^0.7.0",
     "@bigtest/effection": "^0.5.0",
     "@bigtest/effection-express": "^0.5.0",
-    "@effection/events": "^0.7.1",
+    "@effection/events": "^0.7.4",
     "bowser": "^2.9.0"
   },
   "volta": {

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -25,12 +25,10 @@
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
-  },
   "dependencies": {
-    "@effection/events": "^0.7.1",
-    "@effection/subscription": "^0.7.1",
+    "effection": "0.7.0",
+    "@effection/events": "^0.7.4",
+    "@effection/subscription": "^0.7.2",
     "ramda": "0.27.0"
   },
   "volta": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "@bigtest/cli",
   "version": "0.5.0",
@@ -23,7 +24,7 @@
   },
   "devDependencies": {
     "@bigtest/todomvc": "^0.5.0",
-    "@effection/events": "^0.7.1",
+    "@effection/events": "^0.7.4",
     "@frontside/tsconfig": "*",
     "@types/capture-console": "1.0.0",
     "@types/json5": "^0.0.30",
@@ -43,10 +44,10 @@
     "@bigtest/effection": "^0.5.0",
     "@bigtest/project": "^0.5.0",
     "@bigtest/server": "^0.5.0",
-    "@effection/node": "^0.6.4",
+    "@effection/node": "^0.6.5",
     "capture-console": "^1.0.1",
     "deepmerge": "^4.2.2",
-    "effection": "^0.6.2",
+    "effection": "^0.7.0",
     "json5": "^2.1.3"
   },
   "volta": {

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -20,13 +20,12 @@
     "@frontside/tsconfig": "^0.0.1",
     "@types/mocha": "^7.0.1",
     "@types/node": "^14.0.11",
-    "effection": "^0.6.3",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*",
     "typescript": "^3.9.5"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
+  "dependencies": {
+    "effection": "^0.7.0"
   }
 }

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -21,18 +21,15 @@
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
-    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
-  },
   "dependencies": {
-    "@effection/events": "^0.7.1",
+    "@effection/events": "^0.7.4",
     "@types/express-ws": "^3.0.0",
     "@types/node": "^13.13.4",
+    "effection": "^0.7.0",
     "express": "^4.17.1",
     "express-ws": "^4.0.0"
   },

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -21,16 +21,13 @@
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
-    "effection": "^0.6.0",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
-  },
   "dependencies": {
-    "@effection/events": "^0.7.1",
+    "effection": "^0.7.0",
+    "@effection/events": "^0.7.4",
     "@types/node": "^13.13.4"
   },
   "volta": {

--- a/packages/parcel/package.json
+++ b/packages/parcel/package.json
@@ -19,13 +19,11 @@
   },
   "dependencies": {
     "@bigtest/effection": "^0.5.0",
-    "@effection/events": "^0.7.1",
-    "@effection/node": "^0.6.2",
+    "@effection/events": "^0.7.4",
+    "@effection/node": "^0.6.5",
+    "effection": "^0.7.0",
     "parcel": "^1.12.4",
     "parcel-bundler": "^1.12.4"
-  },
-  "peerDependencies": {
-    "effection": "^0.6.2"
   },
   "volta": {
     "node": "12.16.0",
@@ -35,7 +33,6 @@
     "@frontside/tsconfig": "*",
     "@types/node": "^13.13.4",
     "@types/parcel-bundler": "^1.12.1",
-    "effection": "^0.6.2",
     "expect": "^25.1.0",
     "yargs": "^15.3.0"
   }

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -17,19 +17,16 @@
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
   },
   "dependencies": {
-    "@bigtest/driver": "^0.5.0"
+    "@bigtest/driver": "^0.5.0",
+    "effection": "^0.7.0"
   },
   "devDependencies": {
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
-    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
-  },
-  "peerDependencies": {
-    "effection": "^0.6.2"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,15 +34,11 @@
     "@types/rimraf": "3.0.0",
     "@types/websocket": "^1.0.0",
     "abort-controller": "^3.0.0",
-    "effection": "^0.6.2",
     "expect": "^24.9.0",
     "mocha": "^6.2.2",
     "node-fetch": "^2.6.0",
     "ts-node": "^8.9.1",
     "typescript": "^3.6.3"
-  },
-  "peerDependencies": {
-    "effection": "^0.6.2"
   },
   "dependencies": {
     "@babel/core": "^7.0.0-0",
@@ -58,11 +54,12 @@
     "@bigtest/project": "^0.5.0",
     "@bigtest/suite": "^0.5.0",
     "@bigtest/webdriver": "^0.5.0",
-    "@effection/events": "^0.7.1",
-    "@effection/node": "^0.6.4",
+    "@effection/events": "^0.7.4",
+    "@effection/node": "^0.6.5",
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",
     "chokidar": "^3.3.1",
+    "effection": "^0.7.0",
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
     "fprint": "^2.0.1",

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -39,9 +39,9 @@
     "webpack": "4.41.2"
   },
   "dependencies": {
-    "effection": "^0.6.2",
+    "effection": "^0.7.0",
     "@bigtest/effection-express": "^0.5.0",
-    "@effection/node": "^0.6.2",
+    "@effection/node": "^0.6.5",
     "express": "^4.17.1"
   },
   "volta": {

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -25,15 +25,13 @@
     "mocha": "^6.2.2",
     "ts-node": "*"
   },
-  "peerDependencies": {
-    "effection": "^0.6.2"
-  },
   "dependencies": {
     "@bigtest/atom": "^0.5.0",
     "@bigtest/driver": "^0.5.0",
-    "@effection/node": "^0.6.2",
+    "@effection/node": "^0.6.5",
     "abort-controller": "^3.0.0",
     "chromedriver": "~83.0.0",
+    "effection": "^0.7.0",
     "geckodriver": "^1.19.1",
     "node-fetch": "^2.6.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,36 +1333,28 @@
     tar "^2.2.2"
     tar-stream "1.6.2"
 
-"@effection/events@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.6.1.tgz#839aad2303f4c95cf70092bbc62d5992f72e1a26"
-  integrity sha512-IdJO10dxoPYtZHAAefEsQ4sXT5jF4gZ+CI/HBPHPVFih2+OJZaNbTg2s5uwufkSk2Kma1jsXl1JaXZ0ruDLIFQ==
-
-"@effection/events@^0.7.1", "@effection/events@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.7.3.tgz#2df633df29417b6f8279d061e908ef5c4970b993"
-  integrity sha512-Lf83FUhQ6zTbygcVohoSrBLG+5W6GMhjPPNKilKywImO53Uc9qftDveLgHv+6ypLbybxP/eRtZLpzhq2Jnc+Jg==
+"@effection/events@^0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.7.4.tgz#13a3a0789f29c5df5bee121ff336ac7e9bb11a5f"
+  integrity sha512-lfO2RNCi1KpAv61OeNqztCufM1L/X390KkLC4vCnzvoxVT11uwi+qnK/v9tc4WsowKDCL/0Vj86bB70RnQ8rng==
   dependencies:
-    "@effection/subscription" "^0.7.1"
+    "@effection/subscription" "^0.7.2"
+    effection "^0.7.0"
 
-"@effection/node@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@effection/node/-/node-0.6.2.tgz#69aa57683e13dd990864de1e4ae37f138f4dbdf8"
-  integrity sha512-FB4Tck9Nub/1eJZoClvWpr1TVUpkduk+UTx+gNjSAgY30VAncVaxr0o6KaGfbtyzWDpmi9NhtB8YO0/ur7EDfQ==
+"@effection/node@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@effection/node/-/node-0.6.5.tgz#936487d04f4f734b4d6e5604d881b202732b165f"
+  integrity sha512-9Ke85fVLQDHc0JNKqfizrMqs4a5rDjz1SNDlyIoNZqcYGajr5ETzK75Z7UcxK1iO6MsUcoeoH6SJoEkXJcHjQg==
   dependencies:
-    "@effection/events" "^0.6.0"
+    "@effection/events" "^0.7.4"
+    effection "^0.7.0"
 
-"@effection/node@^0.6.4":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@effection/node/-/node-0.6.4.tgz#65b4818eaee1ea55fbe642aaad77cd53e261317c"
-  integrity sha512-X+2iAlnY9JkNjgyw3Xh1BSYCLoLVpDIITUTygULykDrP4i6Wcc4H6CD4X+qilTCOl5hT7VBqlUCLuIo3q8Hqwg==
+"@effection/subscription@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@effection/subscription/-/subscription-0.7.2.tgz#1510d2844d979d67af36bbc5b19425ce73ab5f37"
+  integrity sha512-BdYyq3jdr0vZXjKHBl/Uu9TUvzGaEKqxU45Su/hYUZvO2uoIZkQwxMxsKA/ol9tOXzvzzhEHYdQlmJJ5mN9U3Q==
   dependencies:
-    "@effection/events" "^0.7.3"
-
-"@effection/subscription@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@effection/subscription/-/subscription-0.7.1.tgz#fdc66c1978af594b3e76fb091a62b7268223d0fc"
-  integrity sha512-hSJM6tNYPPxo/+jm6usFHJe8C68gZXN633A5duRTG2fTUCSzU0jhfKsQZMwC4g1SYJ5Z3vVGXKMUZgfPHeHC6g==
+    effection "^0.7.0"
 
 "@frontside/eslint-config@^1.0.0":
   version "1.0.0"
@@ -4890,10 +4882,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-effection@0.6.4, effection@^0.6.0, effection@^0.6.2, effection@^0.6.3:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.4.tgz#590cbe6c40357acf6c185940fbae2b1434fafcc4"
-  integrity sha512-ZzACE6YjtMbM0t0/fov2LkpCDdZffQ0eVI8qdaygQCtYEErVc4VT55AArGKCovQpyevmY5sdMnR9K/rB1wkAwQ==
+effection@0.7.0, effection@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-0.7.0.tgz#9cdb74d075021af0715c18124038d3b0dca01363"
+  integrity sha512-p9Y1YiFI/WH5L1DzGJg/RFPFQgpXyHd1xKvGpFkzR8ah/nUGdcDtXHavj9wJgPpuHtxM2ef5YPXA7ySMmuEa1w==
 
 electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.413:
   version "1.3.425"


### PR DESCRIPTION
Motivation
-----------

We recently changed effection to use a [unique symbol][1] which should make the need to have it as a peer dependency everywhere obsolete. 

Approach
----------
This upgrade effection to the "universal symbol" version and then upgrades all bigtest packages to consume that version as a normal dependency.