### PR TITLE
Allow DSL to consume units of work (like interactor) directly

### DIFF
--- a/.changeset/direct-dsl.md
+++ b/.changeset/direct-dsl.md
@@ -1,0 +1,15 @@
+---
+"@bigtest/suite": minor
+"@bigtest/interactor": minor
+---
+Allow passing any fully-formed step into the `step()` method of the
+DSL. For example:
+```ts
+.step({ description: 'visit /users', action: () => App.visit('/users')})
+```
+Interactions implement this natively, so you can now use them
+directly:
+
+```ts
+.step(App.visit('/users'))
+```

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -14,7 +14,7 @@ globalThis.fetch = async function(url) {
 const H2 = createInteractor('h2')({ selector: 'h2' });
 
 module.exports = test("tests")
-  .step("load the app", async () => { await App.visit('/app.html') })
+  .step(App.visit('/app.html'))
   .child(
     "test with failing assertion", test => test
       .step("successful step", async () => {

--- a/packages/interactor/src/interaction.ts
+++ b/packages/interactor/src/interaction.ts
@@ -1,23 +1,33 @@
 export interface Interaction<T> extends Promise<T> {
   description: string;
+  action: () => Promise<T>;
 }
 
-export function interaction<T>(description: string, fn: () => Promise<T>): Interaction<T> {
+export interface ReadonlyInteraction<T> extends Interaction<T> {
+  check: () => Promise<T>;
+}
+
+export function interaction<T>(description: string, action: () => Promise<T>): Interaction<T> {
   let promise: Promise<T>;
   return {
     description,
+    action,
     [Symbol.toStringTag]: `[interaction ${description}]`,
     then(onFulfill, onReject) {
-      if(!promise) { promise = fn(); }
+      if(!promise) { promise = action(); }
       return promise.then(onFulfill, onReject);
     },
     catch(onReject) {
-      if(!promise) { promise = fn(); }
+      if(!promise) { promise = action(); }
       return promise.catch(onReject);
     },
     finally(handler) {
-      if(!promise) { promise = fn(); }
+      if(!promise) { promise = action(); }
       return promise.finally(handler);
     }
   }
+}
+
+export function check<T>(description: string, check: () => Promise<T>): ReadonlyInteraction<T> {
+  return { check, ...interaction(description, check) };
 }

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -7,7 +7,7 @@ import { MatchFilter } from './match';
 import { resolve } from './resolve';
 import { formatTable } from './format-table';
 import { NotAbsentError, FilterNotMatchingError } from './errors';
-import { interaction, Interaction } from './interaction';
+import { interaction, check, Interaction, ReadonlyInteraction } from './interaction';
 
 export class Interactor<E extends Element, S extends InteractorSpecification<E>> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -52,16 +52,16 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
     });
   }
 
-  exists(): Interaction<void> {
-    return interaction(`${this.description} exists`, () => {
+  exists(): ReadonlyInteraction<void> {
+    return check(`${this.description} exists`, () => {
       return converge(() => {
         this.unsafeSyncResolve();
       });
     });
   }
 
-  absent(): Interaction<void> {
-    return interaction(`${this.description} does not exist`, () => {
+  absent(): ReadonlyInteraction<void> {
+    return check(`${this.description} does not exist`, () => {
       return converge(() => {
         try {
           this.unsafeSyncResolve();
@@ -75,9 +75,9 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
     });
   }
 
-  is(filters: FilterImplementation<E, S>): Interaction<void> {
+  is(filters: FilterImplementation<E, S>): ReadonlyInteraction<void> {
     let filter = new Filter(this.specification, filters);
-    return interaction(`${this.description} matches filters: ${filter.description}`, () => {
+    return check(`${this.description} matches filters: ${filter.description}`, () => {
       return converge(() => {
         let element = this.unsafeSyncResolve();
         let match = new MatchFilter(filter, element);

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -1,5 +1,4 @@
 import { Interactor } from './interactor';
-import { Interaction } from './interaction';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ActionFn<E extends Element, S extends InteractorSpecification<E>> = (interactor: InteractorInstance<E, S>, ...args: any[]) => unknown;

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -30,7 +30,7 @@ export interface InteractorSpecification<E extends Element> {
 
 export type ActionImplementation<E extends Element, S extends InteractorSpecification<E>> = {
   [P in keyof S['actions']]: S['actions'][P] extends ((interactor: InteractorInstance<E, S>, ...args: infer TArgs) => infer TReturn)
-    ? ((...args: TArgs) => Interaction<TReturn>)
+    ? ((...args: TArgs) => TReturn)
     : never;
 }
 

--- a/packages/interactor/types/dsl.ts
+++ b/packages/interactor/types/dsl.ts
@@ -1,0 +1,27 @@
+import { test } from '@bigtest/suite';
+import { createInteractor, perform } from '../src/index';
+
+const TextField = createInteractor<HTMLInputElement>('text field')({
+  selector: 'input',
+  defaultLocator: (element) => element.id,
+  filters: {
+    enabled: {
+      apply: (element) => !element.disabled,
+      default: true
+    },
+    value: (element) => element.value
+  },
+  actions: {
+    fillIn: perform((element, value: string) => { element.value = value })
+  }
+});
+
+test("using interactors")
+  .step(TextField("username").fillIn("cowboyd"))
+  .step(TextField("password").fillIn("secret"))
+  .assertion(TextField("username").exists())
+
+test("bad interactor usage")
+  // cannot use side-effect interactions in an assertion
+  // $ExpectError
+  .assertion(TextField("username").fillIn('cowboyd'))

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -40,7 +40,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
   step<R extends Context | void>(descriptionOrStep: StepDefinition<C,R> | string, action?: Action<C,R>): TestBuilder<R extends void ? C : C & R> {
     let step = typeof descriptionOrStep !== 'string' ? descriptionOrStep : {
       description: descriptionOrStep,
-      action: action ? action : async () => {}
+      action: action ? action : async () => undefined
     };
 
     return new TestBuilder({
@@ -54,7 +54,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
   assertion(descriptionOrAssertion: string | AssertionDefinition<C>, check?: Check<C>): TestBuilder<C> {
     let assertion = typeof descriptionOrAssertion !== 'string' ? descriptionOrAssertion : {
       description: descriptionOrAssertion,
-      check: check ? check : async () => {}
+      check: check ? check : async () => undefined
     };
 
     return new TestBuilder({

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -1,4 +1,4 @@
-import { TestImplementation, Context, Step, Assertion, Check, Action } from './interfaces';
+import { TestImplementation, Context, Step, Assertion } from './interfaces';
 
 export function test<C extends Context>(description: string): TestBuilder<C> {
   return new TestBuilder<C>({
@@ -7,6 +7,19 @@ export function test<C extends Context>(description: string): TestBuilder<C> {
     assertions: [],
     children: []
   });
+}
+
+export type Action<C extends Context, R extends Context | void> = (context: C) => Promise<R>;
+export type Check<C extends Context> = (context: C) => Promise<void>;
+
+export interface StepDefinition<C extends Context, R extends Context | void> {
+  description: string;
+  action: Action<C,R>;
+}
+
+export interface AssertionDefinition<C extends Context> {
+  description: string;
+  check: Check<C>;
 }
 
 export class TestBuilder<C extends Context> implements TestImplementation {
@@ -22,23 +35,31 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     this.children = test.children;
   }
 
-  step<R extends Context | void>(description: string, action: (context: C) => Promise<R>): TestBuilder<R extends void ? C : C & R> {
+  step<R extends Context | void>(step: StepDefinition<C,R>): TestBuilder<R extends void ? C : C & R>;
+  step<R extends Context | void>(description: string, action: Action<C,R>): TestBuilder<R extends void ? C : C & R>;
+  step<R extends Context | void>(descriptionOrStep: StepDefinition<C,R> | string, action?: Action<C,R>): TestBuilder<R extends void ? C : C & R> {
+    let step = typeof descriptionOrStep !== 'string' ? descriptionOrStep : {
+      description: descriptionOrStep,
+      action: action ? action : async () => {}
+    };
+
     return new TestBuilder({
       ...this,
-      steps: this.steps.concat({
-        description,
-        action: action as Action
-      }),
+      steps: this.steps.concat(step as Step),
     });
   }
 
-  assertion(description: string, check: (context: C) => Promise<void>): TestBuilder<C> {
+  assertion(assertion: AssertionDefinition<C>): TestBuilder<C>;
+  assertion(description: string, check: Check<C>): TestBuilder<C>;
+  assertion(descriptionOrAssertion: string | AssertionDefinition<C>, check?: Check<C>): TestBuilder<C> {
+    let assertion = typeof descriptionOrAssertion !== 'string' ? descriptionOrAssertion : {
+      description: descriptionOrAssertion,
+      check: check ? check : async () => {}
+    };
+
     return new TestBuilder({
       ...this,
-      assertions: this.assertions.concat({
-        description,
-        check: check as Check
-      }),
+      assertions: this.assertions.concat(assertion as Assertion),
     });
   }
 

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -43,3 +43,10 @@ test('a test')
   .step('return nonsense', async () => {
     return "foo";
   })
+
+test('a test')
+  .step({ description: "a description", action: async () => {} })
+  .step('add to context', async () => ({ hello: "world" }))
+  // $ExpectError
+  .step('consume from context', async({ helloX: string }) => { goodbye: helloX })
+  .step({ description: "consume from context", action: async () => {} })


### PR DESCRIPTION
> This is another stab at #311 

If we use interactors with our DSL we end up repeating a lot of information:

```ts
.step("I click the 'next' link", async () => {
  await Link('next').click();
});
```

It would be amazing if we could simply infer this information, and write this more succinctly like this:

```ts
.step(Link('next').click())
```

To accomplish this, we do the simplest thing that could possibly work: we first allow the DSL to consume the units it represents directly, and then second, make interactors compatible with those unit interfaces.

For example, the `step()` function now has an overload to pass description and action as a single object:

```ts
.step({
  description: "this is a step provided as a single object",
  action: () => Promise.resolve({ hello: 'world' })
})
```

Now, we can simply make our interactions implement that interface and we're off to the races.

As an added bonus, interactions are now split into `Interaction` and `ReadonlyInteraction` so that checks like `exists()` or `absent()` canbe used inside `steps`, but actions like `click()` and `fillIn()` _cannot_ be used inside assertions. In typescript this will fail to compile, and in JS it will throw a runtime error.