### PR TITLE
chore: test on multiple os

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.package }}/bigtest.dist.${{ matrix.platform }}
+          name: bigtest.dist.${{ matrix.platform }}
           path: ./packages
       - name: extract prepack
         working-directory: ./packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,12 +58,10 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - uses: actions/download-artifact@v2
+        # this action will also unpack them for us
         with:
           name: bigtest.dist.${{ matrix.platform }}
           path: ./packages
-      - name: extract prepack
-        working-directory: ./packages
-        run: tar -xvf bigtest.dist.${{ matrix.platform }}.zip/bigtest.dist.${{ matrix.platform }}
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,42 +7,63 @@ on:
 
 jobs:
   prepack:
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
     name: Prepack
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # switch to [ubuntu-latest, macos-latest, windows-latest]
+        # when ready to test on windows as well
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - name: cache node_modules
+        uses: actions/cache@v2
+        # cache node_modules based on lockfile which can change
+        # when there is no explicit change in package.json
+        # and prevents cache bust when scripts or metadata is changed
+        # which does not effect the node_modules themselves
         with:
-          path: /home/runner/.cache/yarn/v6
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn
       - name: Run prepack
         run: yarn prepack
-      - name: Tarball prepacked dist
-        run: tar czvf bigtest.dist.tgz ./packages/*/dist
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v2
         with:
-          name: bigtest.dist.tgz
-          path: bigtest.dist.tgz
+          name: bigtest.dist.${{ matrix.platform }}
+          path: ./packages/*/dist
 
   test:
-    runs-on: ubuntu-18.04
-    name: ${{ matrix.package }}
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    name: ${{ matrix.package }} on ${{ matrix.platform }}
     needs: prepack
     strategy:
       matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+        # switch to [ubuntu-latest, macos-latest, windows-latest]
+        # when ready to test on windows as well
         package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - name: cache node_modules
+        uses: actions/cache@v2
+        # cache node_modules based on lockfile which can change
+        # when there is no explicit change in package.json
+        # and prevents cache bust when scripts or metadata is changed
+        # which does not effect the node_modules themselves
         with:
-          path: /home/runner/.cache/yarn/v6
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v1
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/download-artifact@v2
         with:
-          name: bigtest.dist.tgz
-      - run: tar -xvf bigtest.dist.tgz/bigtest.dist.tgz
+          name: ${{ matrix.package }}/bigtest.dist.${{ matrix.platform }}
+          path: ./packages/${{ matrix.package }}
+      - name: extract prepack
+        working-dir: ./packages/${{ matrix.package }}
+        run: tar -xvf bigtest.dist.${{ matrix.platform }}.tgz/bigtest.dist.${{ matrix.platform }}
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,10 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.package }}/bigtest.dist.${{ matrix.platform }}
-          path: ./packages/${{ matrix.package }}
+          path: ./packages
       - name: extract prepack
-        working-directory: ./packages/${{ matrix.package }}
-        run: tar -xvf bigtest.dist.${{ matrix.platform }}.tgz/bigtest.dist.${{ matrix.platform }}
+        working-directory: ./packages
+        run: tar -xvf bigtest.dist.${{ matrix.platform }}.zip/bigtest.dist.${{ matrix.platform }}
       - name: Install dependencies
         run: yarn
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Prepack
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         # switch to [ubuntu-latest, macos-latest, windows-latest]
         # when ready to test on windows as well
     steps:
@@ -42,7 +42,7 @@ jobs:
     needs: prepack
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest]
         # switch to [ubuntu-latest, macos-latest, windows-latest]
         # when ready to test on windows as well
         package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           name: ${{ matrix.package }}/bigtest.dist.${{ matrix.platform }}
           path: ./packages/${{ matrix.package }}
       - name: extract prepack
-        working-dir: ./packages/${{ matrix.package }}
+        working-directory: ./packages/${{ matrix.package }}
         run: tar -xvf bigtest.dist.${{ matrix.platform }}.tgz/bigtest.dist.${{ matrix.platform }}
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
This updates the test script, bumps the version of a bunch of the official actions and prepares to run on ubuntu, mac and windows. There is also a step to cache the node_modules, but this will generally not trigger in PRs (as each PR has it's own cache) unless there a multiple commits. I switched to the node_module cache as that is more consistent between OS. It also sets a timeout to catch situations where the build hangs (like what is currently happening on windows).

This is the first step to address #432. We can enable windows once they pass in CI to keep the builds green.