### PR TITLE
inject `process.env.NODE_ENV` into environment

### DIFF
--- a/.changeset/bundle-with-process-env.md
+++ b/.changeset/bundle-with-process-env.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/bundler": minor
+"@bigtest/cli": patch
+---
+set process.env.NODE_ENV='production' inside the test bundle. This
+will ensure that 3rd party packages that depend on this will continue
+to function

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -31,7 +31,8 @@
     "@rollup/plugin-node-resolve": "^8.1.0",
     "effection": "^0.7.0",
     "express": "^4.17.1",
-    "rollup": "^2.18.1"
+    "rollup": "^2.18.1",
+    "rollup-plugin-inject-process-env": "^1.3.0"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -4,7 +4,9 @@ import { subscribe, Subscribable, SymbolSubscribable, ChainableSubscription } fr
 import { Channel } from '@effection/channel';
 import { watch, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
 import resolve from '@rollup/plugin-node-resolve';
-import * as commonjs from '@rollup/plugin-commonjs';
+import commonjs from '@rollup/plugin-commonjs';
+import injectProcessEnv from 'rollup-plugin-inject-process-env';
+
 // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 // @ts-ignore
 import babel from '@rollup/plugin-babel';
@@ -16,7 +18,7 @@ interface BundleOptions {
 };
 
 interface BundlerOptions {
-  mainFields: Array<"browser" | "main">;
+  mainFields: Array<"browser" | "main" | "module">;
 };
 
 export interface BundlerError extends Error {
@@ -27,7 +29,7 @@ export type BundlerMessage =
   | { type: 'update' }
   | { type: 'error'; error: BundlerError };
 
-function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: BundlerOptions = { mainFields: ["browser", "main"] }): Array<RollupWatchOptions> {
+function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: BundlerOptions = { mainFields: ["browser", "module", "main"] }): Array<RollupWatchOptions> {
   // Rollup types are wrong; `watch.exclude` allows RegExp[]
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore
@@ -48,6 +50,7 @@ function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: Bun
           mainFields,
           extensions: ['.js', '.ts']
         }),
+
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         commonjs(),
@@ -56,7 +59,10 @@ function prepareRollupOptions(bundles: Array<BundleOptions>, { mainFields }: Bun
           extensions: ['.js', '.ts'],
           presets: ['@babel/preset-env', '@babel/preset-typescript'],
           plugins: ['@babel/plugin-transform-runtime']
-        })
+        }),
+        injectProcessEnv({
+          NODE_ENV: 'production'
+        }),
       ]
     }
   });

--- a/packages/bundler/test/bundler.test.ts
+++ b/packages/bundler/test/bundler.test.ts
@@ -1,7 +1,7 @@
 import { describe } from 'mocha';
 import { promises as fs, existsSync } from 'fs';
-import * as expect from 'expect';
-import * as rmrf from 'rimraf';
+import expect from 'expect';
+import rmrf from 'rimraf';
 import { Subscribable } from '@effection/subscription';
 
 import { spawn } from './world';

--- a/packages/bundler/tsconfig.json
+++ b/packages/bundler/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@frontside/tsconfig",
-  "files": ["src/index.ts"]
+  "files": ["src/index.ts"],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9459,7 +9459,7 @@ magic-string@^0.22.4:
   dependencies:
     vlq "^0.2.2"
 
-magic-string@^0.25.2:
+magic-string@^0.25.2, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
@@ -12637,6 +12637,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup-plugin-inject-process-env@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-inject-process-env/-/rollup-plugin-inject-process-env-1.3.0.tgz#eb746fbbf0a571174707010c0cf62eb292c89dc4"
+  integrity sha512-LYuOvcnLZErqK1WaDGMT5ECn1JPvOgeURfQGR9tRRyMb/sqmt5G7jT2/KSChRkyEDNKsn24J4FBxubB8bbs2Fg==
+  dependencies:
+    magic-string "^0.25.7"
 
 rollup@^2.18.1:
   version "2.18.1"


### PR DESCRIPTION
Motivation
-----------

Many third party libraries use `process.env.NODE_ENV` even when running on the browser. While this isn't strictly our responsibility to account for this, there's little we can do about it. In the case that fomented this change, we had a package (@mirage/graphql) that depended on a package (graphql) that referenced `process.env.NODE_ENV`. Parcel and webpack (through a plugin) both make this variable available, and so we should too.

Approach
----------
In order to define the global `process.env` variable, we're using what appears to be the most well-worn rollup plugin to do so. However, because of the way its exports are constructed, it did require us to tweak our `tsconfig` to use `esModuleInterop`.

I hardcoded the `NODE_ENV` to 'production' since there's no reason to slow down elements of the test bundle itself. We may want to consider allowing to set this to some other value at some point, but not too sure what form that would take.

Finally, I added a preference for ES modules as an entry point since they are usually better behaved with TypeScript.