### PR TITLE
Run yarn before changeset action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: yarn
     - name: Create Release Pull Request
       uses: changesets/action@master
       env:


### PR DESCRIPTION
To fix #351.

Forgot to add `run: yarn` prior to the changeset action in the release workflow. 

Adding this command should result in a new pull request created by the changeset action using the changeset files that are currently on the master branch.