### PR TITLE
Interactor is generic over its specification

### DIFF
--- a/.changeset/interactor-specification-type.md
+++ b/.changeset/interactor-specification-type.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/interactor": minor
+---
+Interactors are generically typed over the specification that they use.

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -7,9 +7,9 @@ import { defaultOptions } from './options';
 
 export function createInteractor<E extends Element>(interactorName: string) {
   return function<S extends InteractorSpecification<E>>(specification: Partial<S>): InteractorType<E, S> {
-    let fullSpecification: InteractorSpecification<E> = Object.assign({ selector: interactorName }, defaultSpecification, specification);
+    let fullSpecification = Object.assign({}, defaultSpecification, specification) as unknown as S;
 
-    let InteractorClass = class extends Interactor<E> {};
+    let InteractorClass = class extends Interactor<E, S> {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -5,18 +5,18 @@ import { defaultOptions } from './options';
 import { NoSuchElementError, AmbiguousElementError, NotAbsentError } from './errors';
 import { interaction, Interaction } from './interaction';
 
-export class Interactor<E extends Element> {
+export class Interactor<E extends Element, S extends InteractorSpecification<E>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private ancestors: Array<Interactor<any>> = [];
+  private ancestors: Array<Interactor<any, any>> = [];
 
   constructor(
     public name: string,
-    private specification: InteractorSpecification<E>,
+    private specification: S,
     private locator: Locator<E>
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  find<T extends Interactor<any>>(interactor: T): T {
+  find<T extends Interactor<any, any>>(interactor: T): T {
     return Object.create(interactor, {
       ancestors: {
         value: [...this.ancestors, this, ...interactor.ancestors]
@@ -38,7 +38,7 @@ export class Interactor<E extends Element> {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let ancestorChain: Array<Interactor<any>> = [...this.ancestors, this];
+    let ancestorChain: Array<Interactor<any, any>> = [...this.ancestors, this];
 
     return ancestorChain.reduce((parentElement: Element, interactor) => {
       let elements = Array.from(parentElement.querySelectorAll(interactor.specification.selector));

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -24,7 +24,7 @@ export type LocatorImplementation<E extends Element, S extends InteractorSpecifi
   [P in keyof S['locators']]: (value: string) => InteractorInstance<E, S>
 }
 
-export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E> & ActionImplementation<E, S>;
+export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E, S> & ActionImplementation<E, S>;
 
 export type InteractorType<E extends Element, S extends InteractorSpecification<E>> =
   ((value: string) => InteractorInstance<E, S>) &


### PR DESCRIPTION
Currently an interactor is typed `Interactor<E extends Element>`, this changes the type to `Interactor<E extends Element, S extends InteractorSpecification<E>>` that is the type of an interactor class and its instance includes a reference to the type of the specification that generated it.

The reason that this is useful is because it allows methods on the interactor to refer to the specification. As part of #359, I would like to add the ability to check for a given filter via `has({ filter: whatever })`, but this requires knowledge of the type of the filter specification to make it type-safe.

Why didn't we do this in the first place then? It does have some downsides. The type of the specification is not easily namable, so when an interactor needs to be referenced somewhere where its type must be explicitly given, then that is not easily done. Also, previously we had not yet worked out how to work around the variance issues that crop up around `find`, so we were unable to make this work.