### PR TITLE
Interactor definitions

### DIFF
--- a/.changeset/interactor-definitions.md
+++ b/.changeset/interactor-definitions.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": "minor"
+---
+
+Add built in interactors `Link` and `Heading`.

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "lint": "eslint '{src,test}/**/*.ts'",
     "mocha": "mocha -r ts-node/register",
-    "test:unit": "mocha -r ts-node/register test/**/*.test.ts",
+    "test:unit": "mocha -r ts-node/register 'test/**/*.test.ts'",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",
     "prepack": "tsc --outdir dist/esm --sourcemap --module es2015 && tsc --outdir dist/cjs --sourcemap --module commonjs && tsc --outdir dist/types --emitDeclarationOnly"

--- a/packages/interactor/src/definitions/heading.ts
+++ b/packages/interactor/src/definitions/heading.ts
@@ -1,0 +1,11 @@
+import { createInteractor } from '../create-interactor';
+
+export const Heading = createInteractor<HTMLHeadingElement>('heading')({
+  selector: 'h1,h2,h3,h4,h5,h6',
+  locators: {
+    byId: (element) => element.id
+  },
+  filters: {
+    level: (element) => parseInt(element.tagName[1])
+  }
+});

--- a/packages/interactor/src/definitions/link.ts
+++ b/packages/interactor/src/definitions/link.ts
@@ -1,0 +1,17 @@
+import { createInteractor, perform } from '../index';
+
+export const Link = createInteractor<HTMLLinkElement>('link')({
+  selector: 'a[href]',
+  locators: {
+    byId: (element) => element.id,
+    byTitle: (element) => element.title,
+  },
+  filters: {
+    title: (element) => element.title,
+    href: (element) => element.href,
+    id: (element) => element.id,
+  },
+  actions: {
+    click: perform((element) => { element.click(); })
+  },
+});

--- a/packages/interactor/src/index.ts
+++ b/packages/interactor/src/index.ts
@@ -2,3 +2,6 @@ export { Interactor } from './interactor';
 export { createInteractor } from './create-interactor';
 export { App } from './app';
 export { perform } from './perform';
+
+export { Link } from './definitions/link';
+export { Heading } from './definitions/heading';

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -1,8 +1,6 @@
 import { describe, it } from 'mocha';
-import * as expect from 'expect'
-
-import { bigtestGlobals } from '@bigtest/globals';
-import { JSDOM } from 'jsdom';
+import * as expect from 'expect';
+import { dom } from './helpers';
 
 import { createInteractor, perform } from '../src/index';
 
@@ -64,17 +62,7 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")({
   }
 });
 
