### PR TITLE
add globby

### DIFF
--- a/.changeset/globby.md
+++ b/.changeset/globby.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+replace glob with globby

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -65,7 +65,7 @@
     "express": "^4.17.1",
     "express-graphql": "^0.9.0",
     "fprint": "^2.0.1",
-    "glob": "^7.1.6",
+    "globby": "^11.0.1",
     "graphql": "^14.5.8",
     "http-proxy": "^1.18.0",
     "nexus": "^0.12.0",

--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -3,20 +3,19 @@ import { Operation } from 'effection';
 import { Mailbox, ensure } from '@bigtest/effection';
 import { throwOnErrorEvent } from '@effection/events';
 import * as fs from 'fs';
-import * as glob from 'glob';
 import * as path from 'path';
-import { promisify } from 'util';
+import * as globby from 'globby';
 
 const { writeFile, mkdir } = fs.promises;
 
 interface ManifestGeneratorOptions {
   delegate: Mailbox;
-  files: string[];
+  files: string[]; 
   destinationPath: string;
 };
 
 function* writeManifest(options: ManifestGeneratorOptions) {
-  let files = yield Promise.all(options.files.map((pattern) => promisify(glob)(pattern))).then((l) => l.flat());
+  let files = yield globby(options.files);
 
   let manifest = 'let load = (res) => res.default || res;\n';
   manifest += 'const children = [\n';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7346,7 +7346,7 @@ globby@^10.0.1:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@^11.0.0:
+globby@^11.0.0, globby@^11.0.1:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
   integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==


### PR DESCRIPTION
Replace `glob` [globby](https://github.com/sindresorhus/globby) with globby as it has a nicer API and is promisified.

From 

```typescript
let files = yield Promise.all(options.files.map((pattern) => promisify(glob)(pattern))).then((l) => l.flat());
```

To

```typescript
let files = yield globby(options.files);
```

