### PR TITLE
GraphQL subscriptions for test events

### DIFF
--- a/.changeset/atom-set-max-listeners.md
+++ b/.changeset/atom-set-max-listeners.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": patch
+---
+
+Can set max listeners on atom

--- a/.changeset/atom-subscribable-slice.md
+++ b/.changeset/atom-subscribable-slice.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": patch
+---
+
+Make slice subscribable

--- a/.changeset/graphql-subscriptions.md
+++ b/.changeset/graphql-subscriptions.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/server": minor
+---
+Add GraphQL subscriptions for streaming results of a test run

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -67,6 +67,7 @@ export interface AssertionResult {
   testRunId: string;
   path: string[];
   error?: ErrorDetails;
+  timeout?: boolean;
 }
 
 export type TestEvent = RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -48,6 +48,10 @@ export class Atom<S> implements Subscribable<S,void> {
     return this.states.filter(predicate).first();
   }
 
+  setMaxListeners(value: number) {
+    this.subscriptions.setMaxListeners(value);
+  }
+
   [SymbolSubscribable]() {
     return this.states[SymbolSubscribable]();
   }

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import { Operation, spawn, fork } from 'effection';
 import { Mailbox } from '@bigtest/effection';
 import { express, Socket } from '@bigtest/effection-express';

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -1,14 +1,16 @@
+import { EventEmitter } from 'events';
 import { Operation, spawn, fork } from 'effection';
 import { Mailbox } from '@bigtest/effection';
 import { express, Socket } from '@bigtest/effection-express';
 import * as graphqlHTTP from 'express-graphql';
-import { graphql as executeGraphql } from 'graphql';
+import { parse as parseGraphql, graphql as executeGraphql, subscribe as executeGraphqlSubscription, ExecutionResult } from 'graphql';
 
 import { schema } from './schema';
+import { GraphqlContext, SpawnContext } from './schema/context';
 import { Atom } from '@bigtest/atom';
 import { OrchestratorState } from './orchestrator/state';
 
-import { Message, QueryMessage, MutationMessage, isQuery, isMutation } from './protocol';
+import { Message, Response, QueryMessage, MutationMessage, SubscriptionMessage, isQuery, isMutation, isSubscription } from './protocol';
 
 export type CommandMessage = { status: "ready" } | { type: "run"; id: string };
 
@@ -18,16 +20,21 @@ interface CommandServerOptions {
   port: number;
 };
 
