### PR TITLE
Annotate type of Socket.send()

### DIFF
--- a/.changeset/annotate-express-socket-send.md
+++ b/.changeset/annotate-express-socket-send.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/effection-express": patch
+---
+Annotate type declaration of `Socket.send()` as `Operation<void>`

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -14,7 +14,7 @@ type WsOperationRequestHandler = (socket: Socket, req: actualExpress.Request) =>
 export class Socket {
   constructor(public raw: WebSocket) {}
 
-  *send(data: unknown) {
+  *send(data: unknown): Operation<void> {
     if(this.raw.readyState === 1) {
       yield util.promisify(this.raw.send.bind(this.raw))(JSON.stringify(data));
     }


### PR DESCRIPTION
Motivation
----------
Type declarations serve not only as correctness check, but also as an educational tool. This is why the TypeScript compiler copies over documentation comments on public interfaces into the declaration file.

Given that, Without any annotation, the type declaration file will show that Socket.send is of type:

```ts
export declare class Socket {
  send(data: unknown): Generator<Promise<void>, any, any>
}
```

which doesn't really capture the intent. The Socket.send is actually an `Operation` which does not yield any value, and should be yielded to. When you see it in the docs, you want it to have it's primary type, even though that type is an alias.

By annonating the method explicitly, the type declaration is:

```ts
export declare class Socket {
  send(data: unknown): Operation<void>;
}
```