### PR TITLE
Migrate client from Mailbox -> Subscription

### DIFF
--- a/.changeset/subscription-based-client.md
+++ b/.changeset/subscription-based-client.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/client": minor
+---
+update Client.subscription() and Client.liveQuery() methods to return
+an effection `Subscription` instead of a Mailbox

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -39,10 +39,11 @@ export function* runTest(config: ProjectOptions, formatter: StreamingFormatter):
   let startTime = performance.now();
 
   while(true) {
-    let result: query.RunResult = yield subscription.receive();
-    if(query.isDoneResult(result)) {
+    let next: IteratorResult<query.RunResult> = yield subscription.next();
+    if (next.done) {
       break;
-    } else if(result.event) {
+    } else if (!query.isDoneResult(next.value)) {
+      let result = next.value;
       let status = result.event.status;
       if(result.event.type === 'testRun:result') {
         testRunStatus = result.event.status;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,7 +19,6 @@
     "prepack": "tsc --outdir dist/esm --sourcemap --module es2015 && tsc --outdir dist/cjs --sourcemap --module commonjs && tsc --outdir dist/types --emitDeclarationOnly"
   },
   "dependencies": {
-    "@bigtest/effection": "^0.5.3",
     "@effection/events": "^0.7.8",
     "effection": "^0.7.0",
     "websocket": "^1.0.31"

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -43,11 +43,11 @@ export class Client {
     return res;
   }
 
-  query<T>(source: string, variables?: Variables): Operation {
+  query<T>(source: string, variables?: Variables): Operation<T> {
     return this.send<T>("query", source, false, variables).expect();
   }
 
-  mutation<T>(source: string, variables?: Variables): Operation {
+  mutation<T>(source: string, variables?: Variables): Operation<T> {
     return this.send<T>("mutation", source, false, variables).expect();
   }
 

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
-import { Mailbox } from '@bigtest/effection';
+import { ChainableSubscription } from '@effection/subscription';
 import { TestConnection, TestServer, run } from './helpers';
 import { Client, Message, Response, isQuery } from '../src';
 
@@ -22,19 +22,19 @@ describe('@bigtest/client', () => {
     });
 
   });
- 
+
   describe('interacting with the server', () => {
     let server: TestServer;
     let client: Client;
     let connection: TestConnection;
-  
+
     beforeEach(async () => {
       server = await TestServer.start(3300);
       let nextConnection = server.connection();
       client = await run(Client.create('http://localhost:3300'));
       connection = await nextConnection;
     });
-  
+
     describe('sending a query', () => {
       let message: Message | undefined;
       let queryResponse: Promise<Response>;
@@ -42,12 +42,12 @@ describe('@bigtest/client', () => {
         queryResponse = run(client.query('echo(message: "Hello World")'));
         message = await connection.receive();
       });
-  
+
       it('is received on the server', () => {
         expect(message).toBeDefined();
         expect(message?.query).toEqual('echo(message: "Hello World")');
       });
-  
+
       describe('when the server responds', () => {
         let response: {};
         beforeEach(async () => {
@@ -56,16 +56,16 @@ describe('@bigtest/client', () => {
             data: { echo: { message: "Hello World" }},
             responseId: message?.responseId
           });
-  
+
           response = await queryResponse;
         });
-  
+
         it('returns the data to the original query', () => {
           expect(response).toBeDefined();
           expect(response).toEqual({echo: { message: "Hello World" }});
         });
       });
-  
+
       describe('when the server responds with an error response', () => {
         beforeEach(async() => {
           await connection.send({
@@ -75,56 +75,56 @@ describe('@bigtest/client', () => {
             ]
           })
         });
-  
+
         it('rejects the original response', async () => {
           await expect(queryResponse).rejects.toEqual(new Error('failed'));
         });
       });
     });
-  
+
     describe('creating a live query', () => {
-      let mailbox: Mailbox<Response>;
+      let subscription: ChainableSubscription<unknown, unknown>;
       let message: Message;
       beforeEach(async () => {
-        mailbox = await run(client.liveQuery('echo(message: "Hello World")'));
+        subscription = await run(client.liveQuery('echo(message: "Hello World")'));
         message = await connection.receive() as Message;
       });
-  
+
       it('sends the live query message to the server', () => {
         expect(message).toBeDefined();
         expect(message?.query).toEqual('echo(message: "Hello World")');
         expect(isQuery(message)).toEqual(true);
       });
-  
+
       describe('sending a result', () => {
-        let response: Response;
-  
+        let response: unknown;
+
         beforeEach(async () => {
           await connection.send({
             responseId: message?.responseId,
             data: {echo: { message: "Hello World" }}
           })
-          response = await run(mailbox.receive());
+          response = await run(subscription.expect());
         });
-  
+
         it('is delivered to the query mailbox', () => {
           expect(response).toBeDefined();
           expect(response).toEqual({echo: { message: "Hello World" }});
         });
       });
     });
-  
+
     describe('sending a mutation', () => {
       let message: Message;
       let mutationResponse: Promise<Response>;
-  
+
       beforeEach(async () => {
         mutationResponse = run(client.mutation('{ run }'));
         message = await connection.receive() as Message;
-  
+
         expect(message?.mutation).toEqual('{ run }');
       });
-  
+
       describe('when the sever responds', () => {
         beforeEach(async () => {
           await connection.send({
@@ -132,7 +132,7 @@ describe('@bigtest/client', () => {
             data: { run: 'TestRun:1' }
           })
         });
-  
+
         it('returns the mutation to the client', async () => {
           await expect(mutationResponse).resolves.toEqual({ run: 'TestRun:1' });
         });

--- a/packages/client/test/helpers.ts
+++ b/packages/client/test/helpers.ts
@@ -2,7 +2,6 @@ import { Operation, resource, main } from 'effection';
 import { Channel } from '@effection/channel';
 import { subscribe } from '@effection/subscription';
 import { express, Socket } from '@bigtest/effection-express';
-import { Mailbox } from '@bigtest/effection';
 
 import { beforeEach } from 'mocha';
 
@@ -42,11 +41,9 @@ export class TestConnection {
   static *create(socket: Socket): Operation<TestConnection> {
     let connection = new TestConnection(socket);
     return yield resource(connection, function*() {
-      let incoming: Mailbox<Message> = yield socket.subscribe();
-      while (true) {
-        let message: Message = yield incoming.receive();
+      yield subscribe(socket).forEach(function*(message) {
         connection.incoming.send(message);
-      }
+      })
     });
   }
 

--- a/packages/server/bin/live-query.ts
+++ b/packages/server/bin/live-query.ts
@@ -9,7 +9,7 @@ main(function* main() {
   let subscription = yield client.liveQuery(source);
 
   while (true) {
-    let data = yield subscription.receive();
+    let { value: data } = yield subscription.next();
     console.log('==== new subscription result ==== ');
     console.log(JSON.stringify(data, null, 2));
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -60,6 +60,7 @@
     "@effection/events": "^0.7.8",
     "@effection/fetch": "^0.1.2",
     "@effection/node": "^0.8.0",
+    "@effection/subscription": "^0.11.0",
     "@nexus/schema": "^0.13.1",
     "bowser": "^2.8.1",
     "chokidar": "^3.3.1",

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -1,5 +1,5 @@
 import { Operation, spawn, fork } from 'effection';
-import { forEach } from '@effection/subscription';
+import { subscribe } from '@effection/subscription';
 import { Mailbox } from '@bigtest/effection';
 import { express, Socket } from '@bigtest/effection-express';
 import * as graphqlHTTP from 'express-graphql';
@@ -71,7 +71,7 @@ function handleMessage(options: CommandServerOptions): (socket: Socket) => Opera
     yield publishQueryResult(message, options.atom.get(), socket);
 
     if (message.live) {
-      yield fork(forEach(options.atom, (state) => publishQueryResult(message, state, socket)));
+      yield fork(subscribe(options.atom).forEach((state) => publishQueryResult(message, state, socket)));
     }
   }
 

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -6,6 +6,8 @@ import { Slice } from '@bigtest/atom';
 import { Test } from '@bigtest/suite';
 import { Client } from '@bigtest/client';
 
+import { ChainableSubscription } from '@effection/subscription';
+
 import { actions } from './helpers';
 import { createCommandServer } from '../src/command-server';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
@@ -187,13 +189,13 @@ describe('command server', () => {
 
   describe('subscribing to a live query', () => {
     let client: Client;
-    let subscription: Mailbox;
+    let subscription: ChainableSubscription<unknown, unknown>;
     let initial: unknown;
 
     beforeEach(async () => {
       client = await actions.fork(Client.create(`ws://localhost:${COMMAND_PORT}`));
       subscription = await actions.fork(client.liveQuery('{ agents { browser { name } } }'));
-      initial = await actions.fork(subscription.receive());
+      initial = await actions.fork(subscription.expect());
     });
 
     it('contains the initial result of the query', () => {
@@ -226,7 +228,7 @@ describe('command server', () => {
             }
           }
         });
-        second = await actions.fork(subscription.receive());
+        second = await actions.fork(subscription.first());
       });
 
       it('publishes the new state', () => {

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -1,8 +1,8 @@
 import * as expect from 'expect';
-import { Mailbox } from '@bigtest/effection';
 import { Agent, Command } from '@bigtest/agent';
 import { Client } from '@bigtest/client';
 import { ResultStatus } from '@bigtest/suite';
+import { ChainableSubscription } from '@effection/subscription';
 import { actions } from './helpers';
 import { generateAgentId } from '../src/connection-server';
 
@@ -83,7 +83,7 @@ describe('running tests on an agent', () => {
   let client: Client;
   let agent: Agent;
   let agentId = generateAgentId();
-  let agentsSubscription: Mailbox;
+  let agentsSubscription: ChainableSubscription<AgentsQuery, unknown>;;
 
   beforeEach(async () => {
     await actions.startOrchestrator();
@@ -92,19 +92,21 @@ describe('running tests on an agent', () => {
 
     agentsSubscription = await actions.fork(client.liveQuery(`{ agents { agentId } }`));
 
-    let match: (params: AgentsQuery) => boolean = ({ agents }) => agents && agents.length === 1;
-
-    await actions.fork(agentsSubscription.receive(match));
+    await actions.fork(agentsSubscription.filter(({ agents }) => {
+      return agents && agents.length === 1
+    }).first());
   });
 
   describe('with the fixture tree', () => {
-    let results: Mailbox;
+    let results: ChainableSubscription<QueryResult, unknown>;
     let runCommand: Command;
 
     beforeEach(async () => {
       await actions.fork(client.query(`mutation { run }`));
 
       runCommand = await actions.fork(agent.receive());
+
+
       results = await actions.fork(client.liveQuery(resultsQuery(runCommand.testRunId, agentId)));
     });
 
@@ -115,7 +117,7 @@ describe('running tests on an agent', () => {
     });
 
     it('is marks the run as pending', async () => {
-      await actions.fork(results.receive({ testRun: { status: 'pending' }}));
+      await actions.fork(results.match({ testRun: { status: 'pending' }}).expect());
     });
 
     describe('when the agent reports that it is running', () => {
@@ -127,7 +129,7 @@ describe('running tests on an agent', () => {
       });
 
       it('is marks the agent as running', async () => {
-        await actions.fork(results.receive({ testRun: { agent: { status: 'running' } }}));
+        await actions.fork(results.match({ testRun: { agent: { status: 'running' } }}).expect());
       });
     });
 
@@ -141,7 +143,7 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that particular test as running', async () => {
-        await actions.fork(results.receive({ testRun: { agent: { result: { status: 'running' } } } }));
+        await actions.fork(results.match({ testRun: { agent: { result: { status: 'running' } } } }).expect());
       });
     });
 
@@ -156,11 +158,11 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that step as ok', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === "Signing In" )?.steps
             .find(child => child.description === "when I fill in the login form")?.status === 'ok';
-        }));
+        }).expect());
       });
     });
 
@@ -178,23 +180,22 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that step as failed', async () => {
-        let match: (result: QueryResult) => boolean = ({ testRun }) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === "Signing In" )?.steps
             .find(child => child.description === "when I fill in the login form")?.status === 'failed';
-        };
-        await actions.fork(results.receive(match));
+        }).expect());
       });
 
       it('marks the entire test as failed', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === "Signing In" )?.status === 'failed';
-        }));
+        }).first());
       });
 
       it('disregards the remaining steps, and remaining children', async() => {
-        let match: (result: QueryResult) => boolean = ({ testRun }) => {
+        await actions.fork(results.filter(({ testRun }) => {
           let results = testRun.agent.result.children
             .find(child => child.description === "Signing In");
 
@@ -206,8 +207,7 @@ describe('running tests on an agent', () => {
           } else {
             return false;
           }
-        };
-        await actions.fork(results.receive(match));
+        }).expect());
       });
     });
 
