### PR TITLE
Better error message when matches are ambiguous

### DIFF
--- a/.changeset/ambigous-errors.md
+++ b/.changeset/ambigous-errors.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": "patch"
+---
+
+Better error messages on ambiguous matches

--- a/packages/interactor/src/escape-html.ts
+++ b/packages/interactor/src/escape-html.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(text: string): string {
+  return text
+     .replace(/&/g, "&amp;")
+     .replace(/</g, "&lt;")
+     .replace(/>/g, "&gt;")
+     .replace(/"/g, "&quot;")
+     .replace(/'/g, "&#039;");
+}

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -26,6 +26,14 @@ export class Match<E extends Element, S extends InteractorSpecification<E>> {
   get sortWeight(): number {
     return this.matchLocator.sortWeight + this.matchFilter.sortWeight;
   }
+
+  elementDescription(): string {
+    let tag = this.element.tagName.toLowerCase();
+    let attrs = Array.from(this.element.attributes).map((attr) => {
+      return `${attr.name}="${attr.value}"`
+    });
+    return `<${[tag, ...attrs].join(' ')}>`;
+  }
 }
 
 export class MatchLocator<E extends Element> {

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -1,6 +1,7 @@
 import { Locator } from './locator';
 import { Filter } from './filter';
 import { InteractorSpecification } from './specification';
+import { escapeHtml } from './escape-html';
 
 const check = (value: unknown): string => value ? "✓" : "⨯";
 
@@ -30,7 +31,7 @@ export class Match<E extends Element, S extends InteractorSpecification<E>> {
   elementDescription(): string {
     let tag = this.element.tagName.toLowerCase();
     let attrs = Array.from(this.element.attributes).map((attr) => {
-      return `${attr.name}="${attr.value}"`
+      return `${attr.name}="${escapeHtml(attr.value)}"`
     });
     return `<${[tag, ...attrs].join(' ')}>`;
   }

--- a/packages/interactor/src/resolve.ts
+++ b/packages/interactor/src/resolve.ts
@@ -15,7 +15,8 @@ export function resolve(parentElement: Element, interactor: Interactor<any, any>
   if(matching.length === 1) {
     return matching[0].element;
   } else if(matching.length > 1) {
-    throw new AmbiguousElementError(`${interactor.description} is ambiguous`);
+    let alternatives = matching.map((m) => '- ' + m.elementDescription());
+    throw new AmbiguousElementError(`${interactor.description} matches multiple elements:\n\n${alternatives.join('\n')}`);
   } else if(elements.length === 0) {
     throw new NoSuchElementError(`did not find ${interactor.description}`);
   } else {

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -338,6 +338,19 @@ describe('@bigtest/interactor', () => {
       await expect(Datepicker("Start Date").has({ open: true })).resolves.toBeUndefined();
       await expect(Datepicker("Start Date").has({ month: "January" })).resolves.toBeUndefined();
     });
+
+    it('throws an error if ambiguous', async () => {
+      dom(`
+        <p><a href="/foo">Foo</a></p>
+        <p><a href="/bar">Foo</a></p>
+      `);
+
+      await expect(Link('Foo').click()).rejects.toHaveProperty('message', [
+        'link "Foo" matches multiple elements:', '',
+        '- <a href="/foo">',
+        '- <a href="/bar">',
+      ].join('\n'))
+    });
   });
 
   describe('filters', () => {

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -342,13 +342,13 @@ describe('@bigtest/interactor', () => {
     it('throws an error if ambiguous', async () => {
       dom(`
         <p><a href="/foo">Foo</a></p>
-        <p><a href="/bar">Foo</a></p>
+        <p><a href="/bar&quot;">Foo</a></p>
       `);
 
       await expect(Link('Foo').click()).rejects.toHaveProperty('message', [
         'link "Foo" matches multiple elements:', '',
         '- <a href="/foo">',
-        '- <a href="/bar">',
+        '- <a href="/bar&quot;">',
       ].join('\n'))
     });
   });


### PR DESCRIPTION
When a match in an interactor is ambiguous, we show a list of elements that matched by formatting their opening tag as suggested by @cowboyd in #454.

Closes #454