### PR TITLE
Wait for test frame to be cleared before running test.

### DIFF
--- a/.changeset/wait-for-clear-frame.md
+++ b/.changeset/wait-for-clear-frame.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/agent": patch
+---
+Wait for test frame to be cleared

--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -54,9 +54,8 @@ function* run(agent: Agent, testFrame: TestFrame, command: Run) {
     for (let lanePath of lanePaths(test)) {
       console.log('[agent] running lane', lanePath);
 
-      testFrame.clear();
       bigtestGlobals.appUrl = appUrl;
-
+      yield testFrame.clear();
       yield runLane(testRunId, agent, test, lanePath);
       console.log('[agent] lane completed', lanePath);
     }

--- a/packages/agent/app/test-frame.ts
+++ b/packages/agent/app/test-frame.ts
@@ -1,6 +1,7 @@
 import { Operation, resource } from 'effection';
 import { Mailbox, subscribe } from '@bigtest/effection';
 import { bigtestGlobals } from '@bigtest/globals';
+import { once } from '@effection/events';
 
 export class TestFrame {
   static *start(): Operation<TestFrame> {
@@ -34,7 +35,8 @@ export class TestFrame {
     return JSON.parse(message.data);
   }
 
-  clear() {
+  *clear(): Operation<void> {
     this.element.src = 'about:blank';
+    yield once(this.element, 'load');
   }
 }


### PR DESCRIPTION
Otherwise this could cause a race condition where the test frame is cleared after we have already begun running the test.