### PR TITLE
Locator stacking

### DIFF
--- a/.changeset/default-locator-ref.md
+++ b/.changeset/default-locator-ref.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Allow an `InteractorSpecification`'s `defaultLocator` to reference by name a locator in the `LocatorSpecification`.

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -32,7 +32,7 @@ export function createInteractor<E extends Element>(interactorName: string) {
     }
 
     let result = function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
-      let locator = new Locator(specification.defaultLocator || defaultLocator, value);
+      let locator = new Locator(specification.defaultLocator || defaultLocator, value, { locators: specification.locators });
       let filter = new Filter(specification, filters || {});
       let interactor = new InteractorClass(interactorName, specification, locator, filter);
       return interactor as InteractorInstance<E, S>;
@@ -41,7 +41,7 @@ export function createInteractor<E extends Element>(interactorName: string) {
     for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
       Object.defineProperty(result, locatorName, {
         value: function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
-          let locator = new Locator(locatorFn, value, locatorName);
+          let locator = new Locator(locatorFn, value, { name: locatorName });
           let filter = new Filter(specification, filters || {});
           let interactor = new InteractorClass(interactorName, specification, locator, filter);
           return interactor as InteractorInstance<E, S>;

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -6,18 +6,20 @@ export interface LocatorOptions<E extends Element> {
 }
 
 export class Locator<E extends Element> {
-  private locatorFn: LocatorFn<E>;
+  private locatorFns: Array<LocatorFn<E>>;
   public name?: string;
 
-  constructor(locator: string | LocatorFn<E>, public value: string, { locators = {}, name }: LocatorOptions<E> = { locators: {} }) {
+  constructor(locator: string | string[] | LocatorFn<E>, public value: string, { locators = {}, name }: LocatorOptions<E> = { locators: {} }) {
     if (typeof locator === 'string') {
       let locatorFn = locators[locator];
       if (!locatorFn) {
         throw new Error(`Unable to find locator "${locator}"`);
       }
-      this.locatorFn = locatorFn;
+      this.locatorFns = [locatorFn];
+    } else if (typeof locator === 'object') {
+      this.locatorFns = locator.map(name => locators[name]);
     } else {
-      this.locatorFn = locator;
+      this.locatorFns = [locator];
     }
     this.name = name;
   }
@@ -33,6 +35,12 @@ export class Locator<E extends Element> {
   }
 
   matches(element: E): boolean {
-    return this.locatorFn(element) === this.value;
+    for (let fn of this.locatorFns) {
+      if (fn(element) === this.value) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,7 +1,26 @@
-import { LocatorFn } from './specification';
+import { LocatorFn, LocatorSpecification } from './specification';
+
+export interface LocatorOptions<E extends Element> {
+  name?: string;
+  locators?: LocatorSpecification<E>;
+}
 
 export class Locator<E extends Element> {
-  constructor(public locatorFn: LocatorFn<E>, public value: string, public name?: string) {}
+  private locatorFn: LocatorFn<E>;
+  public name?: string;
+
+  constructor(locator: string | LocatorFn<E>, public value: string, { locators = {}, name }: LocatorOptions<E> = { locators: {} }) {
+    if (typeof locator === 'string') {
+      let locatorFn = locators[locator];
+      if (!locatorFn) {
+        throw new Error(`Unable to find locator "${locator}"`);
+      }
+      this.locatorFn = locatorFn;
+    } else {
+      this.locatorFn = locator;
+    }
+    this.name = name;
+  }
 
   get description(): string {
     if(this.name) {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -21,7 +21,7 @@ export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>
 
 export interface InteractorSpecification<E extends Element> {
   selector?: string;
-  defaultLocator?: LocatorFn<E>;
+  defaultLocator?: string | LocatorFn<E>;
   locators?: LocatorSpecification<E>;
   actions?: ActionSpecification<E>;
   filters?: FilterSpecification<E>;

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -21,7 +21,7 @@ export type ActionSpecification<E extends Element> = Record<string, ActionFn<E>>
 
 export interface InteractorSpecification<E extends Element> {
   selector?: string;
-  defaultLocator?: string | LocatorFn<E>;
+  defaultLocator?: string | string[] | LocatorFn<E>;
   locators?: LocatorSpecification<E>;
   actions?: ActionSpecification<E>;
   filters?: FilterSpecification<E>;

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -76,13 +76,22 @@ describe('@bigtest/interactor', () => {
       await expect(Link.byTitle('Zebra').exists()).rejects.toHaveProperty('message', 'link with title "Zebra" does not exist');
     });
 
-    it('can use a custom locator as its default locator', async  () => {
-      dom(`
-        <div id="foo">bar</div>
-      `);
+    describe('with default locator reference', () => {
+      let Div = createInteractor('div')({
+        defaultLocator: 'byId',
+        locators: {
+          byId: (element) => element.id || "",
+        }
+      });
 
-      await expect(Div('foo').exists()).resolves.toBeUndefined();
-      await expect(Div('bar').exists()).rejects.toHaveProperty('message', 'div "bar" does not exist');
+      it('can use a custom locator as its default locator', async  () => {
+        dom(`
+          <div id="foo">bar</div>
+        `);
+
+        await expect(Div('foo').exists()).resolves.toBeUndefined();
+        await expect(Div('bar').exists()).rejects.toHaveProperty('message', 'div "bar" does not exist');
+      });
     });
   });
 

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -57,6 +57,35 @@ describe('@bigtest/interactor', () => {
     bigtestGlobals.defaultInteractorTimeout = 20;
   });
 
+  describe('locators', () => {
+    it('has a default locator which selects based on textContent', async  () => {
+      dom(`
+        <h1>Foo Bar</h1>
+      `);
+
+      await expect(Header('Foo Bar').exists()).resolves.toBeUndefined();
+      await expect(Header('Foo').exists()).rejects.toHaveProperty('message', 'header "Foo" does not exist');
+    });
+
+    it('supports custom locators', async  () => {
+      dom(`
+        <p><a title="Monkey" href="/foobar">Foo Bar</a></p>
+      `);
+
+      await expect(Link.byTitle('Monkey').exists()).resolves.toBeUndefined();
+      await expect(Link.byTitle('Zebra').exists()).rejects.toHaveProperty('message', 'link with title "Zebra" does not exist');
+    });
+
+    it('can use a custom locator as its default locator', async  () => {
+      dom(`
+        <div id="foo">bar</div>
+      `);
+
+      await expect(Div('foo').exists()).resolves.toBeUndefined();
+      await expect(Div('bar').exists()).rejects.toHaveProperty('message', 'div "bar" does not exist');
+    });
+  });
+
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`
@@ -65,15 +94,6 @@ describe('@bigtest/interactor', () => {
 
       await expect(Link('Foo Bar').exists()).resolves.toBeUndefined();
       await expect(Link('Blah').exists()).rejects.toHaveProperty('message', 'link "Blah" does not exist');
-    });
-
-    it('can use locators', async () => {
-      dom(`
-        <p><a title="Monkey" href="/foobar">Foo Bar</a></p>
-      `);
-
-      await expect(Link.byTitle('Monkey').exists()).resolves.toBeUndefined();
-      await expect(Link.byTitle('Zebra').exists()).rejects.toHaveProperty('message', 'link with title "Zebra" does not exist');
     });
 
     it('can wait for condition to become true', async () => {

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -93,6 +93,39 @@ describe('@bigtest/interactor', () => {
         await expect(Div('bar').exists()).rejects.toHaveProperty('message', 'div "bar" does not exist');
       });
     });
+
+    describe('with default locator referencing multiple locators', () => {
+      let Div = createInteractor('div')({
+        defaultLocator: ['byId', 'byText'],
+        locators: {
+          byId: (element) => element.id,
+          byText: (element) => element.textContent || ""
+        },
+        filters: {
+          text: (element) => element.textContent
+        }
+      });
+
+      it('can use a custom locator as its default locator', async  () => {
+        dom(`
+          <div id="foo">bar</div>
+          <div id="baz">qux</div>
+        `);
+
+        await expect(Div('foo').exists()).resolves.toBeUndefined();
+        await expect(Div('bar').exists()).resolves.toBeUndefined();
+      });
+
+      it('will throw an AmbiguousElementError if locators find more than one match', async  () => {
+        dom(`
+          <div id="foo">bar</div>
+          <div id="bar">foo</div>
+        `);
+
+        await expect(Div('foo').exists()).rejects.toHaveProperty('message', 'div "foo" is ambiguous');
+        await expect(Div('bar').exists()).rejects.toHaveProperty('message', 'div "bar" is ambiguous');
+      });
+    });
   });
 
   describe('.exists', () => {

--- a/packages/interactor/types/create-interactor.ts
+++ b/packages/interactor/types/create-interactor.ts
@@ -30,16 +30,3 @@ Div('foo').click();
 
 // $ExpectError
 Div('foo').blah();
-
-Link.byHref('foobar');
-
-// cannot use wrong type argument on locator
-// $ExpectError
-Link.byHref(123);
-
-// cannot use locator which is not defined
-// $ExpectError
-Div.byHref('foobar');
-
-// $ExpectError
-Div.moo('foobar');

--- a/packages/interactor/types/locators.ts
+++ b/packages/interactor/types/locators.ts
@@ -1,0 +1,39 @@
+import { createInteractor } from '../src/index';
+
+const Link = createInteractor<HTMLLinkElement>('link')({
+  selector: 'a',
+  defaultLocator: ['byHref', 'byTitle'],
+  locators: {
+    byHref: (element) => element.href,
+    byTitle: (element) => element.title
+  }
+});
+
+Link('foobar');
+
+Link.byHref('foobar');
+
+// cannot use wrong type argument on locator
+// $ExpectError
+Link.byHref(123);
+
+// cannot use locator which is not defined
+// $ExpectError
+Link.byValue('foobar');
+
+const Button = createInteractor<HTMLButtonElement>('button')({
+  selector: 'button',
+  defaultLocator: 'byText',
+  locators: {
+    byText: (element) => element.textContent || ""
+  }
+});
+
+Button('foobar');
+
+const TextField = createInteractor<HTMLInputElement>('text field')({
+  selector: 'input[type="text"]',
+  defaultLocator: (element) => element.placeholder,
+});
+
+TextField('foobar');


### PR DESCRIPTION
## Motivation

<!-- It can save cognitive load to locate elements using different strategies without the need to explicitly select which strategy. -->

## Approach

Given:

```ts
let Div = createInteractor<HTMLDivElement>('div')({
  // These locators are tried in order
  defaultLocator: ['byId', 'byText'],
  locators: {
    byId: (element) => element.id,
    byText: (element) => element.textContent || ""
  }
});
```

and:

```html
<div id="some-div-id">Hello, world.</div>
```

Both of these would match the element:

```ts
Div('some-div-id');
// or
Div('Hello, world.');
```