### PR TITLE
Move to `v*` branches instead of `master`

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,6 +4,6 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "master",
+  "baseBranch": "v0",
   "updateInternalDependencies": "patch"
 }

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -3,7 +3,7 @@ name: Changeset
 on:
   push:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   create-release-pr:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on:
   pull_request:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   build:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-previews:
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Publish PR Preview
       uses: thefrontside/actions/publish-pr-preview@v1.4
-      if: ${{ github.head_ref != 'changeset-release/master' }}
+      if: ${{ !startsWith(github.head_ref, 'changeset-release/') }}
       with:
         before_all: yarn prepack
         npm_publish: yarn publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   publish-releases:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   pull_request:
     branches:
-      - master
+      - 'v[0-9]+'
 
 jobs:
   prepack:


### PR DESCRIPTION
Closes #349 

## Motivation

`master` can be a violent word and make people not feel welcome as an employee or contributor.

## Approach

Rather than simply changing the name of the default branch, we took a step back and looked at what could be a better branching strategy in general. We've landed on having major release branches (such as `v0`, `v1`, etc.) and setting the default to the latest major release branch. When we begin working on a new major release we:

1. Make a new branch for that version
1. Set the default branch to that version

Note: we will need to change the changeset `config.json` `baseBranch` option manually for each new major release branch.

### To-do

- [ ] Make a new branch off of `master` called `v0` and set it as the default
- [ ] Point existing PRs to new `v0` branch