### PR TITLE
Increase step timeout

### DIFF
--- a/.changeset/compute-step-timeout.md
+++ b/.changeset/compute-step-timeout.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/agent": minor
+---
+
+Set step timeout to 60s and throw agent warning if interactor timeout is >= step timeout.

--- a/packages/agent/shared/agent.ts
+++ b/packages/agent/shared/agent.ts
@@ -1,6 +1,6 @@
 import { Operation, resource, spawn } from 'effection';
 import { on, once } from '@effection/events';
-import { subscribe, Subscribable, createSubscription } from '@effection/subscription';
+import { subscribe, createSubscription } from '@effection/subscription';
 import { AgentProtocol, AgentEvent, Command } from './protocol';
 
 export * from './protocol';

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -91,4 +91,5 @@ export interface Run {
   manifestUrl: string;
   testRunId: string;
   tree: Test;
+  stepTimeout: number;
 }

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -89,9 +89,9 @@ describe("@bigtest/agent", function() {
         beforeEach(async () => {
           let manifestUrl = 'http://localhost:8000/test/fixtures/manifest.js';
           let appUrl = 'http://localhost:8000/test/fixtures';
+          let stepTimeout = 500;
 
-          connection.send({ type: 'run', testRunId, manifestUrl, appUrl, tree: fixtureManifest });
-
+          connection.send({ type: 'run', testRunId, manifestUrl, appUrl, tree: fixtureManifest, stepTimeout });
         });
 
         it('receives success results', async () => {

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -19,6 +19,7 @@ interface CommandProcessorOptions {
 function* run(testRunId: string, options: CommandProcessorOptions): Operation {
   console.debug('[command processor] running test', testRunId);
 
+  let stepTimeout = 60_000;
   let testRunSlice = options.atom.slice('testRuns', testRunId);
   let manifest = options.atom.get().manifest;
 
@@ -41,7 +42,7 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
     let { agentId } = agent;
 
     console.debug(`[command processor] starting test run ${testRunId} on agent ${agentId}`);
-    options.delegate.send({ type: 'run', agentId, appUrl, manifestUrl, testRunId, tree: manifest });
+    options.delegate.send({ type: 'run', agentId, appUrl, manifestUrl, testRunId, tree: manifest, stepTimeout });
   }
 
   let aggregator = new TestRunAggregator(testRunSlice, { testRunId, ...options });


### PR DESCRIPTION
## Motivation

Partially addresses https://github.com/thefrontside/bigtest/issues/437.

A hard-coded two seconds does not work universally. For example, some apps may be slow to boot and the test will time out before anything happens.

Additionally, we want the step timeout to be longer than the interactor timeout such that we prioritize the interactor failure message ahead of the step timeout message. This also enables multiple interactor invocations within a step.

## Approach

- Set the step timeout to one minute.
- Make the agent warn (per lane) if the interactor timeout is longer than the step timeout
- Make the step timeout a parameter of the `run` command coming from the server (originally motivated to make it testable but I think it makes it easier for future configurability)

## To-do

Consider a nicer API for managing timeouts.