### PR TITLE
Eliminate `createInteractor` partial application API

### DIFF
--- a/.changeset/elim-interactor-partial-application.md
+++ b/.changeset/elim-interactor-partial-application.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+---
+
+Eliminate `createInteractor()()` partial application API so we can provide all
+arguments to a single function.

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -74,6 +74,8 @@ describe("@bigtest/agent", function() {
       let message: { agentId: string };
       let agentId: string;
 
+      this.timeout(10000);
+
       beforeEach(async function() {
         await main(staticServer(8002));
         browser = await main(Local({ browserName: 'chrome', headless: true }));

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -5,47 +5,48 @@ import { interaction } from './interaction';
 import { converge } from './converge';
 import { defaultOptions } from './options';
 
-export function createInteractor<E extends Element>(interactorName: string) {
-  return function<S extends InteractorSpecification<E>>(specification: Partial<S>): InteractorType<E, S> {
-    let fullSpecification: InteractorSpecification<E> = Object.assign({ selector: interactorName }, defaultSpecification, specification);
+export function createInteractor<
+  E extends Element,
+  S extends InteractorSpecification<E> = InteractorSpecification<E>
+>(interactorName: string, specification: Partial<S>): InteractorType<E, S> {
+  let fullSpecification: InteractorSpecification<E> = Object.assign({ selector: interactorName }, defaultSpecification, specification);
 
-    let InteractorClass = class extends Interactor<E> {};
+  let InteractorClass = class extends Interactor<E> {};
 
-    for(let [actionName, action] of Object.entries(specification.actions || {})) {
-      Object.defineProperty(InteractorClass.prototype, actionName, {
-        value: function() {
-          return interaction(`performing ${actionName} on ${this.description}`, () => {
-            return converge(defaultOptions.timeout, () => {
-              let element = this.unsafeSyncResolve();
-              return action(element);
-            });
+  for(let [actionName, action] of Object.entries(specification.actions || {})) {
+    Object.defineProperty(InteractorClass.prototype, actionName, {
+      value: function() {
+        return interaction(`performing ${actionName} on ${this.description}`, () => {
+          return converge(defaultOptions.timeout, () => {
+            let element = this.unsafeSyncResolve();
+            return action(element);
           });
-        },
-        configurable: true,
-        writable: true,
-        enumerable: false,
-      });
-    }
-
-    let result = function(value: string): InteractorInstance<E, S> {
-      let locator = new Locator(fullSpecification.defaultLocator, value);
-      let interactor = new InteractorClass(interactorName, fullSpecification, locator);
-      return interactor as InteractorInstance<E, S>;
-    }
-
-    for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
-      Object.defineProperty(result, locatorName, {
-        value: function(value: string): InteractorInstance<E, S> {
-          let locator = new Locator(locatorFn, value, locatorName);
-          let interactor = new InteractorClass(interactorName, fullSpecification, locator);
-          return interactor as InteractorInstance<E, S>;
-        },
-        configurable: true,
-        writable: true,
-        enumerable: false,
-      });
-    }
-
-    return result as InteractorType<E, S>;
+        });
+      },
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
   }
+
+  let result = function(value: string): InteractorInstance<E, S> {
+    let locator = new Locator(fullSpecification.defaultLocator, value);
+    let interactor = new InteractorClass(interactorName, fullSpecification, locator);
+    return interactor as InteractorInstance<E, S>;
+  }
+
+  for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
+    Object.defineProperty(result, locatorName, {
+      value: function(value: string): InteractorInstance<E, S> {
+        let locator = new Locator(locatorFn, value, locatorName);
+        let interactor = new InteractorClass(interactorName, fullSpecification, locator);
+        return interactor as InteractorInstance<E, S>;
+      },
+      configurable: true,
+      writable: true,
+      enumerable: false,
+    });
+  }
+
+  return result as InteractorType<E, S>;
 }

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -4,7 +4,7 @@ import { JSDOM } from 'jsdom';
 
 import { createInteractor, setDefaultOptions } from '../src/index';
 
-const Link = createInteractor<HTMLLinkElement>('link')({
+const Link = createInteractor<HTMLLinkElement>('link', {
   selector: 'a',
   locators: {
     byHref: (element) => element.href,
@@ -15,15 +15,15 @@ const Link = createInteractor<HTMLLinkElement>('link')({
   }
 });
 
-const Header = createInteractor('header')({
+const Header = createInteractor('header', {
   selector: 'h1,h2,h3,h4,h5,h6',
 });
 
-const Div = createInteractor('div')({
+const Div = createInteractor('div', {
   defaultLocator: (element) => element.id || "",
 });
 
-const Details = createInteractor<HTMLDetailsElement>('details')({
+const Details = createInteractor<HTMLDetailsElement>('details', {
   selector: 'details',
   defaultLocator: (element) => element.querySelector('summary')?.textContent || ''
 });


### PR DESCRIPTION
## Motivation

The `createInteractor()()` partial application API does not provide any benefit, and may be confusing for a new user since it serves no purpose.

## Approach

Squash the two functions into one, resulting in an API like:

```ts
createInteractor('paragraph', { selector: 'p' });
```