### PR TITLE
Add filters to interactors

### DIFF
--- a/.changeset/interactor-filters.md
+++ b/.changeset/interactor-filters.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Can filter interactors to narrow selection without having to define a separate interactor

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,5 +1,6 @@
-import { InteractorSpecification, InteractorInstance, InteractorType, LocatorFn } from './specification';
+import { InteractorSpecification, FilterImplementation, InteractorInstance, InteractorType, LocatorFn } from './specification';
 import { Locator } from './locator';
+import { Filter } from './filter';
 import { Interactor } from './interactor';
 import { interaction } from './interaction';
 import { converge } from './converge';
@@ -30,17 +31,19 @@ export function createInteractor<E extends Element>(interactorName: string) {
       });
     }
 
-    let result = function(value: string): InteractorInstance<E, S> {
+    let result = function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
       let locator = new Locator(specification.defaultLocator || defaultLocator, value);
-      let interactor = new InteractorClass(interactorName, specification, locator);
+      let filter = new Filter(specification, filters || {});
+      let interactor = new InteractorClass(interactorName, specification, locator, filter);
       return interactor as InteractorInstance<E, S>;
     }
 
     for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
       Object.defineProperty(result, locatorName, {
-        value: function(value: string): InteractorInstance<E, S> {
+        value: function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
           let locator = new Locator(locatorFn, value, locatorName);
-          let interactor = new InteractorClass(interactorName, specification, locator);
+          let filter = new Filter(specification, filters || {});
+          let interactor = new InteractorClass(interactorName, specification, locator, filter);
           return interactor as InteractorInstance<E, S>;
         },
         configurable: true,

--- a/packages/interactor/src/errors.ts
+++ b/packages/interactor/src/errors.ts
@@ -9,3 +9,7 @@ export class AmbiguousElementError extends Error {
 export class NotAbsentError extends Error {
   get name() { return "NotAbsentError" }
 }
+
+export class FilterNotMatchingError extends Error {
+  get name() { return "FilterNotMatchingError" }
+}

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -1,0 +1,46 @@
+export type LocatorFn<E extends Element> = (element: E) => string;
+import { FilterImplementation, InteractorSpecification } from './specification';
+
+export class Filter<E extends Element, S extends InteractorSpecification<E>> {
+  constructor(
+    public specification: S,
+    public filters: FilterImplementation<E, S>
+  ) {};
+
+  get description(): string {
+    let entries = Object.entries(this.filters);
+    if(entries.length === 0) {
+      return '';
+    } else {
+      return entries.map(([key, value]) => {
+        if(typeof(value) === 'boolean') {
+          if(value) {
+            return `which is ${key}`;
+          } else {
+            return `which is not ${key}`;
+          }
+        } else {
+          return `with ${key} ${JSON.stringify(value)}`
+        }
+      }).join(' and ');
+    }
+  }
+
+  matches(element: E): boolean {
+    return Object.entries(this.specification.filters || {}).every(([key, definition]) => {
+      let value;
+      if(key in this.filters) {
+        value = (this.filters as any)[key];
+      } else if(typeof(definition) !== 'function' && 'default' in definition) {
+        value = definition.default;
+      } else {
+        return true;
+      }
+      if(typeof(definition) === 'function') {
+        return definition(element) === value;
+      } else {
+        return definition.apply(element) === value;
+      }
+    });
+  }
+}

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -30,7 +30,7 @@ export class Filter<E extends Element, S extends InteractorSpecification<E>> {
     return Object.entries(this.specification.filters || {}).every(([key, definition]) => {
       let value;
       if(key in this.filters) {
-        value = (this.filters as any)[key];
+        value = (this.filters as any)[key]; // eslint-disable-line @typescript-eslint/no-explicit-any
       } else if(typeof(definition) !== 'function' && 'default' in definition) {
         value = definition.default;
       } else {

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -1,9 +1,9 @@
 import { bigtestGlobals } from '@bigtest/globals';
 import { converge } from './converge';
-import { InteractorSpecification } from './specification';
+import { InteractorSpecification, FilterImplementation } from './specification';
 import { Locator } from './locator';
 import { Filter } from './filter';
-import { NoSuchElementError, AmbiguousElementError, NotAbsentError } from './errors';
+import { NoSuchElementError, AmbiguousElementError, NotAbsentError, FilterNotMatchingError } from './errors';
 import { interaction, Interaction } from './interaction';
 
 const defaultSelector = 'div';
@@ -83,5 +83,23 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
         throw new NotAbsentError(`${this.description} exists but should not`);
       });
     });
+  }
+
+  is(filters: FilterImplementation<E, S>): Interaction<true> {
+    let filter = new Filter(this.specification, filters);
+    return interaction(`${this.description} matches filters: ${filter.description}`, () => {
+      return converge(() => {
+        let element = this.unsafeSyncResolve();
+        if(filter.matches(element)) {
+          return true;
+        } else {
+          throw new FilterNotMatchingError(`${this.description} does not match filters: ${filter.description}`);
+        }
+      });
+    });
+  }
+
+  has(filters: FilterImplementation<E, S>): Interaction<true> {
+    return this.is(filters);
   }
 }

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,6 +1,4 @@
-export type LocatorFn<E extends Element> = (element: E) => string;
-
-export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E>>;
+import { LocatorFn } from './specification';
 
 export class Locator<E extends Element> {
   constructor(public locatorFn: LocatorFn<E>, public value: string, public name?: string) {}

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -13,11 +13,9 @@ export interface FilterObject<T, E extends Element> {
   default?: T;
 }
 
-export type FilterDefinition<T, E extends Element> = FilterFn<T, E> | FilterObject<T, E>;
-
 export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E>>;
 
-export type FilterSpecification<E extends Element> = Record<string, FilterDefinition<unknown, E>>;
+export type FilterSpecification<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>
 
 export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>;
 
@@ -34,7 +32,12 @@ export type ActionImplementation<E extends Element, S extends InteractorSpecific
 }
 
 export type FilterImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['filters']]?: S['filters'][P] extends FilterDefinition<infer TArg, E> ? TArg : never;