-function dom(html: string) {
-  let jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
-  bigtestGlobals.document = jsdom.window.document;
-}
-
 describe('@bigtest/interactor', () => {
-  beforeEach(() => {
-    bigtestGlobals.reset();
-    bigtestGlobals.defaultInteractorTimeout = 20;
-  });
-
   describe('instantiation', () => {
     describe('no arguments', () => {
       let MainNav = createInteractor('main nav')({

--- a/packages/interactor/test/definitions/heading.test.ts
+++ b/packages/interactor/test/definitions/heading.test.ts
@@ -1,0 +1,31 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import { Heading } from '../../src/index';
+import { dom } from '../helpers';
+
+describe('@bigtest/interactor', () => {
+  describe('Heading', () => {
+    it('finds `h1`, `h2`, etc... tags by text', async () => {
+      dom(`
+        <h1>Foo</h1>
+        <h6>Bar</h6>
+        <p>Quox</p>
+      `);
+
+      await expect(Heading('Foo').exists()).resolves.toBeUndefined();
+      await expect(Heading('Bar').exists()).resolves.toBeUndefined();
+      await expect(Heading('Quox').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    describe('filter `level`', () => {
+      it('filters heading tags by their heading level', async () => {
+        dom(`
+          <h2>Foo</h2>
+        `);
+
+        await expect(Heading('Foo', { level: 2 }).exists()).resolves.toBeUndefined();
+        await expect(Heading('Foo', { level: 3 }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+  });
+});

--- a/packages/interactor/test/definitions/link.test.ts
+++ b/packages/interactor/test/definitions/link.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import { Link, Heading } from '../../src/index';
+import { dom } from '../helpers';
+
+describe('@bigtest/interactor', () => {
+  describe('Link', () => {
+    it('finds `a` tags by text', async () => {
+      dom(`
+        <p><a href="/foobar">Foo Bar</a></p>
+        <p><a href="/foobar">Quox</a></p>
+      `);
+
+      await expect(Link('Foo Bar').exists()).resolves.toBeUndefined();
+      await expect(Link('Blah').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    it('does not find `a` tags without `href` attributes, since they are not considered links per the HTML spec', async () => {
+      dom(`
+        <p><a>Foo</a></p>
+      `);
+
+      await expect(Link('Foo').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    describe('.byId', () => {
+      it('finds `a` tags by id', async () => {
+        dom(`
+          <p><a href="/foo" id="foo-link">Foo</a></p>
+          <p><a href="/bar" id="bar-link">Bar</a></p>
+        `);
+
+        await expect(Link.byId('foo-link').exists()).resolves.toBeUndefined();
+        await expect(Link.byId('does-not-exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
+    describe('.byTitle', () => {
+      it('finds `a` tags by their title', async () => {
+        dom(`
+          <p><a href="/foo" title="My Foo Link">Foo</a></p>
+          <p><a href="/bar" title="My Bar Link">Bar</a></p>
+        `);
+
+        await expect(Link.byTitle('My Foo Link').exists()).resolves.toBeUndefined();
+        await expect(Link.byTitle('Does not exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
+    describe('.click', () => {
+      it('clicks on link', async () => {
+        dom(`
+          <p><a href="#" id="foobar">Foo</a></p>
+          <script>
+            foobar.addEventListener('click', (event) => {
+              event.preventDefault();
+              let h1 = document.createElement('h1')
+              h1.textContent = 'Success';
+              document.body.appendChild(h1);
+            });
+          </script>
+        `);
+
+        await Link('Foo').click();
+        await Heading('Success').exists();
+      });
+    });
+
+    describe('filter `title`', () => {
+      it('filters `a` tags by their title', async () => {
+        dom(`
+          <p><a href="/foo" title="My Foo Link">Foo</a></p>
+          <p><a href="/bar" title="My Bar Link">Bar</a></p>
+        `);
+
+        await expect(Link('Foo', { title: 'My Foo Link' }).exists()).resolves.toBeUndefined();
+        await expect(Link('Foo', { title: 'Does not exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
+    describe('filter `href`', () => {
+      it('filters `a` tags by their href attributes', async () => {
+        dom(`
+          <p><a href="/foo">Foo</a></p>
+        `);
+
+        await expect(Link('Foo', { href: '/foo' }).exists()).resolves.toBeUndefined();
+        await expect(Link('Foo', { href: '/wrong' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
+    describe('filter `id`', () => {
+      it('filters `a` tags by id', async () => {
+        dom(`
+          <p><a href="/foo" id="foo-link">Foo</a></p>
+        `);
+
+        await expect(Link('Foo', { id: 'foo-link' }).exists()).resolves.toBeUndefined();
+        await expect(Link('Foo', { id: 'does-not-exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+  });
+});

--- a/packages/interactor/test/helpers.ts
+++ b/packages/interactor/test/helpers.ts
@@ -2,8 +2,10 @@ import { beforeEach } from 'mocha';
 import { bigtestGlobals } from '@bigtest/globals';
 import { JSDOM } from 'jsdom';
 
+let jsdom: JSDOM;
+
 export function dom(html: string) {
-  let jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
+  jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
   bigtestGlobals.document = jsdom.window.document;
 }
 
@@ -12,3 +14,6 @@ beforeEach(() => {
   bigtestGlobals.defaultInteractorTimeout = 20;
 });
 
+afterEach(() => {
+  jsdom?.window?.close();
+});

--- a/packages/interactor/test/helpers.ts
+++ b/packages/interactor/test/helpers.ts
@@ -1,0 +1,14 @@
+import { beforeEach } from 'mocha';
+import { bigtestGlobals } from '@bigtest/globals';
+import { JSDOM } from 'jsdom';
+
+export function dom(html: string) {
+  let jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
+  bigtestGlobals.document = jsdom.window.document;
+}
+
+beforeEach(() => {
+  bigtestGlobals.reset();
+  bigtestGlobals.defaultInteractorTimeout = 20;
+});
+


### PR DESCRIPTION
This adds `Link` and `Headline` as the first built-in interactors. See #379.

This implementation is quite minimal for now. It's meant to serve as a guideline for how and where interactors are added and tested, to serve as a jumping-off point.