+function isAsyncIterator(value: AsyncIterableIterator<unknown> | ExecutionResult<unknown>): value is AsyncIterableIterator<unknown> {
+  return value && ("next" in value) && typeof(value["next"]) === 'function';
+}
+
 export function* createCommandServer(options: CommandServerOptions): Operation {
   let app = express();
 
-  yield app.ws('*', handleMessage(options.delegate, options.atom));
+  yield app.ws('*', handleMessage(options));
 
-  yield spawn(({ spawn }) => {
-    app.raw.use(graphqlHTTP(async () => await spawn(function* getOptionsData() {
-      return { ...graphqlOptions(options.delegate, options.atom.get()), graphiql: true};
-    })));
-  });
+  let outerContext: SpawnContext = yield spawn(undefined);
+
+  app.raw.use(graphqlHTTP(async () => await outerContext.spawn(function* getOptionsData() {
+    let innerContext = yield spawn(undefined);
+    return { ...graphqlOptions(innerContext, options, options.atom.get()), graphiql: true};
+  })));
 
   yield app.listen(options.port);
 
@@ -40,53 +47,75 @@ export function* createCommandServer(options: CommandServerOptions): Operation {
  * Run the query or mutation in `source` against the orchestrator
  * state contained in `state`
  */
-export function graphql(source: string, delegate: Mailbox, state: OrchestratorState): Operation {
-  let options = graphqlOptions(delegate, state);
-  return executeGraphql({...options, contextValue: options.context, source });
+function* graphql(source: string, options: CommandServerOptions, state: OrchestratorState): Operation {
+  let context: SpawnContext = yield spawn(undefined);
+  let opts = graphqlOptions(context, options, state);
+  return yield executeGraphql({...opts, contextValue: opts.context, source });
 }
-
-let testRunIds = (function * () {
-  for (let current = 1; ; current++) {
-    yield `TestRun:${current}`;
-  }
-})()
 
 /**
  * Get the graphql options for running a query against `state`. Needed
  * because the express graphql server calls the `graphql` function for
  * you based on the .
  */
-export function graphqlOptions(delegate: Mailbox, state: OrchestratorState) {
+function graphqlOptions(context: SpawnContext, options: CommandServerOptions, state: OrchestratorState) {
   return {
     schema,
     rootValue: state,
-    context: { delegate, testRunIds }
+    context: new GraphqlContext(context, options.atom, options.delegate)
   };
 }
 
-export function handleMessage(delegate: Mailbox, atom: Atom<OrchestratorState>): (socket: Socket) => Operation {
+function handleMessage(options: CommandServerOptions): (socket: Socket) => Operation {
   function* handleQuery(message: QueryMessage, socket: Socket): Operation {
-    yield publishQueryResult(message, atom.get(), socket);
+    yield publishQueryResult(message, options.atom.get(), socket);
 
     if (message.live) {
-      yield fork(subscribe(message, socket));
+      yield fork(options.atom.each(state => publishQueryResult(message, state, socket)));
     }
   }
 
   function* handleMutation(message: MutationMessage, socket: Socket): Operation {
-    let result = yield graphql(message.mutation, delegate, atom.get());
+    let result: Response = yield graphql(message.mutation, options, options.atom.get());
     result.responseId = message.responseId;
     yield socket.send(result);
+  }
+
+  function* handleSubscription(message: SubscriptionMessage, socket: Socket): Operation {
+    let context: SpawnContext = yield spawn(undefined);
+
+    let result = yield executeGraphqlSubscription({
+      schema,
+      document: parseGraphql(message.subscription),
+      contextValue: new GraphqlContext(context, options.atom, options.delegate)
+    });
+
+    if(isAsyncIterator(result)) {
+      try {
+        while(true) {
+          let next = yield result.next();
+
+          if(next.done) {
+            yield socket.send({ done: true, responseId: message.responseId });
+            break;
+          } else {
+            next.value.responseId = message.responseId;
+            yield socket.send(next.value);
+          }
+        }
+      } finally {
+        result.return && result.return();
+      }
+    } else {
+      result.responseId = message.responseId;
+      yield socket.send(result);
+    }
   }
 
   function* publishQueryResult(message: QueryMessage, state: OrchestratorState, socket: Socket): Operation {
-    let result = yield graphql(message.query, delegate, state);
+    let result: Response = yield graphql(message.query, options, state);
     result.responseId = message.responseId;
     yield socket.send(result);
-  }
-
-  function subscribe(message: QueryMessage, socket: Socket): Operation<void> {
-    return atom.each(state => publishQueryResult(message, state, socket));
   }
 
   return function*(socket) {
@@ -97,6 +126,9 @@ export function handleMessage(delegate: Mailbox, atom: Atom<OrchestratorState>):
 
       if (isQuery(message)) {
         yield fork(handleQuery(message, socket));
+      }
+      if (isSubscription(message)) {
+        yield fork(handleSubscription(message, socket));
       }
       if (isMutation(message)) {
         yield fork(handleMutation(message, socket));

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -1,14 +1,18 @@
 import { Atom } from "@bigtest/atom";
 import { OrchestratorState } from "./state";
 
-export const createOrchestratorAtom = () => new Atom<OrchestratorState>({
-  manifest: {
-    description: "None",
-    fileName: "<init>",
-    steps: [],
-    assertions: [],
-    children: [],
-  },
-  agents: {},
-  testRuns: {},
-});
+export const createOrchestratorAtom = () => {
+  let atom = new Atom<OrchestratorState>({
+    manifest: {
+      description: "None",
+      fileName: "<init>",
+      steps: [],
+      assertions: [],
+      children: [],
+    },
+    agents: {},
+    testRuns: {},
+  });
+  atom.setMaxListeners(100000);
+  return atom;
+}

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -2,20 +2,20 @@ import { Test, TestResult, ResultStatus } from '@bigtest/suite';
 
 export type AgentState = {
   agentId: string;
-  browser: {
+  browser?: {
     name: string;
     version: string;
   };
-  os: {
+  os?: {
     name: string;
     version: string;
     versionName: string;
   };
-  platform: {
+  platform?: {
     type: string;
     vendor: string;
   };
-  engine: {
+  engine?: {
     name: string;
     version: string;
   };

--- a/packages/server/src/protocol.ts
+++ b/packages/server/src/protocol.ts
@@ -1,9 +1,15 @@
 export interface Message {
-  responseId?: string;
   query?: string;
   mutation?: string;
+  subscription?: string;
+  responseId?: string;
+}
+
+export interface Response {
+  done?: boolean;
   data?: unknown;
   errors?: Array<{ message: string }>;
+  responseId?: string;
 }
 
 export interface QueryMessage extends Message {
@@ -11,15 +17,23 @@ export interface QueryMessage extends Message {
   live?: boolean;
 }
 
+export interface SubscriptionMessage extends Message {
+  subscription: string;
+}
+
 export interface MutationMessage extends Message {
   mutation: string;
 }
 
-export interface DataResponse extends Message {
+export interface DataResponse extends Response {
   data: unknown;
 }
 
-export interface ErrorResponse extends Message {
+export interface DoneResponse extends Response {
+  done: true;
+}
+
+export interface ErrorResponse extends Response {
   errors: Array<{ message: string }>;
 }
 
@@ -27,14 +41,22 @@ export function isQuery(message: Message): message is QueryMessage {
   return !!message['query'];
 }
 
+export function isSubscription(message: Message): message is SubscriptionMessage {
+  return !!message['subscription'];
+}
+
 export function isMutation(message: Message): message is MutationMessage {
   return !!message['mutation'];
 }
 
-export function isDataResponse(message: Message): message is DataResponse {
+export function isDataResponse(message: Response): message is DataResponse {
   return !!message['data'];
 }
 
-export function isErrorResponse(message: Message): message is ErrorResponse {
+export function isDoneResponse(message: Response): message is DoneResponse {
+  return !!message['done'];
+}
+
+export function isErrorResponse(message: Response): message is ErrorResponse {
   return !!message['errors'];
 }

--- a/packages/server/src/result-aggregator/assertion.ts
+++ b/packages/server/src/result-aggregator/assertion.ts
@@ -27,7 +27,7 @@ export class AssertionAggregator extends Aggregator<AssertionResult, AggregatorT
   *perform(): Operation<ResultStatus> {
     let result: AssertionResultEvent = yield this.receiveResult();
 
-    this.statusSlice.set(result.status);
+    this.slice.update((s) => ({ ...s, status: result.status, error: result.error, timeout: result.timeout }));
 
     return result.status;
   }

--- a/packages/server/src/result-aggregator/step.ts
+++ b/packages/server/src/result-aggregator/step.ts
@@ -27,7 +27,7 @@ export class StepAggregator extends Aggregator<StepResult, AggregatorTestOptions
   *perform(): Operation<ResultStatus> {
     let result: StepResultEvent = yield this.receiveResult();
 
-    this.statusSlice.set(result.status);
+    this.slice.update((s) => ({ ...s, status: result.status, error: result.error, timeout: result.timeout }));
 
     if (result.status === 'failed') {
       throw new Error('Step Failed');

--- a/packages/server/src/result-stream.ts
+++ b/packages/server/src/result-stream.ts
@@ -30,6 +30,7 @@ export interface StreamerTestOptions extends StreamerAgentOptions {
   path: string[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function* streamResults(type: string, slice: Slice<any, OrchestratorState>, publish: Publish, options: StreamerOptions): Operation<void> {
   let statusSlice = slice.slice<ResultStatus>(['status']);
   let previousStatus = statusSlice.get();

--- a/packages/server/src/result-stream.ts
+++ b/packages/server/src/result-stream.ts
@@ -1,0 +1,112 @@
+import { Operation, fork } from 'effection';
+import { Slice } from '@bigtest/atom';
+import { Subscribable, SymbolSubscribable, Subscription, createSubscription } from '@effection/subscription';
+import { TestResult, StepResult, AssertionResult, ResultStatus } from '@bigtest/suite';
+import { OrchestratorState, TestRunState, TestRunAgentState } from './orchestrator/state';
+import { TestEvent } from './schema/test-event';
+
+type Publish = (event: TestEvent) => void;
+
+export function* resultStream(testRunId: string, slice: Slice<TestRunState, OrchestratorState>): Operation<Subscription<TestEvent, void>> {
+  return yield createSubscription(function*(publish) {
+    // TODO: if we have `once` on slice, we should use it here.
+    if(!slice.get()) {
+      yield Subscribable.from(slice).match({ status: "pending" }).first();
+    }
+
+    yield streamTestRun(slice, publish, { testRunId });
+  });
+}
+
+export interface StreamerOptions {
+  testRunId: string;
+}
+
+export interface StreamerAgentOptions extends StreamerOptions {
+  agentId: string;
+}
+
+export interface StreamerTestOptions extends StreamerAgentOptions {
+  path: string[];
+}
+
+function* streamResults(type: string, slice: Slice<any, OrchestratorState>, publish: Publish, options: StreamerOptions): Operation<void> {
+  let statusSlice = slice.slice<ResultStatus>(['status']);
+  let previousStatus = statusSlice.get();
+
+  let subscription = yield statusSlice[SymbolSubscribable]();
+  while(true) {
+    let { value: status } = yield subscription.next();
+    if(status !== previousStatus) {
+      if(status === 'pending') {
+        // do nothing
+      } else if(status === 'running') {
+        publish({
+          type: `${type}:running`,
+          ...options,
+        } as TestEvent);
+      } else {
+        publish({
+          type: `${type}:result`,
+          status: status,
+          error: slice.get().error,
+          timeout: slice.get().timeout,
+          ...options,
+        } as TestEvent);
+        return;
+      }
+      previousStatus = status;
+    }
+  };
+}
+
+function* streamTestRun(slice: Slice<TestRunState, OrchestratorState>, publish: Publish, options: StreamerOptions): Operation<void> {
+  for(let agentId in slice.get().agents) {
+    let testRunAgentSlice = slice.slice<TestRunAgentState>(['agents', agentId]);
+    yield fork(streamTestRunAgent(testRunAgentSlice, publish, { agentId, ...options }));
+  };
+  yield streamResults('testRun', slice, publish, options);
+}
+
+function* streamTestRunAgent(slice: Slice<TestRunAgentState, OrchestratorState>, publish: Publish, options: StreamerAgentOptions): Operation<void> {
+  let testResultSlice = slice.slice<TestResult>(['result']);
+
+  yield fork(streamTest(testResultSlice, publish, {
+    ...options,
+    path: [testResultSlice.get().description],
+  }));
+  yield streamResults('testRunAgent', slice, publish, options);
+}
+
+function* streamTest(slice: Slice<TestResult, OrchestratorState>, publish: Publish, options: StreamerTestOptions): Operation<void> {
+  for(let [index, step] of Object.entries(slice.get().steps)) {
+    let stepSlice = slice.slice<StepResult>(['steps', index]);
+    yield fork(streamStep(stepSlice, publish, {
+      ...options,
+      path: options.path.concat(step.description),
+    }));
+  }
+  for(let [index, assertion] of Object.entries(slice.get().assertions)) {
+    let assertionSlice = slice.slice<AssertionResult>(['assertions', index]);
+    yield fork(streamAssertion(assertionSlice, publish, {
+      ...options,
+      path: options.path.concat(assertion.description),
+    }));
+  }
+  for(let [index, child] of Object.entries(slice.get().children)) {
+    let childSlice = slice.slice<TestResult>(['children', index]);
+    yield fork(streamTest(childSlice, publish, {
+      ...options,
+      path: options.path.concat(child.description),
+    }));
+  }
+  yield streamResults('test', slice, publish, options);
+}
+
+function* streamStep(slice: Slice<StepResult, OrchestratorState>, publish: Publish, options: StreamerTestOptions): Operation<void> {
+  yield streamResults('step', slice, publish, options)
+}
+
+function* streamAssertion(slice: Slice<AssertionResult, OrchestratorState>, publish: Publish, options: StreamerTestOptions): Operation<void> {
+  yield streamResults('assertion', slice, publish, options)
+}

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -104,18 +104,20 @@ export const schema = makeSchema({
       definition(t) {
         t.id("agentId");
         t.field("os", {
+          nullable: true,
           type: "OS"
         });
         t.field("platform", {
+          nullable: true,
           type: "Platform"
         })
         t.field("browser", {
-          type: "Browser",
           nullable: true,
+          type: "Browser",
         });
         t.field("engine", {
-          type: "Engine",
-          nullable: true
+          nullable: true,
+          type: "Engine"
         })
       }
     }),
@@ -255,10 +257,10 @@ export const schema = makeSchema({
       name: "Error",
       definition(t) {
         t.string("message");
-        t.string("fileName");
-        t.int("lineNumber");
-        t.int("columnNumber");
-        t.string("stack");
+        t.string("fileName", { nullable: true });
+        t.int("lineNumber", { nullable: true });
+        t.int("columnNumber", { nullable: true });
+        t.string("stack", { nullable: true });
       }
     })
   ]

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,7 +1,59 @@
+import { Operation, Context, Controls, contextOf } from 'effection';
+import { EventEmitter } from 'events';
 import { Mailbox } from '@bigtest/effection';
+import { on } from '@effection/events';
+import { Subscription } from '@effection/subscription';
+import { Atom } from '@bigtest/atom';
 import { CommandMessage } from '../command-server';
+import { resultStream } from '../result-stream';
+import { TestEvent } from './test-event';
+import { OrchestratorState, TestRunState } from '../orchestrator/state';
 
-export interface GraphqlContext {
-  delegate: Mailbox<CommandMessage>;
-  testRunIds: Iterator<string, never, void>;
+let testRunIds = (function * () {
+  for (let current = 1; ; current++) {
+    yield `TestRun:${current}`;
+  }
+})();
+
+export interface Spawner {
+  spawn<T>(operation: Operation<T>): Context<T>;
+}
+
+export type SpawnContext = Context<unknown> & Spawner;
+
+export class GraphqlContext {
+  public testRunIds = testRunIds;
+
+  constructor(private context: SpawnContext, private atom: Atom<OrchestratorState>, private delegate: Mailbox<CommandMessage>) {}
+
+  runTest(): string {
+    let { value: id } = this.testRunIds.next();
+
+    this.delegate.send({ type: "run", id });
+
+    return id;
+  }
+
+  async *runTestSubscribe(): AsyncIterator<TestEvent> {
+    let id = this.runTest();
+
+    let slice = this.atom.slice<TestRunState>(['testRuns', id]);
+
+    let scope = this.context.spawn(undefined) as Context & Controls;
+
+    let subscription = await scope.spawn(resultStream(id, slice))
+
+    try {
+      while(true) {
+        let iter = await this.context.spawn(subscription.next());
+        if(iter.done) {
+          break;
+        } else {
+          yield iter.value;
+        }
+      }
+    } finally {
+      scope.halt();
+    }
+  }
 }

--- a/packages/server/src/schema/context.ts
+++ b/packages/server/src/schema/context.ts
@@ -1,8 +1,5 @@
-import { Operation, Context, Controls, contextOf } from 'effection';
-import { EventEmitter } from 'events';
+import { Operation, Context, Controls } from 'effection';
 import { Mailbox } from '@bigtest/effection';
-import { on } from '@effection/events';
-import { Subscription } from '@effection/subscription';
 import { Atom } from '@bigtest/atom';
 import { CommandMessage } from '../command-server';
 import { resultStream } from '../result-stream';

--- a/packages/server/src/schema/test-event.ts
+++ b/packages/server/src/schema/test-event.ts
@@ -1,0 +1,22 @@
+// this just re-exports so it can be used from the schema
+import { TestEvent as AgentTestEvent } from '@bigtest/agent';
+import { ResultStatus } from '@bigtest/suite';
+
+export interface TestRunResult {
+  type: 'testRun:result';
+  status: ResultStatus;
+  testRunId: string;
+}
+
+export interface TestResult {
+  type: 'test:result';
+  status: ResultStatus;
+  testRunId: string;
+  agentId: string;
+  path: string[];
+}
+
+export type TestEvent =
+  TestRunResult |
+  TestResult |
+  (AgentTestEvent & { agentId: string });

--- a/packages/server/test/result-stream.test.ts
+++ b/packages/server/test/result-stream.test.ts
@@ -1,0 +1,370 @@
+import { describe, beforeEach, it } from 'mocha';
+import * as expect from 'expect';
+
+import { Subscription } from '@effection/subscription';
+
+import { Atom, Slice } from '@bigtest/atom';
+import { ResultStatus, StepResult } from '@bigtest/suite';
+
+import { resultStream } from '../src/result-stream';
+import { createOrchestratorAtom } from '../src/orchestrator/atom';
+import { OrchestratorState, TestRunState } from '../src/orchestrator/state';
+import { TestEvent } from '../src/schema/test-event';
+
+import { actions } from './helpers';
+
+describe('result stream', () => {
+  let atom: Atom<OrchestratorState>;
+  let slice: Slice<TestRunState, OrchestratorState>;
+  let subscription: Subscription<TestEvent, void>;
+
+  beforeEach(async () => {
+    atom = createOrchestratorAtom();
+    slice = atom.slice<TestRunState>(['testRuns', 'test-run-1']);
+    slice.set({
+      testRunId: 'test-run-1',
+      status: 'pending',
+      agents: {
+        "agent-1": {
+          status: 'pending',
+          agent: { agentId: 'agent-1' },
+          result: {
+            description: 'some test',
+            status: 'pending',
+            steps: [
+              { description: 'step one', status: 'pending' },
+              { description: 'step two', status: 'pending' }
+            ],
+            assertions: [
+              { description: 'assertion one', status: 'pending' },
+              { description: 'assertion two', status: 'pending' }
+            ],
+            children: [
+              {
+                description: 'another test',
+                status: 'pending',
+                steps: [
+                  { description: 'a child step', status: 'pending' }
+                ],
+                assertions: [
+                  { description: 'a child assertion', status: 'pending' }
+                ],
+                children: []
+              }
+            ]
+          }
+        }
+      }
+    });
+
+    subscription = await actions.fork(resultStream('test-run-1', slice));
+  });
+
+  describe('steps', () => {
+    describe('marking a step as running', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'steps', 0, 'status']).set('running');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'step:running',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'step one'],
+        });
+      });
+    });
+
+    describe('marking a step as ok', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'steps', 0, 'status']).set('ok');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'step:result',
+          status: 'ok',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'step one'],
+        });
+      });
+    });
+
+    describe('marking a step as failed', () => {
+      beforeEach(() => {
+        slice.slice<StepResult>(['agents', 'agent-1', 'result', 'steps', 0]).update((s) => ({
+          ...s,
+          status: 'failed',
+          error: { message: 'blah' },
+          timeout: false
+        }));
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'step:result',
+          status: 'failed',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'step one'],
+          error: { message: 'blah' },
+          timeout: false,
+        });
+      });
+    });
+  });
+
+  describe('assertions', () => {
+    describe('marking a assertion as running', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'assertions', 0, 'status']).set('running');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'assertion:running',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'assertion one'],
+        });
+      });
+    });
+
+    describe('marking a assertion as ok', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'assertions', 0, 'status']).set('ok');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'assertion:result',
+          status: 'ok',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'assertion one'],
+        });
+      });
+    });
+
+    describe('marking a assertion as failed', () => {
+      beforeEach(() => {
+        slice.slice<StepResult>(['agents', 'agent-1', 'result', 'assertions', 0]).update((s) => ({
+          ...s,
+          status: 'failed',
+          error: { message: 'blah' },
+          timeout: false
+        }));
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'assertion:result',
+          status: 'failed',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test', 'assertion one'],
+          error: { message: 'blah' },
+          timeout: false,
+        });
+      });
+    });
+  });
+
+  describe('tests', () => {
+    describe('marking a test as running', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'status']).set('running');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'test:running',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test'],
+        });
+      });
+    });
+
+    describe('marking a test as ok', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'status']).set('ok');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'test:result',
+          status: 'ok',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test'],
+        });
+      });
+    });
+
+    describe('marking a test as failed', () => {
+      beforeEach(() => {
+        slice.slice<StepResult>(['agents', 'agent-1', 'result']).update((s) => ({
+          ...s,
+          status: 'failed',
+          error: { message: 'blah' },
+          timeout: false
+        }));
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'test:result',
+          status: 'failed',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          path: ['some test'],
+          error: { message: 'blah' },
+          timeout: false,
+        });
+      });
+    });
+  });
+
+  describe('agents', () => {
+    describe('marking a agent as running', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'status']).set('running');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRunAgent:running',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1'
+        });
+      });
+    });
+
+    describe('marking a agent as ok', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['agents', 'agent-1', 'status']).set('ok');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRunAgent:result',
+          status: 'ok',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1'
+        });
+      });
+    });
+
+    describe('marking a agent as failed', () => {
+      beforeEach(() => {
+        slice.slice<StepResult>(['agents', 'agent-1']).update((s) => ({
+          ...s,
+          status: 'failed',
+          error: { message: 'blah' },
+          timeout: false
+        }));
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRunAgent:result',
+          status: 'failed',
+          agentId: 'agent-1',
+          testRunId: 'test-run-1',
+          error: { message: 'blah' },
+          timeout: false,
+        });
+      });
+    });
+  });
+
+  describe('test run', () => {
+    describe('marking a test run as running', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['status']).set('running');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRun:running',
+          testRunId: 'test-run-1'
+        });
+      });
+    });
+
+    describe('marking a test run as ok', () => {
+      beforeEach(() => {
+        slice.slice<ResultStatus>(['status']).set('ok');
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRun:result',
+          status: 'ok',
+          testRunId: 'test-run-1'
+        });
+      });
+    });
+
+    describe('marking a test run as failed', () => {
+      beforeEach(() => {
+        slice.update((s) => ({
+          ...s,
+          status: 'failed',
+          error: { message: 'blah' },
+          timeout: false
+        }));
+      });
+
+      it('generates a test event', async () => {
+        let { value } = await actions.fork(subscription.next());
+        expect(value).toEqual({
+          type: 'testRun:result',
+          status: 'failed',
+          testRunId: 'test-run-1',
+          error: { message: 'blah' },
+          timeout: false,
+        });
+      });
+    });
+  });
+
+  describe('finishing all items', () => {
+    beforeEach(() => {
+      slice.slice<ResultStatus>(['status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'steps', 0, 'status']).set('failed');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'steps', 1, 'status']).set('disregarded');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'assertions', 0, 'status']).set('disregarded');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'assertions', 1, 'status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'children', 0, 'status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'children', 0, 'steps', 0, 'status']).set('ok');
+      slice.slice<ResultStatus>(['agents', 'agent-1', 'result', 'children', 0, 'assertions', 0, 'status']).set('ok');
+    });
+
+    it('terminates subscription', async() => {
+      while(true) {
+        let { done } = await actions.fork(subscription.next());
+        if(done) break;
+      }
+    });
+  });
+});

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -173,10 +173,6 @@ describe('running tests on an agent', () => {
           path: ['All tests', "Signing In", "when I fill in the login form"],
           error: {
             message: "this step failed",
-            fileName: 'here.js',
-            lineNumber: 5,
-            columnNumber: 10,
-            stack: ['here.js', 'there.js']
           }
         })
       });
