### PR TITLE
Set exit code based on result of running suite

### DIFF
--- a/.changeset/cli-exit-code.md
+++ b/.changeset/cli-exit-code.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/cli": "minor"
+---
+Set exit code based on result of running test suite

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
     "@bigtest/performance": "^0.5.0",
     "@bigtest/project": "^0.5.1",
     "@bigtest/server": "^0.8.0",
-    "@effection/node": "^0.6.5",
+    "@effection/node": "^0.8.0",
     "capture-console": "^1.0.1",
     "deepmerge": "^4.2.2",
     "effection": "^0.7.0",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -20,9 +20,11 @@ export function * CLI(argv: string[]): Operation {
     yield;
   } else if (command === 'test') {
     yield runTest(config, lines);
-  } else {
+  } else if (command === 'ci') {
     yield startServer(config);
     yield runTest(config, lines);
+  } else {
+    throw new Error(`unknown command: ${command}`);
   }
 }
 
@@ -34,6 +36,10 @@ function parseOptions(config: ProjectOptions, argv: readonly string[]): Command 
         type: 'array',
         choices: Object.keys(config.drivers),
         default: config.launch,
+      })
+      .option('test-files', {
+        describe: 'file globs which form the test suite',
+        type: 'array'
       })
   };
 
@@ -56,6 +62,9 @@ function parseOptions(config: ProjectOptions, argv: readonly string[]): Command 
 
   if(rawOptions['launch']) {
     config.launch = rawOptions['launch'];
+  }
+  if(rawOptions['testFiles']) {
+    config.testFiles = rawOptions['testFiles'] as string[];
   }
 
   return rawOptions._[0] as Command;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,4 @@
 import { CLI } from './cli';
 import { main } from '@effection/node';
 
-main(function* boot() {
-  yield CLI(process.argv.slice(2));
-});
+main(CLI(process.argv.slice(2)));

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -5,8 +5,9 @@ import { ResultStatus } from '@bigtest/suite';
 import { Client } from '@bigtest/server';
 import * as query from './query';
 import { StreamingFormatter } from './format-helpers';
+import { SuiteError } from './suite-error';
 
-export function* runTest(config: ProjectOptions, formatter: StreamingFormatter): Operation<ResultStatus> {
+export function* runTest(config: ProjectOptions, formatter: StreamingFormatter): Operation<void> {
   let client: Client = yield Client.create(`ws://localhost:${config.port}`);
 
   let subscription = yield client.subscription(query.run());
@@ -46,5 +47,7 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     assertionCounts,
   });
 
-  return testRunStatus || 'failed';
+  if(testRunStatus !== 'ok') {
+    throw new SuiteError();
+  }
 }

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -3,9 +3,9 @@ import { ProjectOptions } from '@bigtest/project';
 import { performance } from '@bigtest/performance';
 import { ResultStatus } from '@bigtest/suite';
 import { Client } from '@bigtest/server';
+import { MainError } from '@effection/node';
 import * as query from './query';
 import { StreamingFormatter } from './format-helpers';
-import { SuiteError } from './suite-error';
 
 export function* runTest(config: ProjectOptions, formatter: StreamingFormatter): Operation<void> {
   let client: Client = yield Client.create(`ws://localhost:${config.port}`);
@@ -48,6 +48,6 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
   });
 
   if(testRunStatus !== 'ok') {
-    throw new SuiteError();
+    throw new MainError({ exitCode: 1 });
   }
 }

--- a/packages/cli/src/suite-error.ts
+++ b/packages/cli/src/suite-error.ts
@@ -1,9 +1,0 @@
-export class SuiteError extends Error {
-  constructor() {
-    super("suite failed")
-  }
-
-  name = "SuiteError";
-  effectionSilent = true;
-  effectionExitCode = 1;
-}

