### PR TITLE
Pass arguments to actions

### DIFF
--- a/.changeset/action-arguments.md
+++ b/.changeset/action-arguments.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/interactor": "patch"
+---
+Interactor actions should forward arguments

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -12,11 +12,15 @@ export function createInteractor<E extends Element>(interactorName: string) {
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {
-        value: function() {
-          return interaction(`performing ${actionName} on ${this.description}`, () => {
+        value: function(...args: unknown[]) {
+          let actionDescription = actionName;
+          if(args.length) {
+            actionDescription += ` with ` + args.map((a) => JSON.stringify(a)).join(', ');
+          }
+          return interaction(`${actionDescription} on ${this.description}`, () => {
             return converge(() => {
               let element = this.unsafeSyncResolve();
-              return action(element);
+              return action(element, ...args);
             });
           });
         },

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -13,7 +13,8 @@ const Link = createInteractor<HTMLLinkElement>('link')({
     byTitle: (element) => element.title
   },
   actions: {
-    click: (element) => { element.click() }
+    click: (element) => { element.click() },
+    setHref: (element, value: string) => { element.href = value }
   }
 });
 
@@ -183,6 +184,15 @@ describe('@bigtest/interactor', () => {
       await Header('Hello!').exists();
     });
 
+    it('can pass arguments to action', async () => {
+      dom(`
+        <a id="foo" href="/foobar">Foo Bar</a>
+      `);
+
+      await Link('Foo Bar').setHref('/monkey');
+      await Link.byHref('/monkey').exists();
+    });
+
     it('does nothing unless awaited', async () => {
       dom(`
         <a id="foo" href="/foobar">Foo Bar</a>
@@ -214,7 +224,11 @@ describe('@bigtest/interactor', () => {
     });
 
     it('can return description of interaction', () => {
-      expect(Div("foo").find(Link('Foo Bar')).click().description).toEqual('performing click on link "Foo Bar" within div "foo"');
+      expect(Div("foo").find(Link('Foo Bar')).click().description).toEqual('click on link "Foo Bar" within div "foo"');
+    });
+
+    it('can return description of interaction with argument', () => {
+      expect(Link('Foo Bar').setHref('/monkey').description).toEqual('setHref with "/monkey" on link "Foo Bar"');
     });
   });
 })


### PR DESCRIPTION
Closes #380 

Actions should forward arguments to the action specification function, but currently they do not do this.
