### PR TITLE
Improve atom

### DIFF
--- a/.changeset/atom-channel.md
+++ b/.changeset/atom-channel.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/atom": "minor"
+---
+Switch to using channel internally. Changes return type of subscription from `void` to `undefined`.

--- a/.changeset/atom-each.md
+++ b/.changeset/atom-each.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/atom": "minor"
+---
+Remove `Atom#each`, use `forEach` instead.

--- a/.changeset/atom-set.md
+++ b/.changeset/atom-set.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/atom": "minor"
+---
+Add `set` method to `Atom`

--- a/.changeset/atom-slice.md
+++ b/.changeset/atom-slice.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/atom": "minor"
+---
+Add `once` method to `Slice`.

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint '{src,test}/**/*.ts'",
+    "mocha": "mocha -r ts-node/register",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },
@@ -27,6 +28,7 @@
     "ts-node": "*"
   },
   "dependencies": {
+    "@effection/channel": "^0.6.4",
     "@effection/events": "^0.7.4",
     "@effection/subscription": "^0.9.0",
     "effection": "0.7.0",

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -28,7 +28,7 @@
     "ts-node": "*"
   },
   "dependencies": {
-    "@effection/channel": "^0.6.4",
+    "@effection/channel": "^0.6.5",
     "@effection/events": "^0.7.4",
     "@effection/subscription": "^0.9.0",
     "effection": "0.7.0",

--- a/packages/atom/test/slice.test.ts
+++ b/packages/atom/test/slice.test.ts
@@ -1,0 +1,127 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import { Atom } from '../src/atom';
+import { spawn } from './helpers';
+import { Slice } from '../src/slice';
+import { Subscription, subscribe } from '@effection/subscription';
+
+type Data = { data: string };
+
+describe('@bigtest/atom', () => {
+  describe('Slice', () => {
+    let atom: Atom<Data>;
+    let slice: Slice<string, Data>;
+
+    beforeEach(() => {
+      atom = new Atom({ data: 'foo' });
+      slice = atom.slice<string>(['data']);
+    });
+
+    describe('.get()', () => {
+      it('gets the current state', () => {
+        expect(slice.get()).toEqual('foo');
+      });
+    });
+
+    describe('.update()', () => {
+      beforeEach(() => {
+        slice.update(previous => {
+          expect(previous).toEqual('foo');
+          return 'bar';
+        });
+      });
+
+      it('updates the current state', () => {
+        expect(slice.get()).toEqual('bar');
+      });
+
+      it('updates the atom state', () => {
+        expect(atom.get()).toEqual({ data: 'bar' });
+      });
+    });
+
+    describe('.once()', () => {
+      let result: Promise<string | undefined>;
+
+      describe('when initial state matches', () => {
+        beforeEach(async () => {
+          result = spawn(slice.once((state) => state === 'foo'));
+
+          slice.update(() => 'bar');
+        });
+
+        it('gets the first state that passes the given predicate', async () => {
+          expect(await result).toEqual('foo');
+          expect(slice.get()).toEqual('bar');
+        });
+      });
+
+      describe('when initial state does not match', () => {
+        beforeEach(async () => {
+          result = spawn(slice.once((state) => state === 'baz'));
+
+          slice.update(() => 'bar');
+          slice.update(() => 'baz');
+          slice.update(() => 'quox');
+        });
+
+        it('gets the first state that passes the given predicate', async () => {
+          expect(await result).toEqual('baz');
+          expect(slice.get()).toEqual('quox');
+        });
+      });
+    });
+
+    describe('.slice()', () => {
+      let atom: Atom<{ outer: Data }>;
+      let slice1: Slice<Data, { outer: Data }>;
+      let slice2: Slice<string, { outer: Data }>;
+
+      beforeEach(() => {
+        atom = new Atom<{ outer: Data }>({ outer: { data: "baz" } });
+        slice1 = atom.slice(['outer']);
+        slice2 = slice1.slice(['data']);
+      });
+
+      it('further slices the slice', async () => {
+        expect(slice2.get()).toEqual('baz');
+      });
+
+      describe('updating the returned slice', () => {
+        beforeEach(() => {
+          slice2.set('blah');
+        });
+
+        it('updates the current state', () => {
+          expect(slice2.get()).toEqual('blah');
+        });
+
+        it('updates the parent slice state', () => {
+          expect(slice1.get()).toEqual({ data: 'blah' });
+        });
+
+        it('updates the atom state', () => {
+          expect(atom.get()).toEqual({ outer: { data: 'blah' } });
+        });
+      });
+    });
+
+    describe('subscribe', () => {
+      let subscription: Subscription<string, undefined>;
+
+      beforeEach(async () => {
+        subscription = await spawn(subscribe(slice));
+
+        slice.update(() => 'bar');
+        slice.update(() => 'baz');
+        slice.update(() => 'quox');
+      });
+
+      it('iterates over emitted states', async () => {
+        await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'bar' });
+        await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'baz' });
+        await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'quox' });
+      });
+    });
+  });
+});

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -1,4 +1,5 @@
 import { Operation, spawn, fork } from 'effection';
+import { forEach } from '@effection/subscription';
 import { Mailbox } from '@bigtest/effection';
 import { express, Socket } from '@bigtest/effection-express';
 import * as graphqlHTTP from 'express-graphql';
@@ -70,7 +71,7 @@ function handleMessage(options: CommandServerOptions): (socket: Socket) => Opera
     yield publishQueryResult(message, options.atom.get(), socket);
 
     if (message.live) {
-      yield fork(options.atom.each(state => publishQueryResult(message, state, socket)));
+      yield fork(forEach(options.atom, (state) => publishQueryResult(message, state, socket)));
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,7 +2165,24 @@
     "@effection/subscription" "^0.9.0"
     effection "^0.7.0"
 
-"@effection/events@^0.7.4", "@effection/events@^0.7.6":
+"@effection/channel@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@effection/channel/-/channel-0.6.5.tgz#92e02160afe50d4a4c48628afed38b7511d53ccc"
+  integrity sha512-poiEeAi1uLVjPJCzM9BUCXkaa8GbwDzbwsmbUlrtapTedW3Ca5T2HoFFeW+3l+o2CxSmXRiU466mEncp36p/rg==
+  dependencies:
+    "@effection/events" "^0.7.6"
+    "@effection/subscription" "^0.9.0"
+    effection "^0.7.0"
+
+"@effection/events@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.7.5.tgz#ff391395395b9cbffb3d5afdfcc228e0b6237cce"
+  integrity sha512-WAL8LTuzbogySy9tDgWiIveScVhFy/vvrCxWNgrtN9hph6PwpVKxEg55CoPvjPAz93JuC8qcotAbaWEXp2eoVQ==
+  dependencies:
+    "@effection/subscription" "^0.8.0"
+    effection "^0.7.0"
+
+"@effection/events@^0.7.6":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@effection/events/-/events-0.7.6.tgz#efa9aefc1b0eb013c225af7c46423b540e759f0b"
   integrity sha512-pTThApQxFPFpeRqfW3RnZYASGzw80tTIw5IrUjAt9OwCZJ7WOTEOEFX7YTeh0/fw92YGAjZOKdv6PP37qKF8aQ==


### PR DESCRIPTION
Makes some breaking changes to atom, to make it more usable.

- Switch to using `Channel` internally
- Return type of subscription is `undefined` instead of `void`
- Add `once` method to `Slice`
- Add `set` to `Atom`
- Remove `Atom#each`, use `forEach` instead.

Depends on https://github.com/thefrontside/effection/pull/173 https://github.com/thefrontside/effection/pull/175