### PR TITLE
Revert "chore: test on multiple os"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,61 +7,42 @@ on:
 
 jobs:
   prepack:
-    runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
+    runs-on: ubuntu-18.04
     name: Prepack
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest]
-        # switch to [ubuntu-latest, macos-latest, windows-latest]
-        # when ready to test on windows as well
     steps:
       - uses: actions/checkout@v1
-      - name: cache node_modules
-        uses: actions/cache@v2
-        # cache node_modules based on lockfile which can change
-        # when there is no explicit change in package.json
-        # and prevents cache bust when scripts or metadata is changed
-        # which does not effect the node_modules themselves
+      - uses: actions/cache@v1
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          path: /home/runner/.cache/yarn/v6
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install dependencies
         run: yarn
       - name: Run prepack
         run: yarn prepack
-      - uses: actions/upload-artifact@v2
+      - name: Tarball prepacked dist
+        run: tar czvf bigtest.dist.tgz ./packages/*/dist
+      - uses: actions/upload-artifact@v1
         with:
-          name: bigtest.dist.${{ matrix.platform }}
-          path: ./packages/*/dist
+          name: bigtest.dist.tgz
+          path: bigtest.dist.tgz
 
   test:
-    runs-on: ${{ matrix.platform }}
-    timeout-minutes: 30
-    name: ${{ matrix.package }} on ${{ matrix.platform }}
+    runs-on: ubuntu-18.04
+    name: ${{ matrix.package }}
     needs: prepack
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest]
-        # switch to [ubuntu-latest, macos-latest, windows-latest]
-        # when ready to test on windows as well
         package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
     steps:
       - uses: actions/checkout@v1
-      - name: cache node_modules
-        uses: actions/cache@v2
-        # cache node_modules based on lockfile which can change
-        # when there is no explicit change in package.json
-        # and prevents cache bust when scripts or metadata is changed
-        # which does not effect the node_modules themselves
+      - uses: actions/cache@v1
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/download-artifact@v2
-        # this action will also unpack them for us
+          path: /home/runner/.cache/yarn/v6
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/download-artifact@v1
         with:
-          name: bigtest.dist.${{ matrix.platform }}
-          path: ./packages
+          name: bigtest.dist.tgz
+      - run: tar -xvf bigtest.dist.tgz/bigtest.dist.tgz
       - name: Install dependencies
         run: yarn
       - name: Run tests


### PR DESCRIPTION
Reverts thefrontside/bigtest#486

Ever since we merged #486 there has been significant instability in our test suite, causing PRs which did not fail before to start failing such as #479 #485 and #490 

It could be a coincidence, but just in case, I'm proposing we revert these changes to see if it's related. If it is, then we can come at it again.

