### PR TITLE
Split `AgentEvent` type into a union of two types

### DIFF
--- a/.changeset/agentevent-type.md
+++ b/.changeset/agentevent-type.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/agent": patch
+---
+
+Split `AgentEvent` type into a union of two types

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -69,7 +69,9 @@ export interface AssertionResult {
   error?: ErrorDetails;
 }
 
-export type AgentEvent = Connect | RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;
+export type TestEvent = RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;
+
+export type AgentEvent = Connect | TestEvent;
 
 export type Command = Run;
 


### PR DESCRIPTION
## Motivation

We need an interface pertinent to the test run, without meta data.

## Approach

Split `AgentEvent` into two types, `AgentEvent` and `TestEvent`, where `TestEvent` contains the data relevant to the test run.