### PR TITLE
Ensure app is returning html before considered ready

### DIFF
--- a/.changeset/ensure-app-html-ready.md
+++ b/.changeset/ensure-app-html-ready.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": minor
+---
+ensure that app is not considered ready until it is successfully
+serving html responses, not just accepting socket connections

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -56,6 +56,7 @@
     "@bigtest/suite": "^0.5.2",
     "@bigtest/webdriver": "^0.5.4",
     "@effection/events": "^0.7.4",
+    "@effection/fetch": "^0.1.2",
     "@effection/node": "^0.6.5",
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,6 +1903,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@bigtest/interactor@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.13.0.tgz#9bc7671395b235040a1b25475bd6f19f89a391a6"
+  integrity sha512-w0q3CLCm6MOMLKuVXwSUvZgcf2dd+ygMkfQzd6EFXAeGIIQ9NLZUy51N+uIreOCVzf7RvJF6Qa00sa2GCcDHiQ==
+  dependencies:
+    "@bigtest/globals" "^0.6.0"
+    "@bigtest/performance" "^0.5.0"
+
 "@bigtest/parcel@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@bigtest/parcel/-/parcel-0.5.2.tgz#3ed6d0af2e5ffa809063200834720bdae775373c"


### PR DESCRIPTION
> fixes #404 
Motivation
----------

It isn't enough to know that a server is accepting connections when considering an app to be ready because there are cases (like a create-react-app devserver) where the server will be bound to a port, but not yet providing responses. In the case of create-react-app, it won't actually respond until the app is first built. This false latency can cause the `App.visit()` interactor to fail by timing out.

![2020-07-14 15 00 47](https://user-images.githubusercontent.com/4205/87474761-4130f200-c5e9-11ea-8dc9-003babb42582.gif)


Approach
----------
Now that we have `@effection/fetch` to very conveniently work with http in effection, we can use it to check that we're
actually getting a response before considering the app "reachable".