### PR TITLE
distribute sources with npm package

### DIFF
--- a/.changeset/distribute-suite-sources.md
+++ b/.changeset/distribute-suite-sources.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/suite": patch
+---
+
+distribute typescript sources so that bundlers like parcl can have
+access to them

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "files": [
     "dist/**/*",
+    "src/**/*",
     "README.md"
   ],
   "scripts": {


### PR DESCRIPTION
See https://github.com/thefrontside/bigtest/pull/362 for context

This avoids these warnings:

```
⚠️  Could not load source file "../src/index.ts" in source map of "../../../../node_modules/@bigtest/suite/dist/index.js".
⚠️  Could not load source file "../src/dsl.ts" in source map of "../../../../node_modules/@bigtest/suite/dist/dsl.js".
⚠️  Could not load source file "../src/index.ts" in source map of "../../../../node_modules/@bigtest/suite/dist/index.js".
⚠️  Could not load source file "../src/dsl.ts" in source map of "../../../../node_modules/@bigtest/suite/dist/dsl.js".
```