### PR TITLE
pass unwrapped bundle from manifest-builder to bundler

### DIFF
--- a/.changeset/one-bundle-to-bundler.md
+++ b/.changeset/one-bundle-to-bundler.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": minor
+---
+
+pass bundle and not array of bundles from manifest-builder to bundler

--- a/.changeset/one-bundle.md
+++ b/.changeset/one-bundle.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": minor
+---
+
+pass unwrapped bundle from manifest-builder to bundler

--- a/packages/bundler/test/bundler.test.ts
+++ b/packages/bundler/test/bundler.test.ts
@@ -22,13 +22,12 @@ describe("Bundler", function() {
       beforeEach(async () => {
         await fs.writeFile("./build/test/sources/input.js", "const foo = 'bar';\nexport default foo;\n");
 
-        bundler = await spawn(Bundler.create(
-          [{
-            entry: "./build/test/sources/input.js",
-            outFile: "./build/test/output/manifest.js",
-            globalName: "__bigtestManifest",
-          }],
-        ));
+        bundler = await spawn(Bundler.create({
+          entry: "./build/test/sources/input.js",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
+        
         await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
       });
 
@@ -52,13 +51,11 @@ describe("Bundler", function() {
       beforeEach(async () => {
         await fs.writeFile("./build/test/sources/input.js", "const foo - 'bar';\nexport default foo;\n");
 
-        bundler = await spawn(Bundler.create(
-          [{
-            entry: "./build/test/sources/input.js",
-            outFile: "./build/test/output/manifest.js",
-            globalName: "__bigtestManifest",
-          }],
-        ));
+        bundler = await spawn(Bundler.create({
+          entry: "./build/test/sources/input.js",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
       });
 
       it('emits an error', async () => {
@@ -87,13 +84,12 @@ describe("Bundler", function() {
       beforeEach(async () => {
         await fs.writeFile("./build/test/sources/input.ts", "const foo: string = 'bar';\nexport default foo;\n");
 
-        bundler = await spawn(Bundler.create(
-          [{
-            entry: "./build/test/sources/input.ts",
-            outFile: "./build/test/output/manifest.js",
-            globalName: "__bigtestManifest",
-          }],
-        ));
+        bundler = await spawn(Bundler.create({
+          entry: "./build/test/sources/input.ts",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
+        
         await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
       });
 
@@ -106,13 +102,11 @@ describe("Bundler", function() {
       beforeEach(async () => {
         await fs.writeFile("./build/test/sources/input.ts", "const foo: number = 'bar';\nexport default foo;\n");
 
-        bundler = await spawn(Bundler.create(
-          [{
-            entry: "./build/test/sources/input.ts",
-            outFile: "./build/test/output/manifest.js",
-            globalName: "__bigtestManifest",
-          }],
-        ));
+        bundler = await spawn(Bundler.create({
+          entry: "./build/test/sources/input.ts",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
       });
 
       it('does not typecheck, just transform', async () => {
@@ -127,13 +121,12 @@ describe("Bundler", function() {
     beforeEach(async () => {
       await fs.writeFile("./build/test/sources/input.ts", "const foo: string = 'bar';\nexport default foo;\n");
 
-      bundler = await spawn(Bundler.create(
-        [{
-          entry: "./build/test/sources/input.ts",
-          outFile: "./build/test/output/manifest.js",
-          globalName: "__bigtestManifest",
-        }],
-      ));
+      bundler = await spawn(Bundler.create({
+        entry: "./build/test/sources/input.ts",
+        outFile: "./build/test/output/manifest.js",
+        globalName: "__bigtestManifest"
+      }));
+      
       await fs.writeFile("./build/test/sources/input.ts", "export default {hello: 'world'}\n");
     });
 

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -90,13 +90,11 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
 
   bundlerSlice.set({ type: 'UNBUNDLED' });
 
-  let bundler: Bundler = yield Bundler.create(
-    [{
-      entry: options.srcPath,
-      globalName: bigtestGlobals.manifestProperty,
-      outFile: path.join(options.buildDir, "manifest.js")
-    }],
-  );
+  let bundler: Bundler = yield Bundler.create({
+    entry: options.srcPath,
+    globalName: bigtestGlobals.manifestProperty,
+    outFile: path.join(options.buildDir, "manifest.js")
+  });
 
   yield subscribe(bundler).forEach(function* (message) {
     switch (message.type) {


### PR DESCRIPTION
Currently, the `manifest-builder` passes an array of one element when creating the bundler.

```typescript
  let bundler: Bundler = yield Bundler.create(
    [{
      entry: options.srcPath,
      globalName: bigtestGlobals.manifestProperty,
      outFile: path.join(options.buildDir, "manifest.js")
    }],
  );
```

We can simplify the code by just dealing with the unwrapped object.