### PR TITLE
Add unit tests for `Atom` class

### DIFF
--- a/.changeset/privatize-atom-properties.md
+++ b/.changeset/privatize-atom-properties.md
@@ -1,0 +1,10 @@
+---
+"@bigtest/atom": minor
+---
+
+Some properties on `Atom` are now private which shouldn't have been public:
+
+- `initial`
+- `state`
+- `subscriptions`
+- `states`

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -5,12 +5,12 @@ import { Subscribable, SymbolSubscribable } from '@effection/subscription';
 import { Slice } from "./slice";
 
 export class Atom<S> implements Subscribable<S,void> {
-  initial: S;
-  state: S;
+  private readonly initial: S;
+  private state: S;
 
-  subscriptions = new EventEmitter();
+  private subscriptions = new EventEmitter();
 
-  get states() {
+  private get states() {
     return Subscribable.from(on(this.subscriptions, 'state'))
       .map(([state]) => state as S);
   }

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,0 +1,155 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import { Atom } from '../src/atom';
+import { spawn, converge, never } from './helpers';
+import { Slice } from '../src/slice';
+
+describe('@bigtest/atom', () => {
+  describe('Atom', () => {
+    let subject: Atom<string>;
+
+    beforeEach(() => {
+      subject = new Atom('foo');
+    })
+
+    describe('.get()', () => {
+      it('gets the current state', () => {
+        expect(subject.get()).toEqual('foo');
+      });
+    });
+
+    describe('.update()', () => {
+      beforeEach(() => {
+        subject.update(previous => {
+          expect(previous).toEqual('foo');
+          return 'bar';
+        });
+      });
+
+      it('updates the current state', () => {
+        expect(subject.get()).toEqual('bar');
+      });
+    });
+
+    describe('.each()', () => {
+      let result: string[] = [];
+
+      beforeEach(() => {
+        spawn(subject.each(function*(state) {
+          result.push(state);
+        }));
+
+        subject.update(() => 'bar');
+        subject.update(() => 'baz');
+      });
+
+      it('performs given operation for each state change', async () => {
+        await converge(50, () => {
+          expect(result).toEqual(['bar', 'baz']);
+        });
+      });
+    });
+
+    describe('.once()', () => {
+      let result: Promise<string | undefined>;
+
+      beforeEach(async () => {
+        result = spawn(subject.once(() => true));
+
+        subject.update(() => 'bar');
+        subject.update(() => 'baz');
+      });
+
+      it('gets the first state that passes the given predicate', async () => {
+        expect(await result).toEqual('bar');
+        expect(subject.get()).toEqual('baz');
+      });
+    });
+
+    describe('.reset()', () => {
+      describe('without an initializer', () => {
+        beforeEach(async () => {
+          subject.update(() => 'bar');
+
+          subject.reset();
+        });
+
+        it('resets to the initial value', async () => {
+          expect(subject.get()).toEqual('foo');
+        });
+
+        it('removes listeners', () => {
+          expect(subject['subscriptions'].listenerCount('state')).toEqual(0);
+        });
+      });
+
+      describe('with an initializer', () => {
+        let initializerArgs: string[];
+
+        beforeEach(async () => {
+          subject.update(() => 'bar');
+
+          subject.reset((initial, current) => {
+            initializerArgs = [initial, current];
+            return 'baz';
+          });
+        });
+
+        it('resets to the value returned from the given function', async () => {
+          expect(subject.get()).toEqual('baz');
+        });
+
+        it('provides the initial and current values as arguments to the given function', async () => {
+          expect(initializerArgs).toEqual(['foo', 'bar']);
+        });
+      });
+
+      describe('removing listeners', () => {
+        let result: string[];
+
+        beforeEach(async () => {
+          result = [];
+
+          spawn(subject.each(function*(state) {
+            result.push(state);
+          }));
+
+          subject.update(() => 'state before reset');
+          subject.reset(() => 'reset state');
+          subject.update(() => 'state after reset');
+        });
+
+        it('emits state changes to listeners before reset', async () => {
+          await converge(50, () => {
+            expect(result).toEqual(['state before reset']);
+          });
+        });
+
+        it('stops emitting changes to listeners set before reset', async () => {
+          await never(50, () => {
+            expect(result).toEqual(['state before reset', 'state after reset']);
+          });
+        });
+      });
+    });
+
+    describe('.slice()', () => {
+      interface Foo {
+        foo: {
+          bar: string;
+        };
+      }
+      let subject: Atom<Foo>;
+      let result: Slice<string, Foo>;
+
+      beforeEach(async () => {
+        subject = new Atom({ foo: { bar: "baz" } });
+        result = subject.slice(['foo', 'bar']);
+      });
+
+      it('returns a slice of the Atom with the given path', async () => {
+        expect(result.get()).toEqual('baz');
+      });
+    });
+  });
+});

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -44,7 +44,7 @@ describe('@bigtest/atom', () => {
       });
 
       it('performs given operation for each state change', async () => {
-        await when(50, () => {
+        await when(() => {
           expect(result).toEqual(['bar', 'baz']);
         });
       });
@@ -116,13 +116,13 @@ describe('@bigtest/atom', () => {
         });
 
         it('emits state changes to listeners before reset', async () => {
-          await when(50, () => {
+          await when(() => {
             expect(result).toEqual(['state before reset']);
           });
         });
 
         it('stops emitting changes to listeners set before reset', async () => {
-          await never(50, () => {
+          await never(() => {
             expect(result).toEqual(['state before reset', 'state after reset']);
           });
         });

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -77,10 +77,6 @@ describe('@bigtest/atom', () => {
         it('resets to the initial value', async () => {
           expect(subject.get()).toEqual('foo');
         });
-
-        it('removes listeners', () => {
-          expect(subject['subscriptions'].listenerCount('state')).toEqual(0);
-        });
       });
 
       describe('with an initializer', () => {

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
 import { Atom } from '../src/atom';
-import { spawn, converge, never } from './helpers';
+import { spawn, when, never } from './helpers';
 import { Slice } from '../src/slice';
 
 describe('@bigtest/atom', () => {
@@ -44,7 +44,7 @@ describe('@bigtest/atom', () => {
       });
 
       it('performs given operation for each state change', async () => {
-        await converge(50, () => {
+        await when(50, () => {
           expect(result).toEqual(['bar', 'baz']);
         });
       });
@@ -116,7 +116,7 @@ describe('@bigtest/atom', () => {
         });
 
         it('emits state changes to listeners before reset', async () => {
-          await converge(50, () => {
+          await when(50, () => {
             expect(result).toEqual(['state before reset']);
           });
         });

--- a/packages/atom/test/helpers.ts
+++ b/packages/atom/test/helpers.ts
@@ -4,6 +4,11 @@ import { performance } from 'perf_hooks';
 type World = Context & { spawn<T>(operation: Operation<T>): Promise<T> };
 
 let currentWorld: World;
+let mochaTimeout: number;
+
+before(function() {
+  mochaTimeout = this.timeout(50).timeout();
+});
 
 beforeEach(() => {
   currentWorld = main(undefined) as World;
@@ -21,7 +26,7 @@ async function wait(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function when<T>(timeout: number, fn: () => T): Promise<T> {
+export async function when<T>(fn: () => T, timeout = mochaTimeout): Promise<T> {
   let startTime = performance.now();
 
   while (true) {
@@ -37,7 +42,7 @@ export async function when<T>(timeout: number, fn: () => T): Promise<T> {
   }
 }
 
-export async function never(timeout: number, fn: () => void): Promise<void> {
+export async function never(fn: () => void, timeout = mochaTimeout): Promise<void> {
   let startTime = performance.now();
   let passed = false;
 

--- a/packages/atom/test/helpers.ts
+++ b/packages/atom/test/helpers.ts
@@ -21,7 +21,7 @@ async function wait(ms: number) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function converge<T>(timeout: number, fn: () => T): Promise<T> {
+export async function when<T>(timeout: number, fn: () => T): Promise<T> {
   let startTime = performance.now();
 
   while (true) {

--- a/packages/atom/test/helpers.ts
+++ b/packages/atom/test/helpers.ts
@@ -1,0 +1,60 @@
+import { Context, Operation, main } from 'effection';
+import { performance } from 'perf_hooks';
+
+type World = Context & { spawn<T>(operation: Operation<T>): Promise<T> };
+
+let currentWorld: World;
+
+beforeEach(() => {
+  currentWorld = main(undefined) as World;
+});
+
+afterEach(() => {
+  currentWorld.halt();
+});
+
+export function spawn<T>(operation: Operation<T>): Promise<T> {
+  return currentWorld.spawn(operation);
+}
+
+async function wait(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function converge<T>(timeout: number, fn: () => T): Promise<T> {
+  let startTime = performance.now();
+
+  while (true) {
+    try {
+      return fn();
+    } catch (err) {
+      let diff = performance.now() - startTime;
+      if (diff > timeout) {
+        throw err;
+      }
+      await wait(1);
+    }
+  }
+}
+
+export async function never(timeout: number, fn: () => void): Promise<void> {
+  let startTime = performance.now();
+  let passed = false;
+
+  while (true) {
+    try {
+      fn();
+      passed = true;
+    } catch (err) {
+      let diff = performance.now() - startTime;
+      if (diff > timeout) {
+        return;
+      }
+      await wait(1);
+    }
+
+    if (passed === true) {
+      throw new Error('Assertion passed unexpectedly');
+    }
+  }
+}

--- a/packages/atom/test/project.test.ts
+++ b/packages/atom/test/project.test.ts
@@ -1,8 +1,0 @@
-import { describe, it } from 'mocha';
-import * as expect from 'expect'
-
-describe("@bigtest/atom", () => {
-  it('works', () => {
-    expect(1).toEqual(1);
-  });
-})


### PR DESCRIPTION
## Motivation

There were no tests for this class.

## Approach

- Add unit tests
- Make some properties on `Atom` private since they shouldn't be public