### PR TITLE
Agent harness unification

### DIFF
--- a/.changeset/agent-harness-merge.md
+++ b/.changeset/agent-harness-merge.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/agent": minor
+---
+
+The running of the lanes has been moved from the harness to the agent.

--- a/.changeset/globals-test-frame.md
+++ b/.changeset/globals-test-frame.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/globals": minor
+---
+
+Adds support for test frame, to set a reference to the iframe that the tests are running in.

--- a/packages/agent/app/create-harness.ts
+++ b/packages/agent/app/create-harness.ts
@@ -1,10 +1,4 @@
-import { Operation, fork } from 'effection';
-import { once } from '@effection/events';
-import { bigtestGlobals } from '@bigtest/globals';
-import { TestImplementation, ErrorDetails, Context as TestContext } from '@bigtest/suite';
-
 import { ParentFrame } from './parent-frame';
-import { timebox } from './timebox';
 
 export function* createHarness() {
   console.log('[harness] starting');
@@ -13,104 +7,7 @@ export function* createHarness() {
 
   while(true) {
     let message = yield parentFrame.receive();
-
     console.info('[harness] got message', message);
-
-    if(message.type === 'run') {
-      let manifest: TestImplementation = yield loadManifest(message.manifestUrl);
-      let path = message.path.slice(1);
-      try {
-        parentFrame.send({ type: 'lane:begin', path });
-        yield runTest(parentFrame, manifest, {}, path);
-      } finally {
-        parentFrame.send({ type: 'lane:end', path });
-      }
-    }
   }
 }
 
-const serializeError: (error: ErrorDetails) => ErrorDetails = ({ message, fileName, lineNumber, columnNumber, stack }) => ({
-  message,
-  fileName,
-  lineNumber,
-  columnNumber,
-  stack
-});
-
-function *runTest(parentFrame: ParentFrame, test: TestImplementation, context: TestContext, path: string[], prefix: string[] = []): Operation<void> {
-  let currentPath = prefix.concat(test.description);
-
-  console.debug('[harness] running test', currentPath);
-  parentFrame.send({ type: 'test:running', path: currentPath })
-
-  for(let step of test.steps) {
-    let stepPath = currentPath.concat(step.description);
-    try {
-      console.debug('[harness] running step', step);
-      parentFrame.send({ type: 'step:running', path: stepPath });
-
-      let result: TestContext | void = yield timebox(step.action(context), 2000)
-
-      if (result != null) {
-        context = {...context, ...result};
-      }
-      parentFrame.send({ type: 'step:result', status: 'ok', path: stepPath });
-    } catch(error) {
-      console.error('[harness] step failed', step, error);
-      if (error.name === 'TimeoutError') {
-        parentFrame.send({
-          type: 'step:result',
-          status: 'failed',
-          timeout: true,
-          path: stepPath
-        })
-      } else {
-        parentFrame.send({
-          type: 'step:result',
-          status: 'failed',
-          timeout: false,
-          error: serializeError(error),
-          path: stepPath
-        });
-      }
-      return;
-    }
-  }
-
-  yield function*() {
-    for(let assertion of test.assertions) {
-      yield fork(function*() {
-        let assertionPath = currentPath.concat(assertion.description);
-        try {
-          console.debug('[harness] running assertion', assertion);
-          parentFrame.send({ type: 'assertion:running', path: assertionPath });
-
-          yield timebox(assertion.check(context), 2000)
-
-          parentFrame.send({ type: 'assertion:result', status: 'ok', path: assertionPath });
-        } catch(error) {
-          console.error('[harness] assertion failed', assertion, error);
-          parentFrame.send({ type: 'assertion:result', status: 'failed', error: serializeError(error), path: assertionPath });
-        }
-      });
-    }
-  }
-
-  if (path.length > 0) {
-    for (let child of test.children) {
-      if (child.description === path[0]) {
-        yield runTest(parentFrame, child, context, path.slice(1), currentPath);
-      }
-    }
-  }
-}
-
-function* loadManifest(manifestUrl: string): Operation<TestImplementation> {
-  let scriptElement = document.createElement('script') as HTMLScriptElement;
-  scriptElement.src = manifestUrl;
-  document.head.appendChild(scriptElement);
-
-  yield once(scriptElement, 'load');
-
-  return bigtestGlobals.manifest;
-}

--- a/packages/agent/app/lane.ts
+++ b/packages/agent/app/lane.ts
@@ -1,0 +1,87 @@
+import { timebox } from './timebox';
+
+import { Agent } from '../shared/agent';
+import { TestImplementation, ErrorDetails, Context as TestContext } from '@bigtest/suite';
+import { Operation, fork } from 'effection';
+
+const serializeError: (error: ErrorDetails) => ErrorDetails = ({ message, fileName, lineNumber, columnNumber, stack }) => ({
+  message,
+  fileName,
+  lineNumber,
+  columnNumber,
+  stack
+});
+
+export function *runLane(testRunId: string, agent: Agent, test: TestImplementation, path: string[]): Operation<void> {
+  return yield runLaneSegment(testRunId, agent, test, {}, path.slice(1), []);
+}
+
+function *runLaneSegment(testRunId: string, agent: Agent, test: TestImplementation, context: TestContext, remainingPath: string[], prefix: string[]): Operation<void> {
+  let currentPath = prefix.concat(test.description);
+
+  console.debug('[agent] running test', currentPath);
+  agent.send({ testRunId, type: 'test:running', path: currentPath })
+
+  for(let step of test.steps) {
+    let stepPath = currentPath.concat(step.description);
+    try {
+      console.debug('[agent] running step', step);
+      agent.send({ testRunId, type: 'step:running', path: stepPath });
+
+      let result: TestContext | void = yield timebox(step.action(context), 2000)
+
+      if (result != null) {
+        context = {...context, ...result};
+      }
+      agent.send({ testRunId, type: 'step:result', status: 'ok', path: stepPath });
+    } catch(error) {
+      console.error('[agent] step failed', step, error);
+      if (error.name === 'TimeoutError') {
+        agent.send({
+          testRunId,
+          type: 'step:result',
+          status: 'failed',
+          timeout: true,
+          path: stepPath
+        })
+      } else {
+        agent.send({
+          testRunId,
+          type: 'step:result',
+          status: 'failed',
+          timeout: false,
+          error: serializeError(error),
+          path: stepPath
+        });
+      }
+      return;
+    }
+  }
+
+  yield function*() {
+    for(let assertion of test.assertions) {
+      yield fork(function*() {
+        let assertionPath = currentPath.concat(assertion.description);
+        try {
+          console.debug('[agent] running assertion', assertion);
+          agent.send({ testRunId, type: 'assertion:running', path: assertionPath });
+
+          yield timebox(assertion.check(context), 2000)
+
+          agent.send({ testRunId, type: 'assertion:result', status: 'ok', path: assertionPath });
+        } catch(error) {
+          console.error('[agent] assertion failed', assertion, error);
+          agent.send({ testRunId, type: 'assertion:result', status: 'failed', error: serializeError(error), path: assertionPath });
+        }
+      });
+    }
+  }
+
+  if (remainingPath.length > 0) {
+    for (let child of test.children) {
+      if (child.description === remainingPath[0]) {
+        yield runLaneSegment(testRunId, agent, child, context, remainingPath.slice(1), currentPath);
+      }
+    }
+  }
+}

--- a/packages/agent/app/manifest.ts
+++ b/packages/agent/app/manifest.ts
@@ -1,0 +1,14 @@
+import { Operation } from 'effection';
+import { TestImplementation } from '@bigtest/suite';
+import { bigtestGlobals } from '@bigtest/globals';
+import { once } from '@effection/events';
+
+export function* loadManifest(manifestUrl: string): Operation<TestImplementation> {
+  let scriptElement = document.createElement('script') as HTMLScriptElement;
+  scriptElement.src = manifestUrl;
+  document.head.appendChild(scriptElement);
+
+  yield once(scriptElement, 'load');
+
+  return bigtestGlobals.manifest;
+}

--- a/packages/agent/app/test-frame.ts
+++ b/packages/agent/app/test-frame.ts
@@ -1,9 +1,12 @@
 import { Operation, resource } from 'effection';
 import { Mailbox, subscribe } from '@bigtest/effection';
+import { bigtestGlobals } from '@bigtest/globals';
 
 export class TestFrame {
   static *start(): Operation<TestFrame> {
     let element = document.getElementById('test-frame') as HTMLIFrameElement;
+
+    bigtestGlobals.testFrame = element;
 
     let mailbox = new Mailbox();
     let frame = new TestFrame(element, mailbox);

--- a/packages/globals/src/index.ts
+++ b/packages/globals/src/index.ts
@@ -2,6 +2,7 @@ import './globals';
 import { TestImplementation } from '@bigtest/suite';
 
 interface BigtestOptions {
+  testFrame?: HTMLIFrameElement;
   document?: Document;
   defaultInteractorTimeout?: number;
 }
@@ -32,7 +33,8 @@ export const bigtestGlobals = {
   },
 
   get document(): Document {
-    let doc = options().document || globalThis.document;
+    let testFrame = options().testFrame;
+    let doc = options().document || (testFrame && testFrame.contentDocument) || globalThis.document;
     if(!doc) { throw new Error('no document found') };
     return doc;
   },
@@ -47,5 +49,13 @@ export const bigtestGlobals = {
 
   set defaultInteractorTimeout(value: number) {
     options().defaultInteractorTimeout = value;
+  },
+
+  get testFrame(): HTMLIFrameElement | undefined {
+    return options().testFrame;
+  },
+
+  set testFrame(value: HTMLIFrameElement | undefined) {
+    options().testFrame = value;
   },
 };

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -4,8 +4,8 @@ import { JSDOM } from 'jsdom';
 
 import { bigtestGlobals } from '../src/index';
 
-function makeDocument(): Document {
-  return new JSDOM(`<!doctype html><html></html>`).window.document;
+function makeDocument(body = ''): Document {
+  return new JSDOM(`<!doctype html><html><body>${body}</body></html>`).window.document;
 }
 
 describe('@bigtest/globals', () => {
@@ -54,6 +54,13 @@ describe('@bigtest/globals', () => {
       expect(bigtestGlobals.document).toEqual(globalDocument);
     });
 
+    it('returns the document from the test frame if there is one', () => {
+      let myDocument = makeDocument('<iframe/>');
+      let testFrame = myDocument.querySelector('iframe') as HTMLIFrameElement;
+      bigtestGlobals.testFrame = testFrame;
+      expect(bigtestGlobals.document).toEqual(testFrame.contentDocument);
+    });
+
     it('can assign a document', () => {
       let myDocument = makeDocument();
       bigtestGlobals.document = myDocument;
@@ -69,6 +76,19 @@ describe('@bigtest/globals', () => {
     it('can assign a number', () => {
       bigtestGlobals.defaultInteractorTimeout = 3000;
       expect(bigtestGlobals.defaultInteractorTimeout).toEqual(3000);
+    });
+  });
+
+  describe('testFrame', () => {
+    it('returns undefined if there is not test frame', () => {
+      expect(bigtestGlobals.testFrame).toEqual(undefined);
+    });
+
+    it('can assign a frame', () => {
+      let myDocument = makeDocument('<iframe/>');
+      let frameElement = myDocument.querySelector('iframe') as HTMLIFrameElement;
+      bigtestGlobals.testFrame = frameElement;
+      expect(bigtestGlobals.testFrame).toEqual(frameElement);
     });
   });
 })


### PR DESCRIPTION
Previously the responsibility for running lanes of a test was delegated to the harness, this moves this responsibility to the agent. See #286. By moving this responsibility to the agent, we avoid losing state when we move to another page.

Essentially this makes the harness pretty useless at the moment. But I've neverless left all of the machinery for the harness in place, because I expect that we will need it once we want to do some more advanced setup where the agent shares its state with the harness.