--- a/packages/cli/src/suite-error.ts
+++ b/packages/cli/src/suite-error.ts
@@ -1,0 +1,9 @@
+export class SuiteError extends Error {
+  constructor() {
+    super("suite failed")
+  }
+
+  name = "SuiteError";
+  effectionSilent = true;
+  effectionExitCode = 1;
+}

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -122,7 +122,7 @@ describe('@bigtest/cli', function() {
         expect(child.stdout?.output).toContain("✓ [step]       Failing Test -> first step")
         expect(child.stdout?.output).toContain("✓ [assertion]  Failing Test -> check the thing")
         expect(child.stdout?.output).toContain("⨯ [step]       Failing Test -> child -> child second step")
-        expect(child.stdout?.output).toContain("✓ FAILURE")
+        expect(child.stdout?.output).toContain("⨯ FAILURE")
       });
     });
   });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -38,7 +38,7 @@ describe('@bigtest/cli', function() {
       let runChild: Process;
 
       beforeEach(async () => {
-        startChild = await World.spawn(run('server', '--launch', 'chrome.headless'));
+        startChild = await World.spawn(run('server', '--launch', 'chrome.headless', '--test-files', './test/fixtures/passing.test.ts'));
 
         await World.spawn(startChild.stdout?.waitFor("[orchestrator] running!"));
 
@@ -56,6 +56,30 @@ describe('@bigtest/cli', function() {
         expect(runChild.stdout?.output).toContain("SUCCESS")
       });
     });
+
+    describe('running the suite with failures', () => {
+      let startChild: Process;
+      let runChild: Process;
+
+      beforeEach(async () => {
+        startChild = await World.spawn(run('server', '--launch', 'chrome.headless', '--test-files', './test/fixtures/failing.test.ts'));
+
+        await World.spawn(startChild.stdout?.waitFor("[orchestrator] running!"));
+
+        runChild = await World.spawn(run('test'));
+
+        await World.spawn(runChild.join());
+      });
+
+      afterEach(async () => {
+        await World.spawn(startChild.close());
+      });
+
+      it('exits with error code', async () => {
+        expect(runChild.code).toEqual(1);
+        expect(runChild.stdout?.output).toContain("FAILURE")
+      });
+    });
   });
 
   describe('ci', () => {
@@ -63,7 +87,7 @@ describe('@bigtest/cli', function() {
       let child: Process;
 
       beforeEach(async () => {
-        child = await World.spawn(run('ci', '--launch', 'chrome.headless', '--log-level', 'debug'));
+        child = await World.spawn(run('ci', '--launch', 'chrome.headless', '--test-files', './test/fixtures/passing.test.ts'));
         await World.spawn(child.stdout?.waitFor("[orchestrator] running!"));
         await World.spawn(child.join());
       });
@@ -77,6 +101,28 @@ describe('@bigtest/cli', function() {
         expect(child.stdout?.output).toContain("✓ [step]       Passing Test -> first step")
         expect(child.stdout?.output).toContain("✓ [assertion]  Passing Test -> check the thing")
         expect(child.stdout?.output).toContain("✓ SUCCESS")
+      });
+    });
+
+    describe('running the suite with failures', () => {
+      let child: Process;
+
+      beforeEach(async () => {
+        child = await World.spawn(run('ci', '--launch', 'chrome.headless', '--test-files', './test/fixtures/failing.test.ts'));
+        await World.spawn(child.stdout?.waitFor("[orchestrator] running!"));
+        await World.spawn(child.join());
+      });
+
+      afterEach(async () => {
+        await World.spawn(child.close());
+      });
+
+      it('exits with error code', async () => {
+        expect(child.code).toEqual(1);
+        expect(child.stdout?.output).toContain("✓ [step]       Failing Test -> first step")
+        expect(child.stdout?.output).toContain("✓ [assertion]  Failing Test -> check the thing")
+        expect(child.stdout?.output).toContain("⨯ [step]       Failing Test -> child -> child second step")
+        expect(child.stdout?.output).toContain("✓ FAILURE")
       });
     });
   });

--- a/packages/cli/test/fixtures/failing.test.ts
+++ b/packages/cli/test/fixtures/failing.test.ts
@@ -1,0 +1,16 @@
+import { test } from '@bigtest/suite';
+
+const delay = (time = 50) =>
+  async () => { await new Promise(resolve => setTimeout(resolve, time)) };
+
+export default test('Failing Test')
+  .step("first step", delay())
+  .step("second step", delay())
+  .step("third step", delay())
+  .assertion("check the thing", delay(3))
+  .child(
+    "child", test => test
+      .step("child first step", delay())
+      .step("child second step", async () => { throw new Error('moo') })
+      .step("child third step", delay())
+      .assertion("child first assertion", delay(5)));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,6 +2208,14 @@
     "@effection/events" "^0.7.4"
     effection "^0.7.0"
 
+"@effection/node@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@effection/node/-/node-0.8.0.tgz#a73069ecd60c628d1aa2b9e61a8ff930be8faa7c"
+  integrity sha512-p+6QQINBvGO0ev05LKRMlcsC567ubfBfEefkzNRBNWb1drumOMtD8FMjZjWCB/brPLPO5un7CAOErorfCHvkaA==
+  dependencies:
+    "@effection/events" "^0.7.4"
+    effection "^0.7.0"
+
 "@effection/subscription@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@effection/subscription/-/subscription-0.8.1.tgz#aa0286549b2bb833f211010db33c0324f6b59d81"


### PR DESCRIPTION
Our CLI commands should set the proper exit code 

- [x] Depends on #392 
- [x] Depends on #393 
- [x] Depends on thefrontside/effection#173
- [x] Depends on thefrontside/effection#174