### PR TITLE
Resolve source maps in error stack traces

### DIFF
--- a/.changeset/source-maps.md
+++ b/.changeset/source-maps.md
@@ -1,0 +1,8 @@
+---
+"@bigtest/agent": "minor"
+"@bigtest/server": "minor"
+"@bigtest/cli": "minor"
+"@bigtest/suite": "minor"
+---
+
+Resolve source maps in error stack traces for better debugging

--- a/.changeset/variables.md
+++ b/.changeset/variables.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/client": "minor"
+---
+
+Add support for variables in GraphQL queries

--- a/packages/agent/app/serialize-error.ts
+++ b/packages/agent/app/serialize-error.ts
@@ -8,6 +8,7 @@ interface SourceLocation {
   name?: string;
   line?: number;
   column?: number;
+  sourceLine?: string;
   sourceFile: {
     path: string;
   };
@@ -24,6 +25,7 @@ export function *resolveStackFrames(stackFrames: StackFrame[]): Operation<ErrorS
         return {
           name: location.name || stackFrame.functionName,
           fileName: stackFrame.fileName,
+          code: location.sourceLine,
           line: stackFrame.lineNumber,
           column: stackFrame.columnNumber,
           source: {

--- a/packages/agent/app/serialize-error.ts
+++ b/packages/agent/app/serialize-error.ts
@@ -1,0 +1,40 @@
+import * as getSource from 'get-source';
+import * as ErrorStackParser from 'error-stack-parser';
+import { Operation } from 'effection';
+import { ErrorDetails } from '@bigtest/suite';
+
+interface SourceLocation {
+  name?: string;
+  line?: number;
+  column?: number;
+  sourceFile: {
+    path: string;
+  };
+}
+
+export function *serializeError(error: Error): Operation<ErrorDetails> {
+  let parsedError = yield Promise.all(ErrorStackParser.parse(error).map(async (stackFrame) => {
+    if(stackFrame.fileName && stackFrame.lineNumber && stackFrame.columnNumber) {
+      let source = await getSource.async(stackFrame.fileName);
+      let location: SourceLocation = await source.resolve({ line: stackFrame.lineNumber, column: stackFrame.columnNumber });
+      return {
+        name: location.name || stackFrame.functionName,
+        fileName: stackFrame.fileName,
+        line: stackFrame.lineNumber,
+        column: stackFrame.columnNumber,
+        source: {
+          fileName: location.sourceFile.path,
+          line: location.line,
+          column: location.column
+        }
+      };
+    } else {
+      return { fileName: stackFrame.fileName, line: stackFrame.lineNumber, column: stackFrame.columnNumber };
+    }
+  }));
+  return {
+    name: error.name,
+    message: error.message,
+    stack: parsedError
+  };
+}

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -46,7 +46,9 @@
     "@bigtest/globals": "^0.6.0",
     "@effection/events": "^0.7.7",
     "bowser": "^2.9.0",
-    "effection": "^0.7.0"
+    "effection": "^0.7.0",
+    "error-stack-parser": "^2.0.6",
+    "get-source": "^2.0.11"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/cli/src/formatters/lines.ts
+++ b/packages/cli/src/formatters/lines.ts
@@ -26,6 +26,9 @@ function formatEvent(event: RunResultEvent) {
         if(stackFrame.name) {
           result += `@ ${stackFrame.name}`;
         }
+        if(stackFrame.code) {
+          result += `\n|        > ${stackFrame.code.trim()}`
+        }
       }
     }
   }

--- a/packages/cli/src/formatters/lines.ts
+++ b/packages/cli/src/formatters/lines.ts
@@ -1,9 +1,5 @@
 import { StreamingFormatter, Counts, RunResultEvent, icon } from '../format-helpers';
 
-function filterStack(text: string): string {
-  return text.split('\n').filter((l) => !l.match(/__bigtest/)).join('\n');
-}
-
 function formatFooterCounts(label: string, counts: Counts): string {
   return [
     `${label}:`.padEnd(14),
@@ -19,16 +15,21 @@ function formatEvent(event: RunResultEvent) {
     result += ' ' + event.path.slice(1).join(' -> ');
   }
   if(event.error) {
-    result += '\n' + prefixLines(event.error.stack ? filterStack(event.error.stack) : `Error: ${event.error.message}`, '|   ')
+    result += ["\n|    ERROR:", event.error.name, event.error.message].filter(e => e).join(' ');
+    if(event.error.stack) {
+      for(let stackFrame of event.error.stack) {
+        let location = stackFrame.source || stackFrame;
+        result += `\n|      `
+        if(location.fileName) {
+          result += `${location.fileName}:${location.line || 0}:${location.column || 0} `;
+        }
+        if(stackFrame.name) {
+          result += `@ ${stackFrame.name}`;
+        }
+      }
+    }
   }
   return result;
-}
-
-function prefixLines(text: string, prefix: string) {
-  return text
-    .split('\n')
-    .map((l) => prefix + l)
-    .join('\n')
 }
 
 const formatter: StreamingFormatter = {

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -2,7 +2,7 @@ import { ResultStatus, ErrorDetails } from '@bigtest/suite';
 
 export function run() {
   return `
-    subscription($showInternal: Boolean! = true, $showDependencies: Boolean! = true) {
+    subscription($showInternalStackTrace: Boolean! = true, $showDependenciesStackTrace: Boolean! = true) {
       event: run {
         type
         status
@@ -11,7 +11,7 @@ export function run() {
         path
         error {
           message
-          stack(showInternal: $showInternal, showDependencies: $showDependencies) {
+          stack(showInternal: $showInternalStackTrace, showDependencies: $showDependenciesStackTrace) {
             name
             fileName
             line

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -2,7 +2,7 @@ import { ResultStatus, ErrorDetails } from '@bigtest/suite';
 
 export function run() {
   return `
-    subscription($showInternalStackTrace: Boolean! = true, $showDependenciesStackTrace: Boolean! = true) {
+    subscription($showInternalStackTrace: Boolean! = true, $showDependenciesStackTrace: Boolean! = true, $showStackTraceCode: Boolean! = true) {
       event: run {
         type
         status
@@ -14,6 +14,7 @@ export function run() {
           stack(showInternal: $showInternalStackTrace, showDependencies: $showDependenciesStackTrace) {
             name
             fileName
+            code @include(if: $showStackTraceCode)
             line
             column
             source {

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -1,8 +1,8 @@
-import { ResultStatus } from '@bigtest/suite';
+import { ResultStatus, ErrorDetails } from '@bigtest/suite';
 
 export function run() {
   return `
-    subscription {
+    subscription($showInternal: Boolean! = true, $showDependencies: Boolean! = true) {
       event: run {
         type
         status
@@ -11,10 +11,17 @@ export function run() {
         path
         error {
           message
-          fileName
-          lineNumber
-          columnNumber
-          stack
+          stack(showInternal: $showInternal, showDependencies: $showDependencies) {
+            name
+            fileName
+            line
+            column
+            source {
+              fileName
+              line
+              column
+            }
+          }
         }
         timeout
       }
@@ -27,13 +34,7 @@ export type RunResultEvent = {
   testRunId: string;
   status?: ResultStatus;
   path?: string[];
-  error?: {
-    message: string;
-    fileName?: string;
-    lineNumber?: string;
-    columnNumber?: string;
-    stack?: string;
-  };
+  error?: ErrorDetails;
   timeout?: boolean;
 }
 

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -25,7 +25,7 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     }
   };
 
-  let subscription = yield client.subscription(query.run(), { showDependencies: false, showInternal: false });
+  let subscription = yield client.subscription(query.run(), { showDependenciesStackTrace: false, showInternalStackTrace: false });
   let stepCounts = { ok: 0, failed: 0, disregarded: 0 };
   let assertionCounts = { ok: 0, failed: 0, disregarded: 0 };
   let testRunStatus: ResultStatus | undefined;

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -25,7 +25,11 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
     }
   };
 
-  let subscription = yield client.subscription(query.run(), { showDependenciesStackTrace: false, showInternalStackTrace: false });
+  let subscription = yield client.subscription(query.run(), {
+    showDependenciesStackTrace: false,
+    showInternalStackTrace: false,
+    showStackTraceCode: false
+  });
   let stepCounts = { ok: 0, failed: 0, disregarded: 0 };
   let assertionCounts = { ok: 0, failed: 0, disregarded: 0 };
   let testRunStatus: ResultStatus | undefined;

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -10,23 +10,22 @@ import { StreamingFormatter } from './format-helpers';
 export function* runTest(config: ProjectOptions, formatter: StreamingFormatter): Operation<void> {
 
   let uri = `ws://localhost:${config.port}`;
-  
+
   let client: Client = yield function*() {
     try {
       return yield Client.create(uri);
     } catch (e) {
       if (e.name === 'NoServerError') {
-        throw new MainError({ 
+        throw new MainError({
           exitCode: 1,
           message: `Could not connect to BigTest server on ${uri}. Run "bigtest server" to start the server.`
         });
       }
       throw e;
-    }  
+    }
   };
 
-  let subscription = yield client.subscription(query.run());
-
+  let subscription = yield client.subscription(query.run(), { showDependencies: false, showInternal: false });
   let stepCounts = { ok: 0, failed: 0, disregarded: 0 };
   let assertionCounts = { ok: 0, failed: 0, disregarded: 0 };
   let testRunStatus: ResultStatus | undefined;

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -140,6 +140,7 @@ describe('@bigtest/cli', function() {
         expect(child.stdout?.output).toContain("✓ [step]       Failing Test -> first step")
         expect(child.stdout?.output).toContain("✓ [assertion]  Failing Test -> check the thing")
         expect(child.stdout?.output).toContain("⨯ [step]       Failing Test -> child -> child second step")
+        expect(child.stdout?.output).toContain("test/fixtures/failing.test.ts:14")
         expect(child.stdout?.output).toContain("⨯ FAILURE")
       });
     });

--- a/packages/client/src/protocol.ts
+++ b/packages/client/src/protocol.ts
@@ -1,7 +1,10 @@
+export type Variables = Record<string, unknown>;
+
 export interface Message {
   query?: string;
   mutation?: string;
   subscription?: string;
+  variables?: Variables;
   responseId?: string;
 }
 

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -10,7 +10,7 @@ import { GraphqlContext, SpawnContext } from './schema/context';
 import { Atom } from '@bigtest/atom';
 import { OrchestratorState } from './orchestrator/state';
 
-import { Message, Response, QueryMessage, MutationMessage, SubscriptionMessage, isQuery, isMutation, isSubscription } from '@bigtest/client';
+import { Variables, Message, Response, QueryMessage, MutationMessage, SubscriptionMessage, isQuery, isMutation, isSubscription } from '@bigtest/client';
 
 export type CommandMessage = { status: "ready" } | { type: "run"; id: string };
 
@@ -47,10 +47,10 @@ export function* createCommandServer(options: CommandServerOptions): Operation {
  * Run the query or mutation in `source` against the orchestrator
  * state contained in `state`
  */
-function* graphql(source: string, options: CommandServerOptions, state: OrchestratorState): Operation {
+function* graphql(source: string, variables: Variables | undefined, options: CommandServerOptions, state: OrchestratorState): Operation {
   let context: SpawnContext = yield spawn(undefined);
   let opts = graphqlOptions(context, options, state);
-  return yield executeGraphql({...opts, contextValue: opts.context, source });
+  return yield executeGraphql({...opts, contextValue: opts.context, source, variableValues: variables });
 }
 
 /**
@@ -76,7 +76,7 @@ function handleMessage(options: CommandServerOptions): (socket: Socket) => Opera
   }
 
   function* handleMutation(message: MutationMessage, socket: Socket): Operation {
-    let result: Response = yield graphql(message.mutation, options, options.atom.get());
+    let result: Response = yield graphql(message.mutation, message.variables, options, options.atom.get());
     result.responseId = message.responseId;
     yield socket.send(result);
   }
@@ -87,7 +87,8 @@ function handleMessage(options: CommandServerOptions): (socket: Socket) => Opera
     let result = yield executeGraphqlSubscription({
       schema,
       document: parseGraphql(message.subscription),
-      contextValue: new GraphqlContext(context, options.atom, options.delegate)
+      contextValue: new GraphqlContext(context, options.atom, options.delegate),
+      variableValues: message.variables
     });
 
     if(isAsyncIterator(result)) {
@@ -113,7 +114,7 @@ function handleMessage(options: CommandServerOptions): (socket: Socket) => Opera
   }
 
   function* publishQueryResult(message: QueryMessage, state: OrchestratorState, socket: Socket): Operation {
-    let result: Response = yield graphql(message.query, options, state);
+    let result: Response = yield graphql(message.query, message.variables, options, state);
     result.responseId = message.responseId;
     yield socket.send(result);
   }

--- a/packages/server/src/manifest-server.ts
+++ b/packages/server/src/manifest-server.ts
@@ -7,12 +7,17 @@ interface ManifestServerOptions {
   delegate: Mailbox;
   dir: string;
   port: number;
+  proxyPort: number;
 };
 
 export function* createManifestServer(options: ManifestServerOptions): Operation {
   let app = express();
 
-  app.raw.use(staticMiddleware(options.dir));
+  app.raw.use(staticMiddleware(options.dir, {
+    setHeaders(res) {
+      res.setHeader('Access-Control-Allow-Origin', `http://localhost:${options.proxyPort}`);
+    }
+  }));
 
   yield app.listen(options.port);
 

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -85,6 +85,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     delegate: manifestServerDelegate,
     dir: manifestDistDir,
     port: options.project.manifest.port,
+    proxyPort: options.project.proxy.port,
   }));
 
   yield fork(createManifestGenerator({

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -5,9 +5,11 @@ import {
   mutationType,
   subscriptionField,
   stringArg,
+  booleanArg,
   makeSchema,
   enumType,
 } from "@nexus/schema";
+import { ErrorStackFrame } from '@bigtest/suite';
 
 export const schema = makeSchema({
   typegenAutoConfig: {
@@ -288,12 +290,53 @@ export const schema = makeSchema({
     }),
     objectType({
       name: "Error",
+      rootTyping: {
+        name: "ErrorDetails",
+        path: "@bigtest/suite"
+      },
       definition(t) {
         t.string("message");
+        t.list.field("stack", {
+          type: "ErrorStackFrame",
+          nullable: true,
+          args: {
+            showInternal: booleanArg({ required: false, default: true }),
+            showDependencies: booleanArg({ required: false, default: true }),
+          },
+          async resolve({ stack }, { showInternal, showDependencies }) {
+            if(stack) {
+              return stack.filter((frame: ErrorStackFrame) => {
+                if(!showInternal && frame.fileName?.match(/__bigtest/)) {
+                  return false;
+                }
+                if(!showDependencies && frame.source?.fileName?.match(/node_modules/)) {
+                  return false;
+                }
+                return true;
+              });
+            } else {
+              return null;
+            }
+          }
+        });
+      }
+    }),
+    objectType({
+      name: "ErrorStackFrame",
+      definition(t) {
+        t.string("name", { nullable: true });
         t.string("fileName", { nullable: true });
-        t.int("lineNumber", { nullable: true });
-        t.int("columnNumber", { nullable: true });
-        t.string("stack", { nullable: true });
+        t.int("line", { nullable: true });
+        t.int("column", { nullable: true });
+        t.field("source", { type: "ErrorStackFrameSource", nullable: true });
+      }
+    }),
+    objectType({
+      name: "ErrorStackFrameSource",
+      definition(t) {
+        t.string("fileName", { nullable: true });
+        t.int("line", { nullable: true });
+        t.int("column", { nullable: true });
       }
     })
   ]

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -326,6 +326,7 @@ export const schema = makeSchema({
       definition(t) {
         t.string("name", { nullable: true });
         t.string("fileName", { nullable: true });
+        t.string("code", { nullable: true });
         t.int("line", { nullable: true });
         t.int("column", { nullable: true });
         t.field("source", { type: "ErrorStackFrameSource", nullable: true });

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -123,5 +123,6 @@ export interface ErrorStackLocation {
 
 export interface ErrorStackFrame extends ErrorStackLocation {
   name?: string;
+  code?: string;
   source?: ErrorStackLocation;
 }

--- a/packages/suite/src/interfaces.ts
+++ b/packages/suite/src/interfaces.ts
@@ -110,9 +110,18 @@ export interface AssertionResult extends Node {
 }
 
 export interface ErrorDetails {
+  name?: string;
   message: string;
+  stack?: ErrorStackFrame[];
+}
+
+export interface ErrorStackLocation {
   fileName?: string;
-  lineNumber?: number;
-  columnNumber?: number;
-  stack?: string;
+  line?: number;
+  column?: number;
+}
+
+export interface ErrorStackFrame extends ErrorStackLocation {
+  name?: string;
+  source?: ErrorStackLocation;
 }

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -31,7 +31,7 @@
     "@effection/fetch": "^0.1.2",
     "@effection/node": "^0.8.0",
     "abort-controller": "^3.0.0",
-    "chromedriver": "~83.0.0",
+    "chromedriver": "~85.0.0",
     "effection": "^0.7.0",
     "geckodriver": "^1.19.1",
     "node-fetch": "^2.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -3338,6 +3343,13 @@ adm-zip@0.4.11:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.11.tgz#2aa54c84c4b01a9d0fb89bb11982a51f13e3d62a"
   integrity sha512-L8vcjDTCOIJk7wFvmlEUN7AsSb8T+2JrdP7KINBjzr24TJ5Mwj590sLu3BC7zNZowvJWa/JtPmD8eJCzdtDWjA==
+
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
 
 agent-base@^4.3.0:
   version "4.3.0"
@@ -4618,15 +4630,16 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@~83.0.0:
-  version "83.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-83.0.0.tgz#75d7d838e58014658c3990089464166fef951926"
-  integrity sha512-AePp9ykma+z4aKPRqlbzvVlc22VsQ6+rgF+0aL3B5onHOncK18dWSkLrSSJMczP/mXILN9ohGsvpuTwoRSj6OQ==
+chromedriver@~85.0.0:
+  version "85.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-85.0.0.tgz#5b9b6a184569f5e2b22b45a928bbc66d1c4bb36f"
+  integrity sha512-Noinnkl9gRsfC1EYA5trcOVf9r/P6JJnWf+mU6KZS3xLjV9x/o71VZ+gqRl3oSI4PnTGnqYRISZFQk/teYVTRg==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.19.2"
     del "^5.1.0"
-    extract-zip "^2.0.0"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
     mkdirp "^1.0.4"
     tcp-port-used "^1.0.1"
 
@@ -5509,6 +5522,13 @@ debug@3.2.6, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
@@ -5522,13 +5542,6 @@ debug@=3.1.0:
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
-  dependencies:
-    ms "^2.1.1"
 
 decamelize-keys@^1.0.0:
   version "1.1.0"
@@ -6683,7 +6696,7 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-zip@^2.0.0:
+extract-zip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
   integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
@@ -7811,6 +7824,14 @@ https-proxy-agent@3.0.0:
   dependencies:
     agent-base "^4.3.0"
     debug "^3.1.0"
+
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
 
 human-id@^1.0.2:
   version "1.0.2"
@@ -9420,7 +9441,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,12 +2132,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -5469,6 +5464,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-buffer@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz#d296973d5a4897a5dbe31716d118211921f04770"
+  integrity sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==
+
 data-urls@^1.0.0, data-urls@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
@@ -6060,6 +6060,13 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+error-stack-parser@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.0.6.tgz#5a99a707bd7a4c58a797902d48d82803ede6aad8"
+  integrity sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==
+  dependencies:
+    stackframe "^1.1.1"
 
 es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstract@^1.17.5:
   version "1.17.6"
@@ -7219,6 +7226,14 @@ get-port@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
   integrity sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=
+
+get-source@^2.0.11:
+  version "2.0.11"
+  resolved "https://registry.yarnpkg.com/get-source/-/get-source-2.0.11.tgz#25b5d3acaad72502405501d139336b790e8b5d73"
+  integrity sha512-3ep0eeCGsW2jTd1IByqtszqGq6xHDeoN8T7HgYJfcAMOxvjKpR6er1tWzHMwjyiqChC84Ov31pkMMJZiQ97rFg==
+  dependencies:
+    data-uri-to-buffer "^2.0.0"
+    source-map "^0.6.1"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -9405,7 +9420,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -13289,6 +13304,11 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stackframe@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
+  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
 
 static-eval@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Closes #431

Use the error-stack-parser and get-source packages to extract the source location from stack traces and transform these sources. This gives us vastly improved stack traces.

Also adds support for filtering the stack trace to hide lines from bigtest itself, as well as dependencies from node_modules. The resulting stack traces are very clean. In the future we can make these configurable via options to the CLI.

Example:

```
⨯ [step]       Failing Test -> child -> child second step
|    ERROR: moo
|      test/fixtures/failing.test.ts:14:54 @ _callee2$
```