### PR TITLE
Manifest builder improvements

### DIFF
--- a/.changeset/bundler-shutdown.md
+++ b/.changeset/bundler-shutdown.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": patch
+---
+
+The `try`/`finally` in `Bundler` was not wrapping the code that it should have; switch to using `ensure()` API.

--- a/.changeset/bundler-shutdown.md
+++ b/.changeset/bundler-shutdown.md
@@ -2,4 +2,4 @@
 "@bigtest/bundler": patch
 ---
 
-The `try`/`finally` in `Bundler` was not wrapping the code that it should have; switch to using `ensure()` API.
+The `try`/`finally` in `Bundler` was not wrapping the code that it should have; fix this by wrapping more.

--- a/.changeset/manifest-builder-warnings.md
+++ b/.changeset/manifest-builder-warnings.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Work around bug in node.js that throws warnings when using `fs.promises.truncate()`: https://github.com/nodejs/node/issues/34189

--- a/.changeset/manifest-watcher.md
+++ b/.changeset/manifest-watcher.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": patch
+---
+
+Properly ignore `node_modules` from `Bundler` file watcher.

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -2,7 +2,6 @@ import { Operation, resource } from 'effection';
 import { on } from '@effection/events';
 import { subscribe, Subscribable, SymbolSubscribable, ChainableSubscription } from '@effection/subscription';
 import { Channel } from '@effection/channel';
-import { ensure } from '@bigtest/effection';
 import { watch, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
 import resolve from '@rollup/plugin-node-resolve';
 import * as commonjs from '@rollup/plugin-commonjs';

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -28,6 +28,9 @@ export type BundlerMessage =
   | { type: 'error'; error: BundlerError };
 
 function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: BundlerOptions = { mainFields: ["browser", "main"] }): Array<RollupWatchOptions> {
+  // Rollup types are wrong; `watch.exclude` allows RegExp[]
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
   return bundles.map(bundle => {
     return {
       input: bundle.entry,
@@ -38,7 +41,7 @@ function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: Bun
         format: 'umd',
       },
       watch: {
-        exclude: ['node_modules/**']
+        exclude: [/node_modules/]
       },
       plugins: [
         resolve({

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -2,7 +2,7 @@ import { bigtestGlobals } from '@bigtest/globals';
 import { Operation } from 'effection';
 import { once } from '@effection/events';
 import { subscribe, ChainableSubscription } from '@effection/subscription';
-import { Mailbox, ensure, Deferred } from '@bigtest/effection';
+import { Mailbox, Deferred } from '@bigtest/effection';
 import { Bundler, BundlerMessage, BundlerError } from '@bigtest/bundler';
 import { Atom } from '@bigtest/atom';
 import { createFingerprint } from 'fprint';
@@ -41,8 +41,12 @@ function* ftruncate(fd: number, len: number): Operation<void> {
 // https://github.com/nodejs/node/issues/34189#issuecomment-654878715
 function* truncate(path: string, len: number): Operation {
   let file: fs.promises.FileHandle = yield open(path, 'r+');
-  yield ensure(() => file.close());
-  yield ftruncate(file.fd, len);
+
+  try {
+    yield ftruncate(file.fd, len);
+  } finally {
+    file.close();
+  }
 }
 
 export function* updateSourceMapURL(filePath: string, sourcemapName: string): Operation{


### PR DESCRIPTION
## Motivation

I noticed a few things to clean up:

- Rollup wasn't properly excluding node_modules from watch
- The `Bundler` `try/finally` was not wrapping the code that needed it
- At the default log level, users see manifest build errors, but nothing when the build becomes successful
- There is a bug in `fs.promises.truncate()` that causes warnings https://github.com/nodejs/node/issues/34189

## Approach

- Use a regex to exclude node_modules from rollup watch
- Use `ensure()` API instead of `try/finally` in `Bundler`
- Upgrade the log level of the successful manifest build notification
- Use `ftruncate()` instead of `truncate()` until the [fix](https://github.com/nodejs/node/pull/34239#issuecomment-656168437) is released