### PR TITLE
distribute @bigtest/interactor sources for bundled sourcemaps

### DIFF
--- a/.changeset/interactor-sources.md
+++ b/.changeset/interactor-sources.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+---
+bundle sources so that parcel can use them to generate bundle
+sourcemaps

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -8,7 +8,8 @@
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "files": [
-    "dist/*",
+    "dist/**/*",
+    "src/**/*",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
In order to generate sourcemaps for a parcel bundle, parcel needs the original sources (and doesn't seem to be able to get them out of the component sourcemaps).

Like our other packages, this adds the sources so that they can be bundled by parcel.