### PR TITLE
Nest bundle inside manifest

### DIFF
--- a/.changeset/bundler-entity
+++ b/.changeset/bundler-entity
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Make bundler a top-level entity

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -6,6 +6,7 @@ import {
   subscriptionField,
   stringArg,
   makeSchema,
+  enumType,
 } from "@nexus/schema";
 
 export const schema = makeSchema({
@@ -52,6 +53,10 @@ export const schema = makeSchema({
 
         t.field("manifest", {
           type: "Test",
+        });
+
+        t.field("bundler", {
+          type: "Bundler"
         });
 
         t.list.field("testRuns", {
@@ -165,6 +170,34 @@ export const schema = makeSchema({
         });
         t.list.field("children", {
           type: "Test"
+        })
+      }
+    }),
+    enumType({
+      name: "BundlerType",
+      members: [
+        'UNBUNDLED',
+        'BUILDING',
+        'GREEN',
+        'ERRORED'
+      ]
+    }),
+    objectType({
+      name: "Bundler",
+      definition(t) {
+        t.field("type", {
+          type: 'BundlerType'
+        });
+        t.string("path", {
+          nullable: true
+        }),
+        t.list.field("errors", {
+          type: "Error",
+          nullable: true
+        }),
+        t.list.field("warnings", {
+          type: "Error",
+          nullable: true
         })
       }
     }),


### PR DESCRIPTION
This is a follow up to #450  makes bundler a top-level entity in the graphql schema:

```javascript
t.field("bundler", {
  type: "Bundler"
});
.....
enumType({
  name: "BundlerType",
  members: [
    'UNBUNDLED',
    'BUILDING',
    'GREEN',
    'ERRORED'
  ]
}),
objectType({
  name: "Bundler",
  definition(t) {
    t.field("type", {
      type: 'BundlerType'
    });
    t.string("path", {
      nullable: true
    }),
    t.list.field("errors", {
      type: "Error",
      nullable: true
    }),
    t.list.field("warnings", {
      type: "Error",
      nullable: true
    })
  }
}),
```