### PR TITLE
Add App Interactor, stop loading app automatically

### DIFF
--- a/.changeset/app-interactor.md
+++ b/.changeset/app-interactor.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/globals": minor
+"@bigtest/interactor": minor
+"@bigtest/agent": minor
+---
+Add an app interactor which can be used to load the application into the test frame. Agent no longer loads app automatically.

--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -1,5 +1,6 @@
 import * as Bowser from 'bowser';
 import { TestImplementation } from '@bigtest/suite';
+import { bigtestGlobals } from '@bigtest/globals';
 import { TestFrame } from './test-frame';
 import { QueryParams } from './query-params';
 import { Agent, Run } from '../shared/agent';
@@ -52,7 +53,10 @@ function* run(agent: Agent, testFrame: TestFrame, command: Run) {
   try {
     for (let lanePath of lanePaths(test)) {
       console.log('[agent] running lane', lanePath);
-      yield testFrame.load(appUrl);
+
+      testFrame.clear();
+      bigtestGlobals.appUrl = appUrl;
+
       yield runLane(testRunId, agent, test, lanePath);
       console.log('[agent] lane completed', lanePath);
     }

--- a/packages/agent/app/test-frame.ts
+++ b/packages/agent/app/test-frame.ts
@@ -33,4 +33,8 @@ export class TestFrame {
     let { args: [message] } = yield this.mailbox.receive();
     return JSON.parse(message.data);
   }
+
+  clear() {
+    this.element.src = 'about:blank';
+  }
 }

--- a/packages/globals/src/index.ts
+++ b/packages/globals/src/index.ts
@@ -5,6 +5,7 @@ interface BigtestOptions {
   testFrame?: HTMLIFrameElement;
   document?: Document;
   defaultInteractorTimeout?: number;
+  appUrl?: string;
 }
 
 const defaultManifest: TestImplementation = {
@@ -58,4 +59,17 @@ export const bigtestGlobals = {
   set testFrame(value: HTMLIFrameElement | undefined) {
     options().testFrame = value;
   },
+
+  get appUrl(): string | undefined {
+    return options().appUrl;
+  },
+
+  set appUrl(value: string | undefined) {
+    options().appUrl = value;
+  },
+
+  reset() {
+    delete globalThis.__bigtest;
+    delete globalThis.__bigtestManifest;
+  }
 };

--- a/packages/globals/test/globals.test.ts
+++ b/packages/globals/test/globals.test.ts
@@ -10,8 +10,7 @@ function makeDocument(body = ''): Document {
 
 describe('@bigtest/globals', () => {
   beforeEach(() => {
-    delete globalThis.__bigtestManifest;
-    delete globalThis.__bigtest;
+    bigtestGlobals.reset();
     delete globalThis.document;
   });
 

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "lint": "eslint '{src,test}/**/*.ts'",
+    "mocha": "mocha -r ts-node/register",
     "test:unit": "mocha -r ts-node/register test/**/*.test.ts",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",

--- a/packages/interactor/src/app.ts
+++ b/packages/interactor/src/app.ts
@@ -1,26 +1,21 @@
 import { interaction, Interaction } from './interaction';
 import { bigtestGlobals } from '@bigtest/globals';
 
-async function visit(path: string) {
-  let appUrl = bigtestGlobals.appUrl;
-  if(!appUrl) {
-    throw new Error('no app url defined');
-  }
-  let testFrame = bigtestGlobals.testFrame;
-  if(!testFrame) {
-    throw new Error('no test frame defined');
-  }
-
-  let url = new URL(appUrl);
-  url.pathname = path;
-  testFrame.src = url.toString();
-}
-
 export const App = {
-  load(): Interaction<void> {
-    return interaction('loading the app', () => visit('/'));
-  },
-  visit(path: string): Interaction<void> {
-    return interaction(`visiting ${JSON.stringify(path)}`, () => visit(path));
+  visit(path = '/'): Interaction<void> {
+    return interaction(`visiting ${JSON.stringify(path)}`, async () => {
+      let appUrl = bigtestGlobals.appUrl;
+      if(!appUrl) {
+        throw new Error('no app url defined');
+      }
+      let testFrame = bigtestGlobals.testFrame;
+      if(!testFrame) {
+        throw new Error('no test frame defined');
+      }
+
+      let url = new URL(appUrl);
+      url.pathname = path;
+      testFrame.src = url.toString();
+    });
   }
 }

--- a/packages/interactor/src/app.ts
+++ b/packages/interactor/src/app.ts
@@ -1,0 +1,26 @@
+import { interaction, Interaction } from './interaction';
+import { bigtestGlobals } from '@bigtest/globals';
+
+async function visit(path: string) {
+  let appUrl = bigtestGlobals.appUrl;
+  if(!appUrl) {
+    throw new Error('no app url defined');
+  }
+  let testFrame = bigtestGlobals.testFrame;
+  if(!testFrame) {
+    throw new Error('no test frame defined');
+  }
+
+  let url = new URL(appUrl);
+  url.pathname = path;
+  testFrame.src = url.toString();
+}
+
+export const App = {
+  load(): Interaction<void> {
+    return interaction('loading the app', () => visit('/'));
+  },
+  visit(path: string): Interaction<void> {
+    return interaction(`visiting ${JSON.stringify(path)}`, () => visit(path));
+  }
+}

--- a/packages/interactor/src/index.ts
+++ b/packages/interactor/src/index.ts
@@ -1,2 +1,3 @@
 export { Interactor } from './interactor';
 export { createInteractor } from './create-interactor';
+export { App } from './app';

--- a/packages/interactor/test/app.test.ts
+++ b/packages/interactor/test/app.test.ts
@@ -1,0 +1,60 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { bigtestGlobals } from '@bigtest/globals';
+import { JSDOM } from 'jsdom';
+
+import { App } from '../src/index';
+
+describe('@bigtest/interactor', () => {
+  beforeEach(() => {
+    bigtestGlobals.reset();
+    let jsdom = new JSDOM(`<!doctype html><html><body><iframe/></body></html>`);
+    bigtestGlobals.testFrame = jsdom.window.document.querySelector('iframe') as HTMLIFrameElement;
+    bigtestGlobals.appUrl = 'http://example.com';
+  });
+
+  describe('App', () => {
+    describe('load', () => {
+      it('can load the app by visiting the root path', async () => {
+        await App.load();
+        await expect(bigtestGlobals.testFrame?.src).toEqual('http://example.com/');
+      });
+
+      it('is an interaction which can describe itself', async () => {
+        expect(App.load().description).toEqual('loading the app');
+      });
+
+      it('throws an error if app url is not defined', async () => {
+        bigtestGlobals.appUrl = undefined;
+        await expect(App.load()).rejects.toThrow('no app url defined');
+      });
+
+      it('throws an error if test frame is not defined', async () => {
+        bigtestGlobals.testFrame = undefined;
+        await expect(App.load()).rejects.toThrow('no test frame defined');
+      });
+    });
+
+    describe('visit', () => {
+      it('can load the app by visiting the given path', async () => {
+        await App.visit('/foobar');
+        await expect(bigtestGlobals.testFrame?.src).toEqual('http://example.com/foobar');
+      });
+
+      it('is an interaction which can describe itself', async () => {
+        expect(App.visit('/foobar').description).toEqual('visiting "/foobar"');
+      });
+
+      it('throws an error if app url is not defined', async () => {
+        bigtestGlobals.appUrl = undefined;
+        await expect(App.visit('/foobar')).rejects.toThrow('no app url defined');
+      });
+
+      it('throws an error if test frame is not defined', async () => {
+        bigtestGlobals.testFrame = undefined;
+        await expect(App.visit('/foobar')).rejects.toThrow('no test frame defined');
+      });
+    });
+  });
+});

--- a/packages/interactor/test/app.test.ts
+++ b/packages/interactor/test/app.test.ts
@@ -15,28 +15,12 @@ describe('@bigtest/interactor', () => {
   });
 
   describe('App', () => {
-    describe('load', () => {
+    describe('visit', () => {
       it('can load the app by visiting the root path', async () => {
-        await App.load();
+        await App.visit();
         await expect(bigtestGlobals.testFrame?.src).toEqual('http://example.com/');
       });
 
-      it('is an interaction which can describe itself', async () => {
-        expect(App.load().description).toEqual('loading the app');
-      });
-
-      it('throws an error if app url is not defined', async () => {
-        bigtestGlobals.appUrl = undefined;
-        await expect(App.load()).rejects.toThrow('no app url defined');
-      });
-
-      it('throws an error if test frame is not defined', async () => {
-        bigtestGlobals.testFrame = undefined;
-        await expect(App.load()).rejects.toThrow('no test frame defined');
-      });
-    });
-
-    describe('visit', () => {
       it('can load the app by visiting the given path', async () => {
         await App.visit('/foobar');
         await expect(bigtestGlobals.testFrame?.src).toEqual('http://example.com/foobar');

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -30,14 +30,17 @@ const Details = createInteractor<HTMLDetailsElement>('details')({
   defaultLocator: (element) => element.querySelector('summary')?.textContent || ''
 });
 
-bigtestGlobals.defaultInteractorTimeout = 20;
-
 function dom(html: string) {
   let jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
   bigtestGlobals.document = jsdom.window.document;
 }
 
 describe('@bigtest/interactor', () => {
+  beforeEach(() => {
+    bigtestGlobals.reset();
+    bigtestGlobals.defaultInteractorTimeout = 20;
+  });
+
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`


### PR DESCRIPTION
The agent no longer loads the app automatically for each test lane, rather the user will need to load the app manually via `App.load()` or `App.visit(path)` somewhere. These can be required from the interactor package like this:

``` typescript
import { App, Link } from '@bigtest/interactor';
import { test } from '@bigtest/suite';

export default test('some test')
  .step(App.load())
  .step(Link('whatever').click())
```

Depends on #377 