### PR TITLE
Once should check the current state

### DIFF
--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -44,8 +44,12 @@ export class Atom<S> implements Subscribable<S,void> {
     return this.states.forEach(fn);
   }
 
-  once(predicate: (state: S) => boolean): Operation<S | undefined> {
-    return this.states.filter(predicate).first();
+  *once(predicate: (state: S) => boolean): Operation<S | undefined> {
+    if(predicate(this.state)) {
+      return this.state;
+    } else {
+      return yield this.states.filter(predicate).first();
+    }
   }
 
   [SymbolSubscribable]() {

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -53,16 +53,32 @@ describe('@bigtest/atom', () => {
     describe('.once()', () => {
       let result: Promise<string | undefined>;
 
-      beforeEach(async () => {
-        result = spawn(subject.once(() => true));
+      describe('when initial state matches', () => {
+        beforeEach(async () => {
+          result = spawn(subject.once((state) => state === 'foo'));
 
-        subject.update(() => 'bar');
-        subject.update(() => 'baz');
+          subject.update(() => 'bar');
+        });
+
+        it('gets the first state that passes the given predicate', async () => {
+          expect(await result).toEqual('foo');
+          expect(subject.get()).toEqual('bar');
+        });
       });
 
-      it('gets the first state that passes the given predicate', async () => {
-        expect(await result).toEqual('bar');
-        expect(subject.get()).toEqual('baz');
+      describe('when initial state does not match', () => {
+        beforeEach(async () => {
+          result = spawn(subject.once((state) => state === 'baz'));
+
+          subject.update(() => 'bar');
+          subject.update(() => 'baz');
+          subject.update(() => 'quox');
+        });
+
+        it('gets the first state that passes the given predicate', async () => {
+          expect(await result).toEqual('baz');
+          expect(subject.get()).toEqual('quox');
+        });
       });
     });
 


### PR DESCRIPTION
It should return true if the current state matches, not only if a future state matches.