### PR TITLE
No longer using xvfb

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,11 +43,7 @@ jobs:
         with:
           name: bigtest.dist.tgz
       - run: tar -xvf bigtest.dist.tgz/bigtest.dist.tgz
-      - name: Install XVFB
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb
       - name: Install dependencies
         run: yarn
       - name: Run tests
-        run: xvfb-run --auto-servernum -- yarn workspace @bigtest/${{ matrix.package }} test
+        run: yarn workspace @bigtest/${{ matrix.package }} test


### PR DESCRIPTION
## Motivation

I'm attempting to get tests running in GitHub Actions on Windows but it's failing while trying to use `apt` on windows to install xvfb. xvfb was used when interactors were running tests Chrome/Karma. I'm not sure if this is still necessary.

## Approach

Try removing xvfb