+  [P in keyof S['filters']]?:
+    S['filters'][P] extends FilterFn<infer TArg, E> ?
+    TArg :
+    S['filters'][P] extends FilterObject<infer TArg, E> ?
+    TArg :
+    never;
 }
 
 export type LocatorImplementation<E extends Element, S extends InteractorSpecification<E>> = {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -6,7 +6,18 @@ export type ActionFn<E extends Element> = (element: E, ...args: any[]) => unknow
 
 export type LocatorFn<E extends Element> = (element: E) => string;
 
+export type FilterFn<T, E extends Element> = (element: E) => T;
+
+export interface FilterObject<T, E extends Element> {
+  apply: FilterFn<T, E>;
+  default?: T;
+}
+
+export type FilterDefinition<T, E extends Element> = FilterFn<T, E> | FilterObject<T, E>;
+
 export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E>>;
+
+export type FilterSpecification<E extends Element> = Record<string, FilterDefinition<unknown, E>>;
 
 export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>;
 
@@ -15,19 +26,23 @@ export interface InteractorSpecification<E extends Element> {
   defaultLocator?: LocatorFn<E>;
   locators?: LocatorSpecification<E>;
   actions?: ActionSpecification<E>;
+  filters?: FilterSpecification<E>;
 }
 
 export type ActionImplementation<E extends Element, S extends InteractorSpecification<E>> = {
   [P in keyof S['actions']]: S['actions'][P] extends ((element: E, ...args: infer TArgs) => infer TReturn) ? ((...args: TArgs) => Interaction<TReturn>) : never;
 }
 
+export type FilterImplementation<E extends Element, S extends InteractorSpecification<E>> = {
+  [P in keyof S['filters']]?: S['filters'][P] extends FilterDefinition<infer TArg, E> ? TArg : never;
+}
+
 export type LocatorImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['locators']]: (value: string) => InteractorInstance<E, S>
