### PR TITLE
type in lens in Slice to ManualLens instead of any

### DIFF
--- a/.changeset/type-lens-in-slice.md
+++ b/.changeset/type-lens-in-slice.md
@@ -2,4 +2,4 @@
 "@bigtest/atom": patch
 ---
 
-type in lens in Slice to ManualLens instead of any
+type lens in Slice to the provided Ramda type ManualLens instead of any

--- a/.changeset/type-lens-in-slice.md
+++ b/.changeset/type-lens-in-slice.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": patch
+---
+
+type in lens in Slice to ManualLens instead of any

--- a/packages/atom/src/slice.ts
+++ b/packages/atom/src/slice.ts
@@ -1,12 +1,11 @@
 import { Operation } from "effection";
-import { lensPath, view, set, dissoc, over } from "ramda";
+import { lensPath, view, set, dissoc, over, ManualLens } from "ramda";
 import { Atom } from "./atom";
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Sliceable } from './sliceable';
 
 export class Slice<S, A> implements Subscribable<S, undefined> {
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  lens: any;
+  lens: ManualLens<S, A>;
 
   constructor(private atom: Atom<A>, public path: Array<string | number>) {
     this.lens = lensPath(path);
@@ -17,12 +16,12 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
   }
 
   get(): S {
-    return (view(this.lens)(this.state) as unknown) as S;
+    return (view(this.lens)(this.state));
   }
 
   set(value: S): void {
     this.atom.update((state) => {
-      return (set(this.lens, value, state) as unknown) as A;
+      return (set(this.lens, value, state));
     });
   }
 
@@ -31,7 +30,7 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
   }
 
   over(fn: (value: S) => S): void {
-    this.atom.update((state) => (over(this.lens, fn, state) as unknown) as A);
+    this.atom.update((state) => (over(this.lens, fn, state)));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Currently in Slice, lens is typed to any

```typescript

export class Slice<S, A> implements Subscribable<S, undefined> {
  //eslint-disable-next-line @typescript-eslint/no-explicit-any
  lens: any;
```

which has the knock-on effect of having to do a double cast in `get` and `set`

```typescript
  get(): S {
    return (view(this.lens)(this.state) as unknown) as S;
  }
```

This PR types `lens` to the provided ramda type of `ManualLens` and removes the double casts.