### PR TITLE
Consume websockets on the server using @effection/subscription

### DIFF
--- a/.changeset/subscribable-websockets.md
+++ b/.changeset/subscribable-websockets.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/effection-express": minor
+---
+add ability to consume websockets as a subscription alongside the
+Mailbox based API

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@effection/events": "^0.7.4",
+    "@effection/subscription": "^0.9.0",
     "@types/express-ws": "^3.0.0",
     "@types/node": "^13.13.4",
     "effection": "^0.7.0",

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -6,12 +6,16 @@ import * as util from 'util';
 import { Server } from 'http';
 
 import { throwOnErrorEvent, once, on } from '@effection/events';
+import { Subscribable, SymbolSubscribable, Subscription, subscribe } from '@effection/subscription';
 import { Mailbox, ensure } from '@bigtest/effection';
 
 type OperationRequestHandler = (req: actualExpress.Request, res: actualExpress.Response) => Operation<void>;
 type WsOperationRequestHandler = (socket: Socket, req: actualExpress.Request) => Operation<void>;
 
-export class Socket {
+// JSON.parse return type is `any`, so that's the type
+// of the subscription
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class Socket implements Subscribable<any, void> {
   constructor(public raw: WebSocket) {}
 
   *send(data: unknown) {
@@ -31,6 +35,16 @@ export class Socket {
         mailbox.send(JSON.parse(message.data));
       }
     });
+  }
+
+  // JSON.parse return type is `any`, so that's the type
+  // of the subscription
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  *[SymbolSubscribable](): Operation<Subscription<any, void>> {
+    let { raw } = this;
+    let messages = Subscribable.from(on<MessageEvent[]>(raw, 'message'))
+      .map(([event]) => JSON.parse(event.data));
+    return yield subscribe(messages);
   }
 }
 

--- a/packages/effection-express/test/effection.test.ts
+++ b/packages/effection-express/test/effection.test.ts
@@ -2,29 +2,22 @@ import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
 import fetch, { Response } from 'node-fetch';
 
-import { main, Context, Controls } from 'effection';
-
+import { run } from './helpers';
 import { Express, express } from '../src/index';
 
 describe('express', () => {
   let app: Express;
-  let world: Context & Controls;
 
   beforeEach(async () => {
-    world = main(undefined) as Context & Controls;
 
     app = express();
 
-    await world.spawn(app.use(function*(req, res) {
+    await run(app.use(function*(req, res) {
       res.send("hello");
       res.end();
     }));
 
-    await world.spawn(app.listen(26000));
-  });
-
-  afterEach(() => {
-    world.halt();
+    await run(app.listen(26000));
   });
 
   describe('sending requests to the express app', () => {

--- a/packages/effection-express/test/helpers.ts
+++ b/packages/effection-express/test/helpers.ts
@@ -1,0 +1,20 @@
+import { main, Operation } from 'effection';
+
+interface World {
+  halt(): void;
+  spawn<T>(operation: Operation<T>): Promise<T>;
+}
+
+let world: World;
+
+beforeEach(() => {
+  world = main(undefined) as unknown as World;
+});
+
+afterEach(() => {
+  world.halt();
+});
+
+export function run<T>(operation: Operation<T>): Promise<T> {
+  return world.spawn(operation);
+}

--- a/packages/effection-express/test/websocket.test.ts
+++ b/packages/effection-express/test/websocket.test.ts
@@ -11,7 +11,7 @@ import { Socket, express } from '../src';
 import { Mailbox } from '@bigtest/effection/dist';
 
 
-describe.only('websocket server', () => {
+describe('websocket server', () => {
   let client: WebSocket;
   let connection: Socket;
 

--- a/packages/effection-express/test/websocket.test.ts
+++ b/packages/effection-express/test/websocket.test.ts
@@ -1,0 +1,85 @@
+import { describe, beforeEach, it } from 'mocha';
+import * as expect from 'expect';
+
+import { timeout } from 'effection';
+import { Channel } from '@effection/channel';
+import { subscribe, ChainableSubscription } from '@effection/subscription';
+import * as WebSocket from 'ws';
+
+import { run } from './helpers';
+import { Socket, express } from '../src';
+import { Mailbox } from '@bigtest/effection/dist';
+
+
+describe.only('websocket server', () => {
+  let client: WebSocket;
+  let connection: Socket;
+
+  beforeEach(async () => {
+    let incoming = new Channel<Socket>();
+    let sockets = await run(subscribe(incoming));
+
+    let app = express();
+    await run(app.ws('*', function*(socket) {
+      incoming.send(socket);
+    }));
+    await run(app.listen(3400));
+
+
+    client = new WebSocket('http://127.0.0.1:3400');
+
+    connection = await run(sockets.expect());
+  });
+
+  it('accepts connections', () => {
+    expect(connection).toBeDefined();
+  });
+
+  describe('when receiving messages with the depraced mailbox API', () => {
+    let messages: Mailbox;
+
+    beforeEach(async () => {
+      messages = await run(connection.subscribe());
+
+      // we can't send messages until the client is connected
+      await run(function*() {
+        while (client.readyState !== client.OPEN) {
+          expect(client.readyState).toEqual(client.CONNECTING);
+          yield timeout(10);
+        }
+      })
+
+      client.send(JSON.stringify({ message: "Hello World!" }));
+      client.send(JSON.stringify({ message: "Goodbye World!" }));
+    });
+
+    it('publishes them on the server', async () => {
+      expect(await run(messages.receive())).toEqual({ message: "Hello World!" });
+      expect(await run(messages.receive())).toEqual({ message: "Goodbye World!" });
+    });
+  });
+
+  describe('when receiving messages via subscription', () => {
+    let messages: ChainableSubscription<unknown, void>;
+
+    beforeEach(async () => {
+      messages = await run(subscribe(connection));
+
+      // we can't send messages until the client is connected
+      await run(function*() {
+        while (client.readyState !== client.OPEN) {
+          expect(client.readyState).toEqual(client.CONNECTING);
+          yield timeout(10);
+        }
+      })
+
+      client.send(JSON.stringify({ message: "Hello World!" }));
+      client.send(JSON.stringify({ message: "Goodbye World!" }));
+    });
+
+    it('publishes them on the server', async () => {
+      expect(await run(messages.expect())).toEqual({ message: "Hello World!" });
+      expect(await run(messages.expect())).toEqual({ message: "Goodbye World!" });
+    });
+  });
+})


### PR DESCRIPTION
Motivation
-----------
In order to write tests for the bigtest agent, we need to simulate an orchestrator agent handler that the agent can connect to. However, the @bigtest/effection-express package requires you to write your websocket handler with the deprecated mailbox handler interface.

Approach
----------
Rather than replace the mailbox interface, this adds the subscription interface along side. That way, consumers of effection-express can migrate over gradually over time.

In order to verify both interfaces, tests have been wrapped around the websocket API for both the Mailbox interface as well as the subscription interface.