### PR TITLE
add @bigtest/performance

### DIFF
--- a/.changeset/bigtest-performance.md
+++ b/.changeset/bigtest-performance.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+"@bigtest/cli": patch
+---
+use @bigtest/performance to ponyfill performance apis

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages": [
       "packages/effection",
       "packages/effection-express",
+      "packages/performance",
       "packages/atom",
       "packages/suite",
       "packages/agent",

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -17,6 +17,7 @@
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
   "devDependencies": {
+    "@bigtest/performance": "^0.5.0",
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",

--- a/packages/atom/test/helpers.ts
+++ b/packages/atom/test/helpers.ts
@@ -1,5 +1,5 @@
 import { Context, Operation, main } from 'effection';
-import { performance } from 'perf_hooks';
+import { performance } from '@bigtest/performance';
 
 type World = Context & { spawn<T>(operation: Operation<T>): Promise<T> };
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@bigtest/effection": "^0.5.1",
+    "@bigtest/performance": "^0.5.0",
     "@bigtest/project": "^0.5.1",
     "@bigtest/server": "^0.6.0",
     "@effection/node": "^0.6.5",

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -1,6 +1,6 @@
 import { Operation } from 'effection';
 import { ProjectOptions } from '@bigtest/project';
-import { performance } from 'perf_hooks';
+import { performance } from '@bigtest/performance';
 import { ResultStatus } from '@bigtest/suite';
 import { Client } from '@bigtest/server';
 import * as query from './query';

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -16,6 +16,9 @@
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
+  "dependencies": {
+    "@bigtest/performance": "^0.5.0"
+  },
   "devDependencies": {
     "@frontside/tsconfig": "*",
     "@types/mocha": "^7.0.1",

--- a/packages/interactor/src/converge.ts
+++ b/packages/interactor/src/converge.ts
@@ -1,5 +1,4 @@
-const win: { performance?: unknown } = (typeof(window) === 'object') ? window : {};
-const performance = (typeof(win.performance) === 'object') ? win.performance : require('perf_hooks').performance;
+import { performance } from '@bigtest/performance';
 
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/performance/.gitignore
+++ b/packages/performance/.gitignore
@@ -1,0 +1,4 @@
+/node_modules
+/yarn-error.log
+.node-version
+.cache

--- a/packages/performance/CHANGELOG.md
+++ b/packages/performance/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @bigtest/performance

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -3,7 +3,7 @@
 Cross platform access to the browser [performance API][1] which is
 needed for implementing accurate convergences and deadlines.
 
-``` java-server-pages
+``` js
 import { performance, PerformanceObserver } from '@bigtest/performance';
 ```
 

--- a/packages/performance/README.md
+++ b/packages/performance/README.md
@@ -1,0 +1,15 @@
+# @bigtest/performance
+
+Cross platform access to the browser [performance API][1] which is
+needed for implementing accurate convergences and deadlines.
+
+``` java-server-pages
+import { performance, PerformanceObserver } from '@bigtest/performance';
+```
+
+
+[1]: https://developer.mozilla.org/en-US/docs/Web/API/Performance
+
+``` sh
+$ yarn test
+```

--- a/packages/performance/browser-ponyfill.js
+++ b/packages/performance/browser-ponyfill.js
@@ -1,0 +1,1 @@
+export const { PerformanceObserver, performance } = globalThis;

--- a/packages/performance/index.d.ts
+++ b/packages/performance/index.d.ts
@@ -1,0 +1,9 @@
+declare module "@bigtest/performance" {
+  var performance: Performance;
+
+  var PerformanceObserver: {
+    prototype: PerformanceObserver;
+    new(callback: PerformanceObserverCallback): PerformanceObserver;
+    readonly supportedEntryTypes: ReadonlyArray<string>;
+  }
+}

--- a/packages/performance/node-ponyfill.js
+++ b/packages/performance/node-ponyfill.js
@@ -1,0 +1,3 @@
+const { PerformanceObserver, performance } = require('perf_hooks');
+
+module.exports = {  PerformanceObserver, performance };

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@bigtest/performance",
+  "version": "0.5.0",
+  "description": "Cross platform interface to the DOM performance API",
+  "main": "node-ponyfill.js",
+  "browser": "browser-ponyfill.js",
+  "typings": "index.d.ts",
+  "repository": "https://github.com/thefrontside/bigtest.git",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "license": "MIT",
+  "scripts": {
+    "test": "mocha test/**/*.test.js",
+    "lint": "echo no-op",
+    "prepack": "echo no-op"
+  },
+  "devDependencies": {
+    "expect": "^24.9.0",
+    "mocha": "^6.2.2"
+  }
+}

--- a/packages/performance/test/ponyfill.test.js
+++ b/packages/performance/test/ponyfill.test.js
@@ -1,0 +1,10 @@
+const expect = require('expect');
+
+const ponyfill = require('../node-ponyfill');
+
+describe('performance ponyfill', () => {
+  it('contains the perf functions', () => {
+    expect(ponyfill.performance).toBeDefined();
+    expect(ponyfill.performance.measure).toBeInstanceOf(Function);
+  });
+});

--- a/packages/performance/tsconfig.json
+++ b/packages/performance/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@frontside/tsconfig",
+  "include": [
+    "./index.ts"
+  ]
+}


### PR DESCRIPTION
the `perf_hooks` package is not available when bundling for the web which was causing bigtest interactors to fail.

This creates a cross-platform ponyfill that can be used to use performance from both. It's written in plain javascript since having a compilation steps seems kinda pointless.