### PR TITLE
Track console messages and uncaught errors

### DIFF
--- a/.changeset/angry-ways-talk.md
+++ b/.changeset/angry-ways-talk.md
@@ -1,0 +1,8 @@
+---
+"@bigtest/agent": minor
+"@bigtest/cli": minor
+"@bigtest/server": minor
+"@bigtest/suite": minor
+---
+
+Track console messages and uncaught errors and make them available via the API

--- a/packages/agent/app/harness-protocol.ts
+++ b/packages/agent/app/harness-protocol.ts
@@ -1,5 +1,5 @@
 import { ErrorDetails, ConsoleMessage } from '@bigtest/suite';
 
 export type HarnessMessage =
-  { type: 'console'; message: ConsoleMessage } |
-  { type: 'error'; error: ErrorDetails };
+  { type: 'message'; occurredAt: string, message: ConsoleMessage } |
+  { type: 'error'; occurredAt: string, error: ErrorDetails };

--- a/packages/agent/app/harness-protocol.ts
+++ b/packages/agent/app/harness-protocol.ts
@@ -1,4 +1,6 @@
+import { ErrorDetails } from '@bigtest/suite';
 import { ConsoleMessage } from '../shared/protocol';
 
 export type HarnessMessage =
-  { type: 'console'; message: ConsoleMessage };
+  { type: 'console'; message: ConsoleMessage } |
+  { type: 'error'; error: ErrorDetails };

--- a/packages/agent/app/harness-protocol.ts
+++ b/packages/agent/app/harness-protocol.ts
@@ -1,0 +1,4 @@
+import { ConsoleMessage } from '../shared/protocol';
+
+export type HarnessMessage =
+  { type: 'console'; message: ConsoleMessage };

--- a/packages/agent/app/harness-protocol.ts
+++ b/packages/agent/app/harness-protocol.ts
@@ -1,5 +1,4 @@
-import { ErrorDetails } from '@bigtest/suite';
-import { ConsoleMessage } from '../shared/protocol';
+import { ErrorDetails, ConsoleMessage } from '@bigtest/suite';
 
 export type HarnessMessage =
   { type: 'console'; message: ConsoleMessage } |

--- a/packages/agent/app/harness-protocol.ts
+++ b/packages/agent/app/harness-protocol.ts
@@ -1,5 +1,0 @@
-import { ErrorDetails, ConsoleMessage } from '@bigtest/suite';
-
-export type HarnessMessage =
-  { type: 'message'; occurredAt: string, message: ConsoleMessage } |
-  { type: 'error'; occurredAt: string, error: ErrorDetails };

