### PR TITLE
Pipe app log to file

### DIFF
--- a/.changeset/app-log-file.md
+++ b/.changeset/app-log-file.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": "minor"
+---
+
+Pipe app server log to file.

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -44,6 +44,8 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
 
   let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');
 
+  let appLogPath = path.resolve(options.project.cacheDir, 'app.log');
+
   let connectTo = `ws://localhost:${options.project.connection.port}`;
 
   let browserManager: BrowserManager = yield createBrowserManager({
@@ -77,6 +79,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
 
   yield fork(createAppServer({
     delegate: appServerDelegate,
+    logPath: appLogPath,
     ...options.project.app
   }));
 


### PR DESCRIPTION
This is a pretty low-tech solution which gives us at least *some* ability to debug failures in the app server by looking at the log file. I won't have time to build a more comprehensive solution before my vacation, so I will leave this here and focus on building out capturing console logs, which I think is probably more valuable.