### PR TITLE
Add tests for interactor types

### DIFF
--- a/.changeset/interactor-types.md
+++ b/.changeset/interactor-types.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+---
+
+Interactors did not properly type the defined interactors due to incorrectly applied type transformations.

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -14,7 +14,9 @@
   ],
   "scripts": {
     "lint": "eslint '{src,test}/**/*.ts'",
-    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "test:unit": "mocha -r ts-node/register test/**/*.test.ts",
+    "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
+    "test": "yarn test:unit && yarn test:types",
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
   "dependencies": {
@@ -26,6 +28,7 @@
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "@types/jsdom": "^16.2.3",
+    "dtslint": "^3.5.2",
     "expect": "^24.9.0",
     "jsdom": "^16.2.2",
     "mocha": "^6.2.2",

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -5,6 +5,8 @@ import { Locator } from './locator';
 import { NoSuchElementError, AmbiguousElementError, NotAbsentError } from './errors';
 import { interaction, Interaction } from './interaction';
 
+const defaultSelector = 'div';
+
 export class Interactor<E extends Element, S extends InteractorSpecification<E>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private ancestors: Array<Interactor<any, any>> = [];
@@ -35,7 +37,7 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
     let ancestorChain: Array<Interactor<any, any>> = [...this.ancestors, this];
 
     return ancestorChain.reduce((parentElement: Element, interactor) => {
-      let elements = Array.from(parentElement.querySelectorAll(interactor.specification.selector));
+      let elements = Array.from(parentElement.querySelectorAll(interactor.specification.selector || defaultSelector));
       let matchingElements = elements.filter((element) => interactor.locator.matches(element));
 
       if(matchingElements.length === 1) {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -1,7 +1,8 @@
 import { Interactor } from './interactor';
 import { Interaction } from './interaction';
 
-export type ActionFn<E extends Element> = (element: E) => unknown;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ActionFn<E extends Element> = (element: E, ...args: any[]) => unknown;
 
 export type LocatorFn<E extends Element> = (element: E) => string;
 
@@ -10,10 +11,10 @@ export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E
 export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>;
 
 export interface InteractorSpecification<E extends Element> {
-  selector: string;
-  defaultLocator: LocatorFn<E>;
-  locators: LocatorSpecification<E>;
-  actions: ActionSpecification<E>;
+  selector?: string;
+  defaultLocator?: LocatorFn<E>;
+  locators?: LocatorSpecification<E>;
+  actions?: ActionSpecification<E>;
 }
 
 export type ActionImplementation<E extends Element, S extends InteractorSpecification<E>> = {
@@ -30,9 +31,3 @@ export type InteractorType<E extends Element, S extends InteractorSpecification<
   ((value: string) => InteractorInstance<E, S>) &
   LocatorImplementation<E, S>;
 
-export const defaultSpecification: InteractorSpecification<Element> = {
-  selector: 'div',
-  defaultLocator: (element) => element.textContent || "",
-  locators: {},
-  actions: {},
-}

--- a/packages/interactor/types/create-interactor.ts
+++ b/packages/interactor/types/create-interactor.ts
@@ -1,0 +1,45 @@
+import { createInteractor } from '../src/index';
+
+const Link = createInteractor<HTMLLinkElement>('link')({
+  selector: 'a',
+  locators: {
+    byHref: (element) => element.href,
+    byTitle: (element) => element.title
+  },
+  actions: {
+    click: (element) => { element.click() },
+    setHref: (element, value: string) => { element.href = value }
+  }
+});
+
+const Div = createInteractor('div')({
+  defaultLocator: (element) => element.id || "",
+});
+
+Link('foo').click();
+
+Link('foo').setHref('blah');
+
+// cannot use wrong type of argument on action
+// $ExpectError
+Link('foo').setHref(123);
+
+// cannot use action which is not defined
+// $ExpectError
+Div('foo').click();
+
+// $ExpectError
+Div('foo').blah();
+
+Link.byHref('foobar');
+
+// cannot use wrong type argument on locator
+// $ExpectError
+Link.byHref(123);
+
+// cannot use locator which is not defined
+// $ExpectError
+Div.byHref('foobar');
+
+// $ExpectError
+Div.moo('foobar');

--- a/packages/interactor/types/index.d.ts
+++ b/packages/interactor/types/index.d.ts
@@ -1,0 +1,1 @@
+../dist/index.d.ts

--- a/packages/interactor/types/tsconfig.json
+++ b/packages/interactor/types/tsconfig.json
@@ -1,0 +1,17 @@
+// this additional tsconfig is required by dtslint
+// see: https://github.com/Microsoft/dtslint#typestsconfigjson
+{
+  "extends": "@frontside/tsconfig",
+  "compilerOptions": {
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
+
+    // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+    // If the library is global (cannot be imported via `import` or `require`), leave this out.
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
Some of the properties of the interactor types are not verifiable through the test suite, this adds some type tests using dtslint to verify that the types behave as we intend.

It turns out that we did not actually maintain the properties we wanted, due to using `Partial<InteractorSpecification>` which messed up the inferred types somehow.