@@ -243,10 +239,6 @@ describe('running tests on an agent', () => {
           path: ['All tests', 'Signing In', 'then I am logged in'],
           error: {
             message: 'this assertion failed',
-            fileName: 'here.js',
-            lineNumber: 5,
-            columnNumber: 10,
-            stack: ['here.js', 'there.js']
           }
         })
       });
@@ -422,7 +414,7 @@ describe('running tests on an agent', () => {
         status: 'failed',
         testRunId: runCommand.testRunId,
         path: ['All tests', "Signing In", "when I fill in the login form"],
-        error: { message: "this step failed", fileName: 'here.js', lineNumber: 5, columnNumber: 10, stack: ['here.js', 'there.js'] }
+        error: { message: "this step failed" }
       });
     });
 

--- a/packages/server/test/subscription.test.ts
+++ b/packages/server/test/subscription.test.ts
@@ -1,11 +1,8 @@
 import * as expect from 'expect';
 import { Mailbox } from '@bigtest/effection';
-import { Subscription } from '@effection/subscription';
 import { Agent, Command } from '@bigtest/agent';
-import { ResultStatus } from '@bigtest/suite';
 import { actions } from './helpers';
 import { Client } from '../src/client';
-import { TestEvent } from '../src/schema/test-event';
 import { generateAgentId } from '../src/connection-server';
 
 interface AgentsQuery {

--- a/packages/server/test/subscription.test.ts
+++ b/packages/server/test/subscription.test.ts
@@ -1,0 +1,163 @@
+import * as expect from 'expect';
+import { Mailbox } from '@bigtest/effection';
+import { Subscription } from '@effection/subscription';
+import { Agent, Command } from '@bigtest/agent';
+import { ResultStatus } from '@bigtest/suite';
+import { actions } from './helpers';
+import { Client } from '../src/client';
+import { TestEvent } from '../src/schema/test-event';
+import { generateAgentId } from '../src/connection-server';
+
+interface AgentsQuery {
+  agents: {
+    agentId: string;
+  }[];
+}
+
+function subscriptionQuery() {
+  return `
+    subscription {
+      event: run {
+        type
+        status
+        testRunId
+        agentId
+        path
+        error {
+          message
+        }
+        timeout
+      }
+    }
+  `;
+}
+
+describe('running tests with subscription on an agent', () => {
+  let client: Client;
+  let agent: Agent;
+  let agentId = generateAgentId();
+  let agentsSubscription: Mailbox;
+
+  beforeEach(async () => {
+    await actions.startOrchestrator();
+    agent = await actions.createAgent(agentId);
+    client = await actions.fork(Client.create(`http://localhost:24102`));
+
+    agentsSubscription = await actions.fork(client.liveQuery(`{ agents { agentId } }`));
+
+    let match: (params: AgentsQuery) => boolean = ({ agents }) => agents && agents.length === 1;
+
+    await actions.fork(agentsSubscription.receive(match));
+  });
+
+  describe('with the fixture tree', () => {
+    let results: Mailbox;
+    let runCommand: Command;
+    let testRunId: string;
+
+    beforeEach(async () => {
+      results = await actions.fork(client.subscription(subscriptionQuery()));
+      runCommand = await actions.fork(agent.commands.match({ type: 'run' }).first());
+      testRunId = runCommand.testRunId;
+    });
+
+    describe('when the agent reports that it is running', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'run:begin',
+          testRunId: runCommand.testRunId
+        });
+      });
+
+      it('sends a running event', async () => {
+        let event = await actions.fork(results.receive());
+        expect(event).toMatchObject({ event: { type: 'testRunAgent:running', agentId, testRunId } });
+      });
+    });
+
+    describe('when a step succeeeds', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'step:result',
+          status: 'ok',
+          testRunId: runCommand.testRunId,
+          path: ['All tests', 'Signing In', 'when I fill in the login form']
+        })
+      });
+
+      it('sends an event for that step', async () => {
+        let event = await actions.fork(results.receive());
+        expect(event).toMatchObject({
+          event: {
+            type: 'step:result',
+            status: 'ok',
+            path: ['All tests', 'Signing In', 'when I fill in the login form'],
+            agentId,
+            testRunId
+          }
+        });
+      });
+    });
+
+    describe('when a step fails', () => {
+      beforeEach(() => {
+        agent.send({
+          type: 'step:result',
+          status: 'failed',
+          testRunId: runCommand.testRunId,
+          path: ['All tests', 'Signing In', 'when I fill in the login form'],
+          error: {
+            message: 'this step failed',
+          }
+        })
+      });
+
+      it('sends an event for that step', async () => {
+        await actions.fork(results.receive({
+          event: {
+            type: 'step:result',
+            status: 'failed',
+            path: ['All tests', 'Signing In', 'when I fill in the login form'],
+            error: {
+              message: 'this step failed',
+            }
+          }
+        }));
+      });
+
+      it('sends a failed event for the entire test', async () => {
+        await actions.fork(results.receive({
+          event: {
+            type: 'test:result',
+            status: 'failed',
+            path: ['All tests', 'Signing In'],
+          }
+        }));
+      });
+
+      it('sends a disregarded event for the remaining steps, assertions and children', async() => {
+        await actions.fork(results.receive({
+          event: {
+            type: 'step:result',
+            status: 'disregarded',
+            path: ['All tests', 'Signing In', 'when I press the submit button'],
+          }
+        }));
+        await actions.fork(results.receive({
+          event: {
+            type: 'assertion:result',
+            status: 'disregarded',
+            path: ['All tests', 'Signing In', 'then I am logged in'],
+          }
+        }));
+        await actions.fork(results.receive({
+          event: {
+            type: 'test:result',
+            status: 'disregarded',
+            path: ['All tests', 'Signing In', 'when I log out'],
+          }
+        }));
+      });
+    });
+  });
+});

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -95,6 +95,7 @@ export interface TestResult extends Test {
 export interface StepResult extends Node {
   description: string;
   status: ResultStatus;
+  error?: ErrorDetails;
   timeout?: boolean;
 }
 
@@ -104,12 +105,14 @@ export interface StepResult extends Node {
 export interface AssertionResult extends Node {
   description: string;
   status: ResultStatus;
+  error?: ErrorDetails;
+  timeout?: boolean;
 }
 
 export interface ErrorDetails {
   message: string;
-  fileName: string;
-  lineNumber: number;
-  columnNumber: number;
-  stack: string[];
+  fileName?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+  stack?: string[];
 }

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -114,5 +114,5 @@ export interface ErrorDetails {
   fileName?: string;
   lineNumber?: number;
   columnNumber?: number;
-  stack?: string[];
+  stack?: string;
 }


### PR DESCRIPTION
Converts the stream of states we receive in the atom into a stream of events instead. This event can easily be printed by some CLI tool.