### PR TITLE
Show a nice error when running test command without server running

### DIFF
--- a/.changeset/seven-geese-drive.md
+++ b/.changeset/seven-geese-drive.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": patch
+"@bigtest/client": patch
+---
+
+Provide a nice error message when running tests without a server

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -15,7 +15,7 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     try {
       return yield Client.create(uri);
     } catch (e) {
-      if (e.message.includes('websocket server closed connection unexpectedly')) {
+      if (e.name === 'ConnectionAttemptFailed') {
         throw new MainError({ 
           exitCode: 1,
           message: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.`

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -41,7 +41,6 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
       break;
     } else if(result.event) {
       let status = result.event.status;
-      console.log(result.event);
       if(result.event.type === 'testRun:result') {
         testRunStatus = result.event.status;
       }

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -15,7 +15,7 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     try {
       return yield Client.create(uri);
     } catch (e) {
-      if (e.name === 'ConnectionAttemptFailed') {
+      if (e.name === 'NoServerError') {
         throw new MainError({ 
           exitCode: 1,
           message: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.`

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -9,20 +9,21 @@ import { StreamingFormatter } from './format-helpers';
 
 export function* runTest(config: ProjectOptions, formatter: StreamingFormatter): Operation<void> {
 
-  let client: Client;
   let uri = `ws://localhost:${config.port}`;
-
-  try {
-    client = yield Client.create(uri);
-  } catch (e) {
-    if (e.message.includes('websocket server closed connection unexpectedly')) {
-      throw new MainError({ 
-        exitCode: 1,
-        message: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.`
-      });
-    }
-    throw e;
-  }
+  
+  let client: Client = yield function*() {
+    try {
+      return yield Client.create(uri);
+    } catch (e) {
+      if (e.message.includes('websocket server closed connection unexpectedly')) {
+        throw new MainError({ 
+          exitCode: 1,
+          message: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.`
+        });
+      }
+      throw e;
+    }  
+  };
 
   let subscription = yield client.subscription(query.run());
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -33,6 +33,24 @@ describe('@bigtest/cli', function() {
   });
 
   describe('test', () => {
+
+    describe('running without server', () => {
+      let runChild: Process;
+
+      beforeEach(async () => {
+        runChild = await World.spawn(run('test'));
+        await World.spawn(runChild.join());
+      });
+
+      afterEach(async () => {
+        await World.spawn(runChild.close());
+      });
+
+      it("provides a nice error with advice to start `bigtest server`", () => {
+        expect(runChild.stderr?.output).toContain('bigtest server');
+      });
+    });
+
     describe('running the suite successfully', () => {
       let startChild: Process;
       let runChild: Process;

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -5,7 +5,7 @@ import { Mailbox } from '@bigtest/effection';
 import { on, once } from '@effection/events';
 
 import { Message, isErrorResponse, isDataResponse, isDoneResponse } from './protocol';
-import { ConnectionAttemptFailed } from './errors';
+import { NoServerError } from './errors';
 
 let responseIds = 0;
 
@@ -20,8 +20,8 @@ export class Client {
     yield spawn(function* detectStartupError(): Operation<void> {
       let [error] = yield once(socket, 'error');
       
-      if (isYaetiError(error)) {
-        throw new ConnectionAttemptFailed(`Could not connect to server at ${url}`);
+      if (isErrorEvent(error)) {
+        throw new NoServerError(`Could not connect to server at ${url}`);
       } else {
         throw error;
       }
@@ -105,10 +105,10 @@ interface Query {
   live?: boolean;
 }
 
-interface YaetiError {
+interface ErrorEvent {
   type: 'error';
 }
 
-function isYaetiError(error: { type?: 'error' }): error is YaetiError {
+function isErrorEvent(error: { type?: 'error' }): error is ErrorEvent {
   return error.type === 'error';
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,10 +1,11 @@
 import { w3cwebsocket } from 'websocket';
-import { resource, Operation } from 'effection';
+import { resource, Operation, spawn } from 'effection';
 
-import { ensure, Mailbox } from '@bigtest/effection';
+import { Mailbox } from '@bigtest/effection';
 import { on, once } from '@effection/events';
 
 import { Message, isErrorResponse, isDataResponse, isDoneResponse } from './protocol';
+import { ConnectionAttemptFailed } from './errors';
 
 let responseIds = 0;
 
@@ -16,13 +17,25 @@ export class Client {
   static *create(url: string): Operation<Client> {
     let socket = new w3cwebsocket(url) as WebSocket;
 
+    yield spawn(function* detectStartupError(): Operation<void> {
+      let [error] = yield once(socket, 'error');
+      
+      if (isYaetiError(error)) {
+        throw new ConnectionAttemptFailed(`Could not connect to server at ${url}`);
+      } else {
+        throw error;
+      }
+    });
+
     let client = new Client(socket);
     let res = yield resource(client, function*() {
-      yield ensure(() => socket.close());
-
-      let [{ reason, code }] = yield once(socket, 'close');
-      if(code !== 1000) {
+      try {
+        let [{ reason, code }] = yield once(socket, 'close');
+        if(code !== 1000) {
         throw new Error(`websocket server closed connection unexpectedly: [${code}] ${reason}`);
+        }
+      } finally {
+        socket.close();
       }
     });
 
@@ -90,4 +103,12 @@ interface HandleResponse {
 interface Query {
   query: string;
   live?: boolean;
+}
+
+interface YaetiError {
+  type: 'error';
+}
+
+function isYaetiError(error: { type?: 'error' }): error is YaetiError {
+  return error.type === 'error';
 }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,3 +1,3 @@
-export class ConnectionAttemptFailed extends Error {
-  get name() { return 'ConnectionAttemptFailed' }
+export class NoServerError extends Error {
+  get name() { return 'NoServerError' }
 }

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,0 +1,3 @@
+export class ConnectionAttemptFailed extends Error {
+  get name() { return 'ConnectionAttemptFailed' }
+}

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -17,8 +17,8 @@ describe('@bigtest/client', () => {
       }
     });
 
-    it('throws a ConnectionAttemptFailed error', () => {
-      expect(error).toHaveProperty('name', 'ConnectionAttemptFailed');
+    it('throws a NoServerError', () => {
+      expect(error).toHaveProperty('name', 'NoServerError');
     });
 
   });

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -5,117 +5,140 @@ import { TestConnection, TestServer, run } from './helpers';
 import { Client, Message, Response, isQuery } from '../src';
 
 describe('@bigtest/client', () => {
-  let server: TestServer;
-  let client: Client;
-  let connection: TestConnection;
-  beforeEach(async () => {
-    server = await TestServer.start(3300);
-    let nextConnection = server.connection();
-    client = await run(Client.create('http://localhost:3300'));
-    connection = await nextConnection;
-  });
 
-  describe('sending a query', () => {
-    let message: Message | undefined;
-    let queryResponse: Promise<Response>;
+  describe('connecting without a server present', () => {
+    let error: Error;
+
     beforeEach(async () => {
-      queryResponse = run(client.query('echo(message: "Hello World")'));
-      message = await connection.receive();
+      try {
+        await run(Client.create('http://localhost:3300'));
+      } catch (e) {
+        error = e;
+      }
     });
 
-    it('is received on the server', () => {
-      expect(message).toBeDefined();
-      expect(message?.query).toEqual('echo(message: "Hello World")');
+    it('throws a ConnectionAttemptFailed error', () => {
+      expect(error).toHaveProperty('name', 'ConnectionAttemptFailed');
     });
 
-    describe('when the server responds', () => {
-      let response: {};
+  });
+ 
+  describe('interacting with the server', () => {
+    let server: TestServer;
+    let client: Client;
+    let connection: TestConnection;
+  
+    beforeEach(async () => {
+      server = await TestServer.start(3300);
+      let nextConnection = server.connection();
+      client = await run(Client.create('http://localhost:3300'));
+      connection = await nextConnection;
+    });
+  
+    describe('sending a query', () => {
+      let message: Message | undefined;
+      let queryResponse: Promise<Response>;
       beforeEach(async () => {
-        await connection.send({
-          done: true,
-          data: { echo: { message: "Hello World" }},
-          responseId: message?.responseId
+        queryResponse = run(client.query('echo(message: "Hello World")'));
+        message = await connection.receive();
+      });
+  
+      it('is received on the server', () => {
+        expect(message).toBeDefined();
+        expect(message?.query).toEqual('echo(message: "Hello World")');
+      });
+  
+      describe('when the server responds', () => {
+        let response: {};
+        beforeEach(async () => {
+          await connection.send({
+            done: true,
+            data: { echo: { message: "Hello World" }},
+            responseId: message?.responseId
+          });
+  
+          response = await queryResponse;
         });
-
-        response = await queryResponse;
+  
+        it('returns the data to the original query', () => {
+          expect(response).toBeDefined();
+          expect(response).toEqual({echo: { message: "Hello World" }});
+        });
       });
-
-      it('returns the data to the original query', () => {
-        expect(response).toBeDefined();
-        expect(response).toEqual({echo: { message: "Hello World" }});
-      });
-    });
-
-    describe('when the server responds with an error response', () => {
-      beforeEach(async() => {
-        await connection.send({
-          responseId: message?.responseId,
-          errors: [
-            { message: 'failed' }
-          ]
-        })
-      });
-
-      it('rejects the original response', async () => {
-        await expect(queryResponse).rejects.toEqual(new Error('failed'));
+  
+      describe('when the server responds with an error response', () => {
+        beforeEach(async() => {
+          await connection.send({
+            responseId: message?.responseId,
+            errors: [
+              { message: 'failed' }
+            ]
+          })
+        });
+  
+        it('rejects the original response', async () => {
+          await expect(queryResponse).rejects.toEqual(new Error('failed'));
+        });
       });
     });
-  });
-
-  describe('creating a live query', () => {
-    let mailbox: Mailbox<Response>;
-    let message: Message;
-    beforeEach(async () => {
-      mailbox = await run(client.liveQuery('echo(message: "Hello World")'));
-      message = await connection.receive() as Message;
-    });
-
-    it('sends the live query message to the server', () => {
-      expect(message).toBeDefined();
-      expect(message?.query).toEqual('echo(message: "Hello World")');
-      expect(isQuery(message)).toEqual(true);
-    });
-
-    describe('sending a result', () => {
-      let response: Response;
-
+  
+    describe('creating a live query', () => {
+      let mailbox: Mailbox<Response>;
+      let message: Message;
       beforeEach(async () => {
-        await connection.send({
-          responseId: message?.responseId,
-          data: {echo: { message: "Hello World" }}
-        })
-        response = await run(mailbox.receive());
+        mailbox = await run(client.liveQuery('echo(message: "Hello World")'));
+        message = await connection.receive() as Message;
       });
-
-      it('is delivered to the query mailbox', () => {
-        expect(response).toBeDefined();
-        expect(response).toEqual({echo: { message: "Hello World" }});
+  
+      it('sends the live query message to the server', () => {
+        expect(message).toBeDefined();
+        expect(message?.query).toEqual('echo(message: "Hello World")');
+        expect(isQuery(message)).toEqual(true);
+      });
+  
+      describe('sending a result', () => {
+        let response: Response;
+  
+        beforeEach(async () => {
+          await connection.send({
+            responseId: message?.responseId,
+            data: {echo: { message: "Hello World" }}
+          })
+          response = await run(mailbox.receive());
+        });
+  
+        it('is delivered to the query mailbox', () => {
+          expect(response).toBeDefined();
+          expect(response).toEqual({echo: { message: "Hello World" }});
+        });
       });
     });
-  });
-
-  describe('sending a mutation', () => {
-    let message: Message;
-    let mutationResponse: Promise<Response>;
-
-    beforeEach(async () => {
-      mutationResponse = run(client.mutation('{ run }'));
-      message = await connection.receive() as Message;
-
-      expect(message?.mutation).toEqual('{ run }');
-    });
-
-    describe('when the sever responds', () => {
+  
+    describe('sending a mutation', () => {
+      let message: Message;
+      let mutationResponse: Promise<Response>;
+  
       beforeEach(async () => {
-        await connection.send({
-          responseId: message?.responseId,
-          data: { run: 'TestRun:1' }
-        })
+        mutationResponse = run(client.mutation('{ run }'));
+        message = await connection.receive() as Message;
+  
+        expect(message?.mutation).toEqual('{ run }');
       });
-
-      it('returns the mutation to the client', async () => {
-        await expect(mutationResponse).resolves.toEqual({ run: 'TestRun:1' });
+  
+      describe('when the sever responds', () => {
+        beforeEach(async () => {
+          await connection.send({
+            responseId: message?.responseId,
+            data: { run: 'TestRun:1' }
+          })
+        });
+  
+        it('returns the mutation to the client', async () => {
+          await expect(mutationResponse).resolves.toEqual({ run: 'TestRun:1' });
+        });
       });
     });
-  });
+
+  })
+
 });


### PR DESCRIPTION
Closes #427 

## Motivation

People should know what is happening when an error occurred. They should not have to look at stack traces to figure out what it means. When running tests without bigtest server present, we would get an ugly stack trace that said: `websocket server closed connection unexpectedly`. Instead, we want to show an error that suggests to run `bigtest server` before running tests.

## Approach

Detect when we get `websocket server closed connection unexpectedly` and show error: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.` instead.