+  [P in keyof S['locators']]: (value: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>
 }
 
 export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E, S> & ActionImplementation<E, S>;
 
 export type InteractorType<E extends Element, S extends InteractorSpecification<E>> =
-  ((value: string) => InteractorInstance<E, S>) &
+  ((value: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>) &
   LocatorImplementation<E, S>;
-

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -183,6 +183,28 @@ describe('@bigtest/interactor', () => {
     });
   });
 
+  describe('.is', () => {
+    it('can apply filter', async () => {
+      dom(`
+        <input id="Email" value='jonas@example.com'/>
+      `);
+
+      await expect(TextField('Email').is({ value: 'jonas@example.com' })).resolves.toEqual(true);
+      await expect(TextField('Email').is({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', 'text field "Email" does not match filters: with value "incorrect@example.com"');
+    });
+  });
+
+  describe('.has', () => {
+    it('can apply filter', async () => {
+      dom(`
+        <input id="Email" value='jonas@example.com'/>
+      `);
+
+      await expect(TextField('Email').has({ value: 'jonas@example.com' })).resolves.toEqual(true);
+      await expect(TextField('Email').has({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', 'text field "Email" does not match filters: with value "incorrect@example.com"');
+    });
+  });
+
   describe('actions', () => {
     it('can use action to interact with element', async () => {
       dom(`

--- a/packages/interactor/types/filters.ts
+++ b/packages/interactor/types/filters.ts
@@ -1,0 +1,34 @@
+import { createInteractor } from '../src/index';
+
+const TextField = createInteractor<HTMLInputElement>('text field')({
+  selector: 'input',
+  defaultLocator: (element) => element.id,
+  filters: {
+    enabled: {
+      apply: (element) => !element.disabled,
+      default: true
+    },
+    value: (element) => element.value
+  },
+  actions: {
+    fillIn: (element, value: string) => { element.value = value }
+  }
+});
+
+TextField('foo', { enabled: true, value: 'thing' });
+
+TextField('foo', { enabled: false });
+
+// cannot use wrong type of filter
+
+// $ExpectError
+TextField('foo', { enabled: 'thing' });
+// $ExpectError
+TextField('foo', { value: true });
+// $ExpectError
+TextField('foo', { value: 123 });
+
+// cannot use filter which doesn't exist
+
+// $ExpectError
+TextField('foo', { blah: 'thing' });

--- a/packages/interactor/types/filters.ts
+++ b/packages/interactor/types/filters.ts
@@ -19,6 +19,9 @@ TextField('foo', { enabled: true, value: 'thing' });
 
 TextField('foo', { enabled: false });
 
+TextField('foo').has({ value: 'thing' });
+TextField('foo').is({ enabled: true });
+
 // cannot use wrong type of filter
 
 // $ExpectError
@@ -32,3 +35,31 @@ TextField('foo', { value: 123 });
 
 // $ExpectError
 TextField('foo', { blah: 'thing' });
+
+// cannot use wrong type of filter with is
+
+// $ExpectError
+TextField('foo').is({ enabled: 'thing' });
+// $ExpectError
+TextField('foo').is({ value: true });
+// $ExpectError
+TextField('foo').is({ value: 123 });
+
+// cannot use filter which doesn't exist with is
+
+// $ExpectError
+TextField('foo').is({ blah: 'thing' });
+
+// cannot use wrong type of filter with has
+
+// $ExpectError
+TextField('foo').has({ enabled: 'thing' });
+// $ExpectError
+TextField('foo').has({ value: true });
+// $ExpectError
+TextField('foo').has({ value: 123 });
+
+// cannot use filter which doesn't exist with has
+
+// $ExpectError
+TextField('foo').has({ blah: 'thing' });


### PR DESCRIPTION
Filters allow the selection of elements to be narrowed. A default value can also be provided. See #310 

I intentionally left this functionality rather minimal.

This also adds the ability to check for filters via an assertion on an interactor like this:

``` typescript
await TextField("Email").has({ value: "test@example.com" });
```

IMO this reads a little better than:

``` typescript
await TextField("Email", { value: "test@example.com" }).exists();
```