### PR TITLE
equality check on Atom#set to stop updates of equal states

### DIFF
--- a/.changeset/atom-equality-check.md
+++ b/.changeset/atom-equality-check.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": major
+---
+
+equality check in Atom#set to stop equal state subscription updates

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -3,6 +3,7 @@ import { Channel } from '@effection/channel';
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Slice } from "./slice";
 import { Sliceable } from './sliceable';
+import { equals } from 'ramda';
 
 export class Atom<S> implements Subscribable<S,undefined> {
   private readonly initial: S;
@@ -22,6 +23,13 @@ export class Atom<S> implements Subscribable<S,undefined> {
   }
 
   set(value: S) {
+    // need to use a deep equality check on the object's values
+    // because this.state and value
+    // will always be 2 different objects but will often have the 
+    // same values
+    if (equals(this.state, value)) {
+      return;
+    }
     this.state = value;
     this.states.send(value);
   }

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -163,7 +163,7 @@ describe('@bigtest/atom', () => {
       });
     });
 
-    describe('idempotent set', () => {
+    describe('prevent identitcal state notifications', () => {
       let subscription: Subscription<string, undefined>;
 
       beforeEach(async () => {
@@ -173,7 +173,7 @@ describe('@bigtest/atom', () => {
         subject.update(() => 'bar');
       });
 
-      it('iterates over emitted states', async () => {
+      it('only one notification for identical states', async () => {
         await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'bar' });
         await expect(spawn(subscription.next())).rejects;
       });

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -162,5 +162,21 @@ describe('@bigtest/atom', () => {
         await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'quox' });
       });
     });
+
+    describe('idempotent set', () => {
+      let subscription: Subscription<string, undefined>;
+
+      beforeEach(async () => {
+        subscription = await spawn(subscribe(subject));
+
+        subject.update(() => 'bar');
+        subject.update(() => 'bar');
+      });
+
+      it('iterates over emitted states', async () => {
+        await expect(spawn(subscription.next())).resolves.toEqual({ done: false, value: 'bar' });
+        await expect(spawn(subscription.next())).rejects;
+      });
+    })
   });
 });

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -11,6 +11,7 @@ export function* createLogger({ atom, out }: LoggerOptions) {
   let bundlerState = atom.slice('bundler');
 
   yield subscribe(bundlerState).forEach(function* (event) {
+    console.log(event);
     if(event.type === 'ERRORED'){
       out("[manifest builder] build error:", event.error);
       if (event.error.frame) {

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -11,7 +11,6 @@ export function* createLogger({ atom, out }: LoggerOptions) {
   let bundlerState = atom.slice('bundler');
 
   yield subscribe(bundlerState).forEach(function* (event) {
-    console.log(event);
     if(event.type === 'ERRORED'){
       out("[manifest builder] build error:", event.error);
       if (event.error.frame) {


### PR DESCRIPTION
this is a quick fix to stop state updates of similar values causing updates to all slices

I've used [ramda equals](https://ramdajs.com/docs/#equals) because the check is always against 2 different objects with potentially the same values.

You could also use [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal) which benchmarks `R.equals` as one of the slowest ways.

I think the real issue though is that `Slice#update` ends up calling `Atom#set` which replaces the entire tree causing all slices to be notified of the change.