### PR TITLE
Run Interactor tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     needs: prepack
     strategy:
       matrix:
-        package: [agent, cli, effection, logging, bundler, project, server, suite, todomvc, atom, webdriver]
+        package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1


### PR DESCRIPTION
## Motivation

Interactor tests were not running in CI.

## Approach

Run the Interactor tests in CI.

## To-do

Can we make it so that the list of projects to test is not manually managed?