### PR TITLE
Increase resolution of `createInteractor()()` typing

### DIFF
--- a/.changeset/interactor-type-resolution.md
+++ b/.changeset/interactor-type-resolution.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+---
+Genericise locators and actions within interactor types, allowing their
+specific shapes to be captured and hinted at with Intellisense.

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -5,7 +5,8 @@ import { Locator } from './locator';
 import { NoSuchElementError, AmbiguousElementError, NotAbsentError } from './errors';
 import { interaction, Interaction } from './interaction';
 
-export class Interactor<E extends Element, S extends InteractorSpecification<E>> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class Interactor<E extends Element, S extends InteractorSpecification<E, any, any>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private ancestors: Array<Interactor<any, any>> = [];
 

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -9,28 +9,28 @@ export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E
 
 export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>;
 
-export interface InteractorSpecification<E extends Element> {
+export interface InteractorSpecification<E extends Element, L extends LocatorSpecification<E>, A extends ActionSpecification<E>> {
   selector: string;
   defaultLocator: LocatorFn<E>;
-  locators: LocatorSpecification<E>;
-  actions: ActionSpecification<E>;
+  locators: L;
+  actions: A;
 }
 
-export type ActionImplementation<E extends Element, S extends InteractorSpecification<E>> = {
+export type ActionImplementation<E extends Element, A extends ActionSpecification<E>, S extends InteractorSpecification<E, {}, A>> = {
   [P in keyof S['actions']]: S['actions'][P] extends ((element: E, ...args: infer TArgs) => infer TReturn) ? ((...args: TArgs) => Interaction<TReturn>) : never;
 }
 
-export type LocatorImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['locators']]: (value: string) => InteractorInstance<E, S>
+export type LocatorImplementation<E extends Element, L extends LocatorSpecification<E>, A extends ActionSpecification<E>, S extends InteractorSpecification<E, L, A>> = {
+  [P in keyof S['locators']]: (value: string) => InteractorInstance<E, A>;
 }
 
-export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E, S> & ActionImplementation<E, S>;
+export type InteractorInstance<E extends Element, A extends ActionSpecification<E>> = Interactor<E, InteractorSpecification<E, {}, A>> & ActionImplementation<E, A, InteractorSpecification<E, {}, A>>;
 
-export type InteractorType<E extends Element, S extends InteractorSpecification<E>> =
-  ((value: string) => InteractorInstance<E, S>) &
-  LocatorImplementation<E, S>;
+export type InteractorType<E extends Element, L extends LocatorSpecification<E>, A extends ActionSpecification<E>> =
+  ((value: string) => InteractorInstance<E, A>) &
+  LocatorImplementation<E, L, A, InteractorSpecification<E, L, A>>;
 
-export const defaultSpecification: InteractorSpecification<Element> = {
+export const defaultSpecification: InteractorSpecification<Element, {}, {}> = {
   selector: 'div',
   defaultLocator: (element) => element.textContent || "",
   locators: {},


### PR DESCRIPTION
## Motivation

Intellisense was not hinting at which locators and actions were available.

Expected `byHref` and `byTitle`:

<img width="565" alt="Screen Shot 2020-06-27 at 9 46 09 PM" src="https://user-images.githubusercontent.com/671032/85935785-68d24b80-b8c2-11ea-9d15-6109f27be480.png">

Expected `click`:

<img width="617" alt="Screen Shot 2020-06-27 at 9 47 25 PM" src="https://user-images.githubusercontent.com/671032/85935786-68d24b80-b8c2-11ea-8705-8158b67cf665.png">

## Approach

Genericise the locator and action interfaces throughout the interactor types, which allows their specific shapes to be captured. Without generics, `locators` and `actions` are just opaque `Record`s.

<img width="515" alt="Screen Shot 2020-06-27 at 9 48 09 PM" src="https://user-images.githubusercontent.com/671032/85935976-5e18b600-b8c4-11ea-961a-c88b94353ea4.png">
<img width="627" alt="Screen Shot 2020-06-27 at 9 48 31 PM" src="https://user-images.githubusercontent.com/671032/85935977-5e18b600-b8c4-11ea-8447-5c725fa30baa.png">