--- a/packages/agent/app/harness.ts
+++ b/packages/agent/app/harness.ts
@@ -20,13 +20,13 @@ if(window.parent !== window) {
 }
 
 wrapConsole((message) => {
-  postToParent({ type: 'console', message: message })
+  postToParent({ type: 'message', occurredAt: new Date().toString(), message: message })
 });
 
 main(function*() {
   yield spawn(
     on(window, 'error').map(([e]) => e as ErrorEvent).forEach(function*(event) {
-      postToParent({ type: 'error', error: yield serializeError(event.error) });
+      postToParent({ type: 'error', occurredAt: new Date().toString(), error: yield serializeError(event.error) });
     })
   );
   yield;

--- a/packages/agent/app/harness.ts
+++ b/packages/agent/app/harness.ts
@@ -1,3 +1,10 @@
+import { wrapConsole } from './wrap-console';
+import { HarnessMessage } from './harness-protocol';
+
+function postToParent(message: HarnessMessage) {
+  window.parent.postMessage(JSON.stringify(message), "*");
+}
+
 // proxy fetch and XMLHttpRequest requests through the parent frame
 if(window.parent !== window) {
   window.fetch = (input: RequestInfo, init?: RequestInit): Promise<Response> => {
@@ -7,3 +14,7 @@ if(window.parent !== window) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (window as any).XMLHttpRequest = () => new window.parent.window.XMLHttpRequest();
 }
+
+wrapConsole((message) => {
+  postToParent({ type: 'console', message: message })
+});

--- a/packages/agent/app/log-config.ts
+++ b/packages/agent/app/log-config.ts
@@ -1,0 +1,46 @@
+import { LogEvent } from '@bigtest/suite';
+
+/**
+ * This is brute-force way of communicating between the test frame
+ * and app frame. Because they are running on the same origin they can actually share
+ * references to values which enables faster, and more realtime communication with
+ * the server.
+ */
+
+export interface LogConfig {
+  events: LogEvent[];
+}
+
+interface LogConfigurable {
+  currentLogConfig?: LogConfig;
+}
+
+/**
+ * Set information about the lane to run so that the test frame can retrieve it.
+ * should only be called from the agent frame.
+ */
+export function setLogConfig(config: LogConfig) {
+  let context: typeof globalThis = window.window;
+  let bigtest: LogConfigurable = context.__bigtest as LogConfigurable;
+  if (!bigtest) {
+    bigtest = context.__bigtest = {};
+  }
+  bigtest.currentLogConfig = config;
+}
+
+
+export function getLogConfig(): LogConfig | undefined {
+  let context: typeof globalThis = window.window;
+  let bigtest: LogConfigurable = context.__bigtest as LogConfigurable;
+  return bigtest.currentLogConfig;
+}
+
+
+
+/**
+ * Retrieve what to run for a lane. Should be called only from the test frame.
+ */
+export function getLogConfigFromAppFrame(): LogConfig | undefined {
+  let bigtest: LogConfigurable = window.parent?.window.__bigtest as LogConfigurable;
+  return bigtest?.currentLogConfig;
+}

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -1,109 +1,138 @@
-import { Operation, fork } from 'effection';
+import { Operation, fork, spawn } from 'effection';
+import { subscribe } from '@effection/subscription';
+import { on } from '@effection/events';
 import { bigtestGlobals } from '@bigtest/globals';
 import { TestImplementation, Context as TestContext } from '@bigtest/suite';
 
-import { TestEvent } from '../shared/protocol';
+import { TestEvent, ConsoleMessage } from '../shared/protocol';
 
 import { findIFrame } from './find-iframe';
 import { LaneConfig } from './lane-config';
 import { loadManifest } from './manifest';
 import { timebox } from './timebox';
 import { serializeError } from './serialize-error';
+import { HarnessMessage } from './harness-protocol';
+import { wrapConsole } from './wrap-console';
 
 interface TestEvents {
   send(event: TestEvent): void;
 }
-
 export function* runLane(config: LaneConfig) {
   let { events, command, path } = config;
+  let { testRunId, manifestUrl, appUrl, stepTimeout } = command;
+
+  let context: TestContext = {};
+  let consoleMessages: ConsoleMessage[] = [];
+
+  let originalConsole = wrapConsole((message) => consoleMessages.push(message))
+
   try {
-    let { testRunId, manifestUrl, appUrl, stepTimeout } = command;
+    yield spawn(
+      subscribe(on(window, 'message')).forEach(function*([rawMessage]) {
+        let message: HarnessMessage = JSON.parse((rawMessage as { data: string }).data);
+        if(message.type === 'console') {
+          consoleMessages.push(message.message);
+        }
+      })
+    );
+
     bigtestGlobals.appUrl = appUrl;
     bigtestGlobals.testFrame = findIFrame('app-frame');
     let test: TestImplementation = yield loadManifest(manifestUrl);
-    yield runLaneSegment(testRunId, events, test, {}, path.slice(1), [], stepTimeout)
+    yield runLaneSegment(test, path.slice(1), [], stepTimeout)
   } finally {
     events.close();
   }
-}
 
-function *runLaneSegment(
-  testRunId: string,
-  events: TestEvents,
-  test: TestImplementation,
-  context: TestContext,
-  remainingPath: string[],
-  prefix: string[],
-  stepTimeout: number
-): Operation<void> {
-  let currentPath = prefix.concat(test.description);
+  function *runLaneSegment(
+    test: TestImplementation,
+    remainingPath: string[],
+    prefix: string[],
+    stepTimeout: number
+  ): Operation<void> {
+    let currentPath = prefix.concat(test.description);
 
-  console.debug('[agent] running test', currentPath);
-  events.send({ testRunId, type: 'test:running', path: currentPath })
+    originalConsole.debug('[agent] running test', currentPath);
+    events.send({ testRunId, type: 'test:running', path: currentPath })
 
-  if (bigtestGlobals.defaultInteractorTimeout >= stepTimeout) {
-    console.warn(`[agent] the interactor timeout should be less than, but is greater than or equal to, the step timeout of ${stepTimeout}`);
-  }
+    if (bigtestGlobals.defaultInteractorTimeout >= stepTimeout) {
+      originalConsole.warn(`[agent] the interactor timeout should be less than, but is greater than or equal to, the step timeout of ${stepTimeout}`);
+    }
 
-  for(let step of test.steps) {
-    let stepPath = currentPath.concat(step.description);
-    try {
-      console.debug('[agent] running step', step);
-      events.send({ testRunId, type: 'step:running', path: stepPath });
+    for(let step of test.steps) {
+      let stepPath = currentPath.concat(step.description);
+      try {
+        originalConsole.debug('[agent] running step', step);
+        events.send({ testRunId, type: 'step:running', path: stepPath });
 
-      let result: TestContext | void = yield timebox(step.action(context), stepTimeout)
+        let result: TestContext | void = yield timebox(step.action(context), stepTimeout)
 
-      if (result != null) {
-        context = {...context, ...result};
+        if (result != null) {
+          context = {...context, ...result};
+        }
+        events.send({ testRunId, type: 'step:result', status: 'ok', path: stepPath });
+      } catch(error) {
+        originalConsole.error('[agent] step failed', step, error);
+        if (error.name === 'TimeoutError') {
+          events.send({
+            testRunId,
+            type: 'step:result',
+            status: 'failed',
+            timeout: true,
+            path: stepPath,
+            console: consoleMessages
+          })
+        } else {
+          events.send({
+            testRunId,
+            type: 'step:result',
+            status: 'failed',
+            timeout: false,
+            error: yield serializeError(error),
+            path: stepPath,
+            console: consoleMessages
+          });
+        }
+        return;
       }
-      events.send({ testRunId, type: 'step:result', status: 'ok', path: stepPath });
-    } catch(error) {
-      console.error('[agent] step failed', step, error);
-      if (error.name === 'TimeoutError') {
-        events.send({
-          testRunId,
-          type: 'step:result',
-          status: 'failed',
-          timeout: true,
-          path: stepPath
-        })
-      } else {
-        events.send({
-          testRunId,
-          type: 'step:result',
-          status: 'failed',
-          timeout: false,
-          error: yield serializeError(error),
-          path: stepPath
+    }
+
+    yield function*() {
+      for(let assertion of test.assertions) {
+        yield fork(function*() {
+          let assertionPath = currentPath.concat(assertion.description);
+          try {
+            originalConsole.debug('[agent] running assertion', assertion);
+            events.send({ testRunId, type: 'assertion:running', path: assertionPath });
+
+            yield timebox(assertion.check(context), stepTimeout)
+
+            events.send({
+              testRunId,
+              type: 'assertion:result',
+              status: 'ok',
+              path: assertionPath
+            });
+          } catch(error) {
+            originalConsole.error('[agent] assertion failed', assertion, error);
+            events.send({
+              testRunId,
+              type: 'assertion:result',
+              status: 'failed',
+              error: yield serializeError(error),
+              path: assertionPath,
+              console: consoleMessages
+            });
+          }
         });
       }
-      return;
     }
-  }
 
-  yield function*() {
-    for(let assertion of test.assertions) {
-      yield fork(function*() {
-        let assertionPath = currentPath.concat(assertion.description);
-        try {
-          console.debug('[agent] running assertion', assertion);
-          events.send({ testRunId, type: 'assertion:running', path: assertionPath });
-
-          yield timebox(assertion.check(context), stepTimeout)
-
-          events.send({ testRunId, type: 'assertion:result', status: 'ok', path: assertionPath });
-        } catch(error) {
-          console.error('[agent] assertion failed', assertion, error);
-          events.send({ testRunId, type: 'assertion:result', status: 'failed', error: yield serializeError(error), path: assertionPath });
+    if (remainingPath.length > 0) {
+      for (let child of test.children) {
+        if (child.description === remainingPath[0]) {
+          yield runLaneSegment(child, remainingPath.slice(1), currentPath, stepTimeout);
         }
-      });
-    }
-  }
-
-  if (remainingPath.length > 0) {
-    for (let child of test.children) {
-      if (child.description === remainingPath[0]) {
-        yield runLaneSegment(testRunId, events, child, context, remainingPath.slice(1), currentPath, stepTimeout);
       }
     }
   }

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -1,9 +1,9 @@
 import { Operation, fork, spawn } from 'effection';
 import { on } from '@effection/events';
 import { bigtestGlobals } from '@bigtest/globals';
-import { TestImplementation, Context as TestContext, ErrorDetails } from '@bigtest/suite';
+import { TestImplementation, Context as TestContext, ErrorDetails, ConsoleMessage } from '@bigtest/suite';
 
-import { TestEvent, ConsoleMessage } from '../shared/protocol';
+import { TestEvent } from '../shared/protocol';
 
 import { findIFrame } from './find-iframe';
 import { LaneConfig } from './lane-config';

--- a/packages/agent/app/wrap-console.ts
+++ b/packages/agent/app/wrap-console.ts
@@ -1,4 +1,4 @@
-import { ConsoleLevel, ConsoleMessage } from '../shared/protocol';
+import { ConsoleLevel, ConsoleMessage } from '@bigtest/suite';
 
 type CallbackFn = (message: ConsoleMessage) => void
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/agent/app/wrap-console.ts
+++ b/packages/agent/app/wrap-console.ts
@@ -1,0 +1,28 @@
+import { ConsoleLevel, ConsoleMessage } from '../shared/protocol';
+
+type CallbackFn = (message: ConsoleMessage) => void
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ConsoleFn = (message?: any, ...optionalParams: any[]) => void
+
+type Console = {
+  log: ConsoleFn;
+  info: ConsoleFn;
+  debug: ConsoleFn;
+  warn: ConsoleFn;
+  error: ConsoleFn;
+};
+
+export function wrapConsole(callback: CallbackFn): Console {
+  let originalConsole: Partial<Console> = {};
+
+  for(let level of ['log', 'info', 'debug', 'warn', 'error'] as ConsoleLevel[]) {
+    originalConsole[level] = console[level];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    console[level] = (message?: any, ...optionalParams: any[]) => {
+      callback({ level: level, text: [message, ...optionalParams].join(' ') });
+      originalConsole[level]?.call(console, message, ...optionalParams);
+    };
+  }
+
+  return originalConsole as Console;
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -49,6 +49,7 @@
     "@bigtest/effection-express": "^0.7.0",
     "@bigtest/globals": "^0.6.1",
     "@effection/events": "^0.7.8",
+    "@effection/subscription": "^0.11.0",
     "bowser": "^2.9.0",
     "effection": "^0.7.0",
     "error-stack-parser": "^2.0.6",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -42,6 +42,7 @@
     "node-fetch": "^2.6.0",
     "parcel": "^1.12.4",
     "parcel-bundler": "^1.12.4",
+    "regenerator-runtime": "^0.13.7",
     "ts-node": "*"
   },
   "dependencies": {

--- a/packages/agent/shared/agent.ts
+++ b/packages/agent/shared/agent.ts
@@ -1,6 +1,6 @@
 import { Operation, resource, spawn } from 'effection';
 import { on, once } from '@effection/events';
-import { subscribe, createSubscription } from '@effection/subscription';
+import { createSubscription } from '@effection/subscription';
 import { AgentProtocol, AgentEvent, Command } from './protocol';
 
 export * from './protocol';

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -1,6 +1,13 @@
 import { Operation } from 'effection';
 import { Test, ResultStatus, ErrorDetails } from '@bigtest/suite';
 
+export type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+
+export interface ConsoleMessage {
+  level: ConsoleLevel;
+  text: string;
+}
+
 export interface AgentProtocol {
   send(event: AgentEvent): void;
   receive(): Operation<Command>;
@@ -60,6 +67,7 @@ export interface StepResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
+  console?: ConsoleMessage[];
 }
 
 export interface AssertionRunning {
@@ -77,6 +85,7 @@ export interface AssertionResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
+  console?: ConsoleMessage[];
 }
 
 export type TestEvent = RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -1,5 +1,5 @@
 import { Operation } from 'effection';
-import { Test, ResultStatus, ErrorDetails, ConsoleMessage } from '@bigtest/suite';
+import { Test, ResultStatus, ErrorDetails, LogEvent } from '@bigtest/suite';
 
 export interface AgentProtocol {
   send(event: AgentEvent): void;
@@ -60,8 +60,7 @@ export interface StepResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
-  consoleMessages?: ConsoleMessage[];
-  uncaughtErrors?: ErrorDetails[];
+  logEvents?: LogEvent[];
 }
 
 export interface AssertionRunning {
@@ -79,8 +78,7 @@ export interface AssertionResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
-  consoleMessages?: ConsoleMessage[];
-  uncaughtErrors?: ErrorDetails[];
+  logEvents?: LogEvent[];
 }
 
 export type TestEvent = RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -67,7 +67,8 @@ export interface StepResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
-  console?: ConsoleMessage[];
+  consoleMessages?: ConsoleMessage[];
+  uncaughtErrors?: ErrorDetails[];
 }
 
 export interface AssertionRunning {
@@ -85,7 +86,8 @@ export interface AssertionResult {
   path: string[];
   error?: ErrorDetails;
   timeout?: boolean;
-  console?: ConsoleMessage[];
+  consoleMessages?: ConsoleMessage[];
+  uncaughtErrors?: ErrorDetails[];
 }
 
 export type TestEvent = RunBegin | RunEnd | LaneBegin | LaneEnd | TestRunning | StepRunning | StepResult | AssertionRunning | AssertionResult;

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -1,12 +1,5 @@
 import { Operation } from 'effection';
-import { Test, ResultStatus, ErrorDetails } from '@bigtest/suite';
-
-export type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
-
-export interface ConsoleMessage {
-  level: ConsoleLevel;
-  text: string;
-}
+import { Test, ResultStatus, ErrorDetails, ConsoleMessage } from '@bigtest/suite';
 
 export interface AgentProtocol {
   send(event: AgentEvent): void;

--- a/packages/agent/src/agent-handler.ts
+++ b/packages/agent/src/agent-handler.ts
@@ -32,7 +32,7 @@ export function* createAgentHandler(port: number): Operation<ChainableSubscripti
   let ids = 1;
   let app = express();
 
-  return yield subscribe(createSubscription<AgentConnection, void>(function* (publish) {
+  return yield createSubscription<AgentConnection, void>(function* (publish) {
     yield app.ws('*', function*(socket: Socket): Operation<void> {
 
       let commands = new Channel<Command>();
@@ -63,5 +63,5 @@ export function* createAgentHandler(port: number): Operation<ChainableSubscripti
     yield app.listen(port);
 
     yield;
-  }));
+  });
 }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -110,10 +110,17 @@ describe("@bigtest/agent", function() {
           expect(result.status).toEqual('failed');
           let error = result.error;
           let stack = error && error.stack;
-          if(error && stack) {
+          let consoleMessages = result.console;
+          if(error && stack && consoleMessages) {
             expect(error.name).toEqual('Error');
             expect(error.message).toEqual('boom!');
             expect(stack[0].source && stack[0].source.fileName).toContain('/test/fixtures/manifest.js');
+            expect(consoleMessages).toEqual(expect.arrayContaining([
+              { level: 'log', text: 'this is a good step' },
+              { level: 'log', text: 'some log message here' },
+              { level: 'log', text: 'another log message' },
+              { level: 'error', text: 'I am going to fail' },
+            ]));
           } else {
             throw new Error("error and stack must be defined");
           }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -110,8 +110,9 @@ describe("@bigtest/agent", function() {
           expect(result.status).toEqual('failed');
           let error = result.error;
           let stack = error && error.stack;
-          let consoleMessages = result.console;
-          if(error && stack && consoleMessages) {
+          let consoleMessages = result.consoleMessages;
+          let uncaughtErrors = result.uncaughtErrors;
+          if(error && stack && consoleMessages && uncaughtErrors) {
             expect(error.name).toEqual('Error');
             expect(error.message).toEqual('boom!');
             expect(stack[0].source && stack[0].source.fileName).toContain('/test/fixtures/manifest.js');
@@ -120,6 +121,10 @@ describe("@bigtest/agent", function() {
               { level: 'log', text: 'some log message here' },
               { level: 'log', text: 'another log message' },
               { level: 'error', text: 'I am going to fail' },
+            ]));
+            expect(uncaughtErrors.map((e) => e.message)).toEqual(expect.arrayContaining([
+              'uncaught error from test',
+              'uncaught error from app',
             ]));
           } else {
             throw new Error("error and stack must be defined");

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -110,21 +110,18 @@ describe("@bigtest/agent", function() {
           expect(result.status).toEqual('failed');
           let error = result.error;
           let stack = error && error.stack;
-          let consoleMessages = result.consoleMessages;
-          let uncaughtErrors = result.uncaughtErrors;
-          if(error && stack && consoleMessages && uncaughtErrors) {
+          let logEvents = result.logEvents;
+          if(error && stack && logEvents) {
             expect(error.name).toEqual('Error');
             expect(error.message).toEqual('boom!');
             expect(stack[0].source && stack[0].source.fileName).toContain('/test/fixtures/manifest.js');
-            expect(consoleMessages).toEqual(expect.arrayContaining([
-              { level: 'log', text: 'this is a good step' },
-              { level: 'log', text: 'some log message here' },
-              { level: 'log', text: 'another log message' },
-              { level: 'error', text: 'I am going to fail' },
-            ]));
-            expect(uncaughtErrors.map((e) => e.message)).toEqual(expect.arrayContaining([
-              'uncaught error from test',
-              'uncaught error from app',
+            expect(logEvents).toEqual(expect.arrayContaining([
+              expect.objectContaining({ type: "message", message: { level: 'log', text: 'this is a good step' } }),
+              expect.objectContaining({ type: "message", message: { level: 'log', text: 'some log message here' } }),
+              expect.objectContaining({ type: "message", message: { level: 'log', text: 'another log message' } }),
+              expect.objectContaining({ type: "message", message: { level: 'error', text: 'I am going to fail' } }),
+              expect.objectContaining({ type: "error", error: expect.objectContaining({ message: 'uncaught error from test' }) }),
+              expect.objectContaining({ type: "error", error: expect.objectContaining({ message: 'uncaught error from app' }) }),
             ]));
           } else {
             throw new Error("error and stack must be defined");

--- a/packages/agent/test/fixtures/app.html
+++ b/packages/agent/test/fixtures/app.html
@@ -15,6 +15,7 @@
         console.log('another log message');
         document.querySelector('h2').textContent = data.greeting;
       });
+      throw new Error('uncaught error from app');
     </script>
   </body>
 </html>

--- a/packages/agent/test/fixtures/app.html
+++ b/packages/agent/test/fixtures/app.html
@@ -10,7 +10,9 @@
     <h2></h2>
 
     <script>
+      console.log('some log message here');
       fetch('/greeting').then((req) => req.json()).then((data) => {
+        console.log('another log message');
         document.querySelector('h2').textContent = data.greeting;
       });
     </script>

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -24,7 +24,7 @@ module.exports = test("tests")
         // the result of this step, but should be caught and forwarded to the
         // agent.
         setTimeout(() => {
-          throw new Error('uncaught error');
+          throw new Error('uncaught error from test');
         }, 5);
         await new Promise((resolve) => setTimeout(resolve, 10));
       })

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -2,7 +2,29 @@ import { ResultStatus, ErrorDetails } from '@bigtest/suite';
 
 export function run() {
   return `
-    subscription($showInternalStackTrace: Boolean! = true, $showDependenciesStackTrace: Boolean! = true, $showStackTraceCode: Boolean! = true) {
+    fragment ErrorDetails on Error {
+      message
+      stack(showInternal: $showInternalStackTrace, showDependencies: $showDependenciesStackTrace) {
+        name
+        fileName
+        code @include(if: $showStackTraceCode)
+        line
+        column
+        source {
+          fileName
+          line
+          column
+        }
+      }
+    }
+
+    subscription(
+      $showInternalStackTrace: Boolean! = true,
+      $showDependenciesStackTrace: Boolean! = true,
+      $showStackTraceCode: Boolean! = true,
+      $showUncaughtErrors: Boolean! = true,
+      $showConsoleMessages: Boolean! = true
+    ) {
       event: run {
         type
         status
@@ -10,19 +32,14 @@ export function run() {
         testRunId
         path
         error {
+          ...ErrorDetails
+        }
+        consoleMessages @include(if: $showConsoleMessages) {
+          level
           message
-          stack(showInternal: $showInternalStackTrace, showDependencies: $showDependenciesStackTrace) {
-            name
-            fileName
-            code @include(if: $showStackTraceCode)
-            line
-            column
-            source {
-              fileName
-              line
-              column
-            }
-          }
+        }
+        uncaughtErrors @include(if: $showUncaughtErrors) {
+          ...ErrorDetails
         }
         timeout
       }

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -1,4 +1,4 @@
-import { ResultStatus, ErrorDetails } from '@bigtest/suite';
+import { ResultStatus, ErrorDetails, LogEvent } from '@bigtest/suite';
 
 export function run() {
   return `
@@ -23,7 +23,7 @@ export function run() {
       $showDependenciesStackTrace: Boolean! = true,
       $showStackTraceCode: Boolean! = true,
       $showUncaughtErrors: Boolean! = true,
-      $showConsoleMessages: Boolean! = true
+      $showLog: Boolean! = true
     ) {
       event: run {
         type
@@ -34,14 +34,18 @@ export function run() {
         error {
           ...ErrorDetails
         }
-        consoleMessages @include(if: $showConsoleMessages) {
-          level
-          message
+        logEvents @include(if: $showLog) {
+          ... on LogEventMessage {
+            type
+            occurredAt
+            message
+          }
+          ... on LogEventError {
+            type
+            occurredAt
+            error
+          }
         }
-        uncaughtErrors @include(if: $showUncaughtErrors) {
-          ...ErrorDetails
-        }
-        timeout
       }
     }`
 }
@@ -55,6 +59,7 @@ export type RunResultEvent = {
   path?: string[];
   error?: ErrorDetails;
   timeout?: boolean;
+  logEvents?: LogEvent[];
 }
 
 export type Done = { done: true };

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -28,7 +28,9 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
   let subscription = yield client.subscription(query.run(), {
     showDependenciesStackTrace: false,
     showInternalStackTrace: false,
-    showStackTraceCode: false
+    showStackTraceCode: false,
+    showConsoleMessages: false,
+    showUncaughtErrors: false,
   });
   let stepCounts = { ok: 0, failed: 0, disregarded: 0 };
   let assertionCounts = { ok: 0, failed: 0, disregarded: 0 };

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -29,8 +29,7 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     showDependenciesStackTrace: false,
     showInternalStackTrace: false,
     showStackTraceCode: false,
-    showConsoleMessages: false,
-    showUncaughtErrors: false,
+    showLog: false,
   });
   let stepCounts = { ok: 0, failed: 0, disregarded: 0 };
   let assertionCounts = { ok: 0, failed: 0, disregarded: 0 };

--- a/packages/server/src/result-aggregator/assertion.ts
+++ b/packages/server/src/result-aggregator/assertion.ts
@@ -27,7 +27,7 @@ export class AssertionAggregator extends Aggregator<AssertionResult, AggregatorT
   *perform(): Operation<ResultStatus> {
     let result: AssertionResultEvent = yield this.receiveResult();
 
-    this.slice.update((s) => ({ ...s, status: result.status, error: result.error, timeout: result.timeout }));
+    this.slice.update((s) => ({ ...s, ...result }));
 
     return result.status;
   }

--- a/packages/server/src/result-aggregator/step.ts
+++ b/packages/server/src/result-aggregator/step.ts
@@ -27,7 +27,7 @@ export class StepAggregator extends Aggregator<StepResult, AggregatorTestOptions
   *perform(): Operation<ResultStatus> {
     let result: StepResultEvent = yield this.receiveResult();
 
-    this.slice.update((s) => ({ ...s, status: result.status, error: result.error, timeout: result.timeout }));
+    this.slice.update((s) => ({ ...s, ...result }));
 
     if (result.status === 'failed') {
       throw new Error('Step Failed');

--- a/packages/server/src/result-stream.ts
+++ b/packages/server/src/result-stream.ts
@@ -47,9 +47,7 @@ function* streamResults(type: string, slice: Slice<any, OrchestratorState>, publ
       } else {
         publish({
           type: `${type}:result`,
-          status: status,
-          error: slice.get().error,
-          timeout: slice.get().timeout,
+          ...slice.get(),
           ...options,
         } as TestEvent);
         return;

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -98,6 +98,8 @@ export const schema = makeSchema({
         t.id('agentId', { nullable: true });
         t.list.string("path", { nullable: true });
         t.field("error", { type: "Error", nullable: true });
+        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
+        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
         t.boolean("timeout", { nullable: true });
       }
     }),
@@ -274,6 +276,8 @@ export const schema = makeSchema({
           type: "Error",
           nullable: true
         })
+        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
+        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
         t.boolean("timeout", { nullable: true });
       }
     }),
@@ -285,7 +289,17 @@ export const schema = makeSchema({
         t.field("error", {
           type: "Error",
           nullable: true
-        })
+        });
+        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
+        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
+        t.boolean("timeout", { nullable: true });
+      }
+    }),
+    objectType({
+      name: "ConsoleMessage",
+      definition(t) {
+        t.string("level");
+        t.string("text");
       }
     }),
     objectType({

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -10,7 +10,7 @@ import {
   makeSchema,
   enumType,
 } from "@nexus/schema";
-import { ErrorStackFrame, LogEvent } from '@bigtest/suite';
+import { ErrorStackFrame } from '@bigtest/suite';
 
 export const schema = makeSchema({
   typegenAutoConfig: {

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -1,6 +1,7 @@
 import * as path  from 'path';
 import {
   objectType,
+  unionType,
   queryType,
   mutationType,
   subscriptionField,
@@ -9,7 +10,7 @@ import {
   makeSchema,
   enumType,
 } from "@nexus/schema";
-import { ErrorStackFrame } from '@bigtest/suite';
+import { ErrorStackFrame, LogEvent } from '@bigtest/suite';
 
 export const schema = makeSchema({
   typegenAutoConfig: {
@@ -98,8 +99,7 @@ export const schema = makeSchema({
         t.id('agentId', { nullable: true });
         t.list.string("path", { nullable: true });
         t.field("error", { type: "Error", nullable: true });
-        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
-        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
+        t.list.field("logEvents", { type: "LogEvent", nullable: true });
         t.boolean("timeout", { nullable: true });
       }
     }),
@@ -276,8 +276,7 @@ export const schema = makeSchema({
           type: "Error",
           nullable: true
         })
-        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
-        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
+        t.list.field("logEvents", { type: "LogEvent", nullable: true });
         t.boolean("timeout", { nullable: true });
       }
     }),
@@ -290,8 +289,7 @@ export const schema = makeSchema({
           type: "Error",
           nullable: true
         });
-        t.list.field("consoleMessages", { type: "ConsoleMessage", nullable: true });
-        t.list.field("uncaughtErrors", { type: "Error", nullable: true });
+        t.list.field("logEvents", { type: "LogEvent", nullable: true });
         t.boolean("timeout", { nullable: true });
       }
     }),
@@ -300,6 +298,35 @@ export const schema = makeSchema({
       definition(t) {
         t.string("level");
         t.string("text");
+      }
+    }),
+    objectType({
+      name: "LogEventMessage",
+      definition(t) {
+        t.string("type");
+        t.string("occurredAt");
+        t.field("message", { type: "ConsoleMessage" });
+      }
+    }),
+    objectType({
+      name: "LogEventError",
+      definition(t) {
+        t.string("type");
+        t.string("occurredAt");
+        t.field("error", { type: "Error" });
+      }
+    }),
+    unionType({
+      name: "LogEvent",
+      definition(t) {
+        t.members("LogEventMessage", "LogEventError");
+        t.resolveType((item) => {
+          switch(item.type) {
+            case "error": return "LogEventError";
+            case "message": return "LogEventMessage";
+            default: throw new Error("unknown type");
+          }
+        });
       }
     }),
     objectType({

--- a/packages/server/test/result-stream.test.ts
+++ b/packages/server/test/result-stream.test.ts
@@ -67,7 +67,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'step:running',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
@@ -83,7 +83,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'step:result',
           status: 'ok',
           agentId: 'agent-1',
@@ -105,7 +105,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'step:result',
           status: 'failed',
           agentId: 'agent-1',
@@ -126,7 +126,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'assertion:running',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
@@ -142,7 +142,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'assertion:result',
           status: 'ok',
           agentId: 'agent-1',
@@ -164,7 +164,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'assertion:result',
           status: 'failed',
           agentId: 'agent-1',
@@ -185,7 +185,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'test:running',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
@@ -201,7 +201,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'test:result',
           status: 'ok',
           agentId: 'agent-1',
@@ -223,7 +223,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'test:result',
           status: 'failed',
           agentId: 'agent-1',
@@ -244,7 +244,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRunAgent:running',
           agentId: 'agent-1',
           testRunId: 'test-run-1'
@@ -259,7 +259,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRunAgent:result',
           status: 'ok',
           agentId: 'agent-1',
@@ -280,7 +280,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRunAgent:result',
           status: 'failed',
           agentId: 'agent-1',
@@ -300,7 +300,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRun:running',
           testRunId: 'test-run-1'
         });
@@ -314,7 +314,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRun:result',
           status: 'ok',
           testRunId: 'test-run-1'
@@ -334,7 +334,7 @@ describe('result stream', () => {
 
       it('generates a test event', async () => {
         let { value } = await actions.fork(subscription.next());
-        expect(value).toEqual({
+        expect(value).toMatchObject({
           type: 'testRun:result',
           status: 'failed',
           testRunId: 'test-run-1',

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -97,6 +97,8 @@ export interface StepResult extends Node {
   status: ResultStatus;
   error?: ErrorDetails;
   timeout?: boolean;
+  consoleMessages?: ConsoleMessage[];
+  uncaughtErrors?: ErrorDetails[];
 }
 
 /**
@@ -107,6 +109,15 @@ export interface AssertionResult extends Node {
   status: ResultStatus;
   error?: ErrorDetails;
   timeout?: boolean;
+  consoleMessages?: ConsoleMessage[];
+  uncaughtErrors?: ErrorDetails[];
+}
+
+export type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+
+export interface ConsoleMessage {
+  level: ConsoleLevel;
+  text: string;
 }
 
 export interface ErrorDetails {

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -97,8 +97,7 @@ export interface StepResult extends Node {
   status: ResultStatus;
   error?: ErrorDetails;
   timeout?: boolean;
-  consoleMessages?: ConsoleMessage[];
-  uncaughtErrors?: ErrorDetails[];
+  logEvents?: LogEvent[];
 }
 
 /**
@@ -109,11 +108,12 @@ export interface AssertionResult extends Node {
   status: ResultStatus;
   error?: ErrorDetails;
   timeout?: boolean;
-  consoleMessages?: ConsoleMessage[];
-  uncaughtErrors?: ErrorDetails[];
+  logEvents?: LogEvent[];
 }
 
 export type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
+
+export type LogEvent = { type: "error", occurredAt: string, error: ErrorDetails } | { type: "message", occurredAt: string, message: ConsoleMessage };
 
 export interface ConsoleMessage {
   level: ConsoleLevel;

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -113,7 +113,7 @@ export interface AssertionResult extends Node {
 
 export type ConsoleLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
 
-export type LogEvent = { type: "error", occurredAt: string, error: ErrorDetails } | { type: "message", occurredAt: string, message: ConsoleMessage };
+export type LogEvent = { type: "error"; occurredAt: string; error: ErrorDetails } | { type: "message"; occurredAt: string; message: ConsoleMessage };
 
 export interface ConsoleMessage {
   level: ConsoleLevel;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9500,7 +9505,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -12463,6 +12468,11 @@ regenerator-runtime@^0.13.3, regenerator-runtime@^0.13.4:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-runtime@^0.13.7:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.2:
   version "0.14.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,12 +2132,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9505,7 +9500,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
When an error occurs in the agent, track the stack of console logs that have happened in the harness until that time and send them along with the error.

In the future we should also forward all logs to the orchestrator immediately.

Depends on #497 