@@ -222,11 +222,11 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that assertion as ok', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === 'Signing In' )?.assertions
             .find(child => child.description === 'then I am logged in')?.status === 'ok';
-        }));
+        }).expect());
       });
     });
 
@@ -244,11 +244,11 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that assertion as failed', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === 'Signing In')?.assertions
             .find(child => child.description === 'then I am logged in')?.status === 'failed';
-        }));
+        }).expect());
       });
     });
 
@@ -275,11 +275,11 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that test as ok', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === 'Signing In')?.children
             .find(child => child.description === 'when I log out')?.status === 'ok'
-        }));
+        }).expect());
       });
     });
 
@@ -306,11 +306,11 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that test as failed', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === 'Signing In')?.children
             .find(child => child.description === 'when I log out')?.status === 'failed'
-        }));
+        }).expect());
       });
     });
 
@@ -367,18 +367,18 @@ describe('running tests on an agent', () => {
       });
 
       it('marks that test as failed', async () => {
-        await actions.fork(results.receive(({ testRun }: QueryResult) => {
+        await actions.fork(results.filter(({ testRun }) => {
           return testRun.agent.result.children
             .find(child => child.description === 'Signing In')?.status === 'failed';
-        }));
+        }).expect());
       });
 
       it('marks the entire agent as failed if it is the root test', async () => {
-        await actions.fork(results.receive({ testRun: { agent: { status: 'failed' } } }));
+        await actions.fork(results.match({ testRun: { agent: { status: 'failed' } } }).expect());
       });
 
       it('marks the entire suite as failed if it is the root test', async () => {
-        await actions.fork(results.receive({ testRun: { agent: { status: 'failed' } } }));
+        await actions.fork(results.match({ testRun: { agent: { status: 'failed' } } }).expect());
       });
     });
   });
