### PR TITLE
remove runtime dependency on @bigtest/interactor

### DIFF
--- a/.changeset/remove-agent-interactor-dep.md
+++ b/.changeset/remove-agent-interactor-dep.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/agent": patch
+---
+make @bigtest/interactor a devDependency only since it is only used in
+tests

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -20,6 +20,7 @@
     "manifest:build": "parcel build test/fixtures/manifest.src.js --out-dir test/fixtures --out-file manifest.js --no-minify --global __bigtestManifest"
   },
   "devDependencies": {
+    "@bigtest/interactor": "^0.13.0",
     "@bigtest/parcel": "^0.5.2",
     "@bigtest/suite": "^0.5.2",
     "@bigtest/webdriver": "^0.5.4",
@@ -44,7 +45,6 @@
     "@bigtest/effection": "^0.5.1",
     "@bigtest/effection-express": "^0.6.0",
     "@bigtest/globals": "^0.6.0",
-    "@bigtest/interactor": "^0.14.0",
     "@effection/events": "^0.7.4",
     "bowser": "^2.9.0",
     "effection": "^0.7.0"


### PR DESCRIPTION
`@bigtest/agent` only depends on `@bigtest/interactor` in its test suite, but doesn't have anything to do with it at runtime. 

This just moves it to  `devDependencies`