### PR TITLE
increase time-to-connect for webdriver

### DIFF
--- a/.changeset/bump-webdriver-timeout.md
+++ b/.changeset/bump-webdriver-timeout.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/webdriver": patch
+---
+As a stop-gap, increase the timeout to connect to the webdriver
+server

--- a/packages/webdriver/src/local.ts
+++ b/packages/webdriver/src/local.ts
@@ -34,7 +34,7 @@ export function * Local(options: Options): Operation<WebDriver> {
     yield once(child, 'exit');
   });
 
-  yield untilURLAvailable(`${driverURL}/status`, 1000);
+  yield untilURLAvailable(`${driverURL}/status`, 5000);
 
   yield connect(driver, options);
 


### PR DESCRIPTION
Motivation
-----------

Prior to the release of Chrome 84, one second was plently of time to connect to the webdriver server. However, with that release, it started timing out regularly.

Approach
----------

The long term solution is to not have timeout at all inside invididual components, but to set a deadline for the entire startup process. So that the entire orchestrator will have a certain amount of time to startup and services can take as long as they want within that timeframe. However, that requires a lot of changes in the orchestrator state and startup process, so this just hops it up to five seconds.