### PR TITLE
Revert "Bump lodash from 4.17.15 to 4.17.19 in /packages/driver"

### DIFF
--- a/packages/driver/yarn.lock
+++ b/packages/driver/yarn.lock
@@ -383,10 +383,10 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
-effection@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-0.7.0.tgz#9cdb74d075021af0715c18124038d3b0dca01363"
-  integrity sha512-p9Y1YiFI/WH5L1DzGJg/RFPFQgpXyHd1xKvGpFkzR8ah/nUGdcDtXHavj9wJgPpuHtxM2ef5YPXA7ySMmuEa1w==
+effection@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-0.6.3.tgz#2a8dc62c53204492358ba51869e65e42d0799030"
+  integrity sha512-zktqYJC9h9p0MxM/zdsEnwSK+1zpoWS0keCY0W6zRyCfN+pyZUf0748BqC6NlcyhqYsvc6Xx66MElcKXA6reFA==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -855,9 +855,9 @@ locate-path@^3.0.0:
     path-exists "^3.0.0"
 
 lodash@^4.17.15:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
 log-symbols@2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Reverts thefrontside/bigtest#408

This bump is incorrect. We should be removing the lock file instead of updating it. The proper fix is in #412 