### PR TITLE
add slice overloads into a generic type

### DIFF
--- a/.changeset/slice-overloads.md
+++ b/.changeset/slice-overloads.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": patch
+---
+
+add slice overloads into a generic type

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -2,6 +2,7 @@ import { Operation } from "effection";
 import { Channel } from '@effection/channel';
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Slice } from "./slice";
+import { Sliceable } from './sliceable';
 
 export class Atom<S> implements Subscribable<S,undefined> {
   private readonly initial: S;
@@ -38,39 +39,8 @@ export class Atom<S> implements Subscribable<S,undefined> {
     }
   }
 
-
-  /* 
-  * Brute foce overload to allow strong typing of the string path syntax
-  * for every level deep we want to go in the slice there will need to be an overload 
-  * with an argument for each of the string paths
-  * 
-  * e.g. atom.slice('agents', agentId);  // 2 levels deep
-  * 
-  * There must be a matching overload
-  * 
-  * slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], S>;
-  * 
-  * key1 is 'agents' and key2 is 'agents'.
-  * 
-  * key1 is constrained to be a key of the atom `agents` which is atom atom.agents or could be
-  * atom.manifest or atom.testRuns of Atom<OrchestratorState>
-  * 
-  * key2 is constrained to be a key of the return type S[Key1] which is the agents object and in this
-  * example whatever the agentId variable is
-  * 
-  * The return type of the function is Slice<S[Key1][Key2], S>; or Slice<AgentState, OrchestratorState>
-  * in this example
-  */
-  slice<Key extends keyof S>(key: Key): Slice<S[Key], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2]>(key1: Key1, key2: Key2, key3: Key3): Slice<S[Key1][Key2][Key3], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4): Slice<S[Key1][Key2][Key3][Key4], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5): Slice<S[Key1][Key2][Key3][Key4][Key5], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key6: Key6): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key6: Key6, key7: Key7): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7], S>;
-  slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6], Key8 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6][Key7]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key6: Key6, key7: Key7, key8: Key8): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7][Key8], S>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  slice(...keys: string[]): Slice<any, S> {
+  slice: Sliceable<S, S>['slice'] = (...keys: string[]): Slice<any, S> => {
     return new Slice(this, keys);
   }
 

--- a/packages/atom/src/slice.ts
+++ b/packages/atom/src/slice.ts
@@ -2,12 +2,13 @@ import { Operation } from "effection";
 import { lensPath, view, set, dissoc, over } from "ramda";
 import { Atom } from "./atom";
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
+import { Sliceable } from './sliceable';
 
-export class Slice<T, S> implements Subscribable<T, undefined> {
+export class Slice<S, A> implements Subscribable<S, undefined> {
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   lens: any;
 
-  constructor(private atom: Atom<S>, public path: Array<string | number>) {
+  constructor(private atom: Atom<A>, public path: Array<string | number>) {
     this.lens = lensPath(path);
   }
 
@@ -15,34 +16,26 @@ export class Slice<T, S> implements Subscribable<T, undefined> {
     return this.atom.get();
   }
 
-  get(): T {
-    return (view(this.lens)(this.state) as unknown) as T;
+  get(): S {
+    return (view(this.lens)(this.state) as unknown) as S;
   }
 
-  set(value: T): void {
+  set(value: S): void {
     this.atom.update((state) => {
-      return (set(this.lens, value, state) as unknown) as S;
+      return (set(this.lens, value, state) as unknown) as A;
     });
   }
 
-  update(fn: (value: T) => T): void {
+  update(fn: (value: S) => S): void {
     this.set(fn(this.get()));
   }
 
-  over(fn: (value: T) => T): void {
-    this.atom.update((state) => (over(this.lens, fn, state) as unknown) as S);
+  over(fn: (value: S) => S): void {
+    this.atom.update((state) => (over(this.lens, fn, state) as unknown) as A);
   }
 
-  slice<Key extends keyof T>(key: Key): Slice<T[Key], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1]>(key1: Key1, key2: Key2): Slice<T[Key1][Key2], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2]>(key1: Key1, key2: Key2, key3: Key3): Slice<T[Key1][Key2][Key3], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2], Key4 extends keyof T[Key1][Key2][Key3]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4): Slice<T[Key1][Key2][Key3][Key4], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2], Key4 extends keyof T[Key1][Key2][Key3], Key5 extends keyof T[Key1][Key2][Key3][Key4]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5): Slice<T[Key1][Key2][Key3][Key4][Key5], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2], Key4 extends keyof T[Key1][Key2][Key3], Key5 extends keyof T[Key1][Key2][Key3][Key4], Key6 extends keyof T[Key1][Key2][Key3][Key4][Key5]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6): Slice<T[Key1][Key2][Key3][Key4][Key5][Key6], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2], Key4 extends keyof T[Key1][Key2][Key3], Key5 extends keyof T[Key1][Key2][Key3][Key4], Key6 extends keyof T[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof T[Key1][Key2][Key3][Key4][Key5][Key6]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7): Slice<T[Key1][Key2][Key3][Key4][Key5][Key6][Key7], S>;
-  slice<Key1 extends keyof T, Key2 extends keyof T[Key1], Key3 extends keyof T[Key1][Key2], Key4 extends keyof T[Key1][Key2][Key3], Key5 extends keyof T[Key1][Key2][Key3][Key4], Key6 extends keyof T[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof T[Key1][Key2][Key3][Key4][Key5][Key6], Key8 extends keyof T[Key1][Key2][Key3][Key4][Key5][Key6][Key7]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7, key8: Key8): Slice<T[Key1][Key2][Key3][Key4][Key5][Key6][Key7][Key8], S>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  slice(...path: Array<string | number>): Slice<any, S> {
+  slice: Sliceable<S, A>['slice'] =(...path: Array<string | number>): Slice<any, A> => {
     return new Slice(this.atom, this.path.concat(path));
   }
 
@@ -62,7 +55,7 @@ export class Slice<T, S> implements Subscribable<T, undefined> {
           parentLens,
           array.filter((el) => el !== this.get()),
           state
-        ) as unknown) as S;
+        ) as unknown) as A;
       });
     } else {
       let [property] = this.path.slice(-1);
@@ -71,12 +64,12 @@ export class Slice<T, S> implements Subscribable<T, undefined> {
           parentLens,
           dissoc(property, parent as object),
           state
-        ) as unknown) as S;
+        ) as unknown) as A;
       });
     }
   }
 
-  *once(predicate: (state: T) => boolean): Operation<T | undefined> {
+  *once(predicate: (state: S) => boolean): Operation<S | undefined> {
     let currentState = this.get();
     if(predicate(currentState)) {
       return currentState;
@@ -86,7 +79,7 @@ export class Slice<T, S> implements Subscribable<T, undefined> {
     }
   }
 
-  *[SymbolSubscribable](): Operation<Subscription<T, undefined>> {
-    return yield subscribe(Subscribable.from(this.atom).map((state) => view(this.lens)(state) as unknown as T));
+  *[SymbolSubscribable](): Operation<Subscription<S, undefined>> {
+    return yield subscribe(Subscribable.from(this.atom).map((state) => view(this.lens)(state) as unknown as S));
   }
 }

--- a/packages/atom/src/sliceable.ts
+++ b/packages/atom/src/sliceable.ts
@@ -1,0 +1,34 @@
+import { Slice } from './slice';
+
+export type Sliceable<S, A> = {
+  /* 
+  * Brute foce overload to allow strong typing of the string path syntax
+  * for every level deep we want to go in the slice there will need to be an overload 
+  * with an argument for each of the string paths
+  * 
+  * e.g. atom.slice('agents', agentId);  // 2 levels deep
+  * 
+  * There must be a matching overload
+  * 
+  * slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], S>;
+  * 
+  * key1 is 'agents' and key2 is agentId.
+  * 
+  * key1 is constrained to be a key of the atom `agents` which is atom.agents or could be
+  * atom.manifest or atom.testRuns of Atom<OrchestratorState>
+  * 
+  * key2 is constrained to be a key of the return type S[Key1] which is the agents object and in this
+  * example whatever the agentId variable is
+  * 
+  * The return type of the function is Slice<S[Key1][Key2], S>; or Slice<AgentState, OrchestratorState>
+  * in this example
+  */
+ slice<Key extends keyof S>(key: Key): Slice<S[Key], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2]>(key1: Key1, key2: Key2, key3: Key3): Slice<S[Key1][Key2][Key3], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4): Slice<S[Key1][Key2][Key3][Key4], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5): Slice<S[Key1][Key2][Key3][Key4][Key5], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7], A>;
+ slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6], Key8 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6][Key7]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7, key8: Key8): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7][Key8], A>;
+}


### PR DESCRIPTION
This removes the two slice overloads from `Atom` and `Slice` and moves them into 1 file:

```typescript
export type Sliceable<S, A> = {
  /* 
  * Brute foce overload to allow strong typing of the string path syntax
  * for every level deep we want to go in the slice there will need to be an overload 
  * with an argument for each of the string paths
  * 
  * e.g. atom.slice('agents', agentId);  // 2 levels deep
  * 
  * There must be a matching overload
  * 
  * slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], S>;
  * 
  * key1 is 'agents' and key2 is agentId.
  * 
  * key1 is constrained to be a key of the atom `agents` which is atom.agents or could be
  * atom.manifest or atom.testRuns of Atom<OrchestratorState>
  * 
  * key2 is constrained to be a key of the return type S[Key1] which is the agents object and in this
  * example whatever the agentId variable is
  * 
  * The return type of the function is Slice<S[Key1][Key2], S>; or Slice<AgentState, OrchestratorState>
  * in this example
  */
 slice<Key extends keyof S>(key: Key): Slice<S[Key], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1]>(key1: Key1, key2: Key2): Slice<S[Key1][Key2], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2]>(key1: Key1, key2: Key2, key3: Key3): Slice<S[Key1][Key2][Key3], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4): Slice<S[Key1][Key2][Key3][Key4], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5): Slice<S[Key1][Key2][Key3][Key4][Key5], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7], A>;
 slice<Key1 extends keyof S, Key2 extends keyof S[Key1], Key3 extends keyof S[Key1][Key2], Key4 extends keyof S[Key1][Key2][Key3], Key5 extends keyof S[Key1][Key2][Key3][Key4], Key6 extends keyof S[Key1][Key2][Key3][Key4][Key5], Key7 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6], Key8 extends keyof S[Key1][Key2][Key3][Key4][Key5][Key6][Key7]>(key1: Key1, key2: Key2, key3: Key3, key4: Key4, key5: Key5, key: Key6, key7: Key7, key8: Key8): Slice<S[Key1][Key2][Key3][Key4][Key5][Key6][Key7][Key8], A>;
}
```

The functions are then annotated with the type

```typescript
// eslint-disable-next-line @typescript-eslint/no-explicit-any
  slice: Sliceable<S, A>['slice'] =(...path: Array<string | number>): Slice<any, A> => {
    return new Slice(this.atom, this.path.concat(path));
  }
```

Slightly more confusing but removes duplication