@@ -386,15 +386,15 @@ describe('running tests on an agent', () => {
   describe('with multiple agents', function() {
     let secondAgentId = generateAgentId();
     let secondAgent: Agent;
-    let agentResults: Mailbox;
-    let secondAgentResults: Mailbox;
+    let agentResults: ChainableSubscription<QueryResult, unknown>;
+    let secondAgentResults:ChainableSubscription<QueryResult, unknown>;
 
     beforeEach(async () => {
       secondAgent = await actions.createAgent(secondAgentId);
 
-      let match: (results: AgentsQuery) => boolean = ({ agents }) => agents && agents.length === 2;
-
-      await actions.fork(agentsSubscription.receive(match));
+      await actions.fork(agentsSubscription.filter(({ agents }) => {
+        return agents && agents.length === 2
+      }).expect());
 
       await actions.fork(client.query(`mutation { run }`));
 
@@ -419,21 +419,21 @@ describe('running tests on an agent', () => {
     });
 
     it('tracks results for all agents separately', async () => {
-      let matchFailed: (result: QueryResult) => boolean = ({ testRun }) => {
+      let matchFailed = ({ testRun }: QueryResult) => {
         return testRun.agent.result.children
           .find(child => child.description === "Signing In" )?.steps
           .find(child => child.description === "when I fill in the login form")?.status === 'failed';
       };
 
-      await actions.fork(agentResults.receive(matchFailed));
+      await actions.fork(agentResults.filter(matchFailed).expect());
 
-      let matchSucess: (result: QueryResult) => boolean = ({ testRun }) => {
+      let matchSucess = ({ testRun }: QueryResult) => {
         return testRun.agent.result.children
           .find(child => child.description === "Signing In" )?.steps
           .find(child => child.description === "when I fill in the login form")?.status === 'ok';
       }
 
-      await actions.fork(secondAgentResults.receive(matchSucess));
+      await actions.fork(secondAgentResults.filter(matchSucess).first());
     });
   });
 });

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -387,7 +387,7 @@ describe('running tests on an agent', () => {
     let secondAgentId = generateAgentId();
     let secondAgent: Agent;
     let agentResults: ChainableSubscription<QueryResult, unknown>;
-    let secondAgentResults:ChainableSubscription<QueryResult, unknown>;
+    let secondAgentResults: ChainableSubscription<QueryResult, unknown>;
 
     beforeEach(async () => {
       secondAgent = await actions.createAgent(secondAgentId);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,12 +2132,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9485,7 +9480,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9480,7 +9485,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Motivation
-----------
As part of moving towards a general reporter api, we need to incorporate formally the concept of "done-ness" to the stream of events coming from the server. That way, an entire test run can be represented as a single effection subscription.

The first piece in getting this to work is to make the client speak natively in subscriptions to begin with.

Approach
----------
This has been something that we've been meaning to do anyhow since it makes the code a lot nicer, and so this takes that first step by converting the client over to use subscriptions natively.

Instead of returning a mailbox from the `subscription` method, a subscription is returned instead. As an added bonus, the client methods are now parameterized, so that you can map, filter, match etc on a client query in a strongly typed fashion.