### PR TITLE
Support nullary interactors

### DIFF
--- a/.changeset/nullary-interactors.md
+++ b/.changeset/nullary-interactors.md
@@ -1,0 +1,13 @@
+---
+"@bigtest/interactor": minor
+---
+
+Support nullary interactors for singleton elements:
+
+```
+const MainNav = createInteractor('button')({
+  selector: '#main-nav'
+});
+
+MainNav().click('Widgets');
+```

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,4 +1,4 @@
-import { InteractorSpecification, FilterImplementation, InteractorInstance, InteractorType, LocatorFn } from './specification';
+import { InteractorSpecification, FilterImplementation, InteractorInstance, InteractorType, LocatorFn, InteractorConstructor } from './specification';
 import { Locator } from './locator';
 import { Filter } from './filter';
 import { Interactor } from './interactor';
@@ -30,8 +30,8 @@ export function createInteractor<E extends Element>(interactorName: string) {
       });
     }
 
-    let result = function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
-      let locator = new Locator(specification.defaultLocator || defaultLocator, value);
+    let result: InteractorConstructor<E, S> = function(value?: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
+      let locator = value ? new Locator(specification.defaultLocator || defaultLocator, value) : new Locator();
       let filter = new Filter(specification, filters || {});
       let interactor = new InteractorClass(interactorName, specification, locator, filter);
       return interactor as InteractorInstance<E, S>;

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -35,6 +35,9 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
 
   get description(): string {
     return this.ancestorsAndSelf.reverse().map((interactor) => {
+      if (interactor.locator.isNull) {
+        return `${interactor.name} ${interactor.filter.description}`.trim();
+      }
       return `${interactor.name} ${interactor.locator.description} ${interactor.filter.description}`.trim();
     }).join(' within ');
   }

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,8 +1,20 @@
-import { LocatorFn } from './specification';
+import { LocatorFn, NullLocatorFn } from './specification';
 import { noCase } from 'change-case';
 
 export class Locator<E extends Element> {
-  constructor(public locatorFn: LocatorFn<E>, public value: string, public name?: string) {}
+  public locatorFn: LocatorFn<E> | NullLocatorFn;
+  public value: string | null;
+  public name: string | null;
+  public isNull: boolean;
+
+  constructor();
+  constructor(locatorFn: LocatorFn<E>, value: string, name?: string);
+  constructor(locatorFn?: LocatorFn<E>, value?: string | null, name?: string) {
+    this.locatorFn = locatorFn || (() => null);
+    this.value = value || null;
+    this.name = name || null;
+    this.isNull = this.value == null;
+  }
 
   get description(): string {
     if(this.name) {

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -39,8 +39,8 @@ export class Match<E extends Element, S extends InteractorSpecification<E>> {
 
 export class MatchLocator<E extends Element> {
   public matches: boolean;
-  public expected: string;
-  public actual: string;
+  public expected: string | null;
+  public actual: string | null;
 
   constructor(
     public locator: Locator<E>,

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -6,6 +6,8 @@ export type ActionFn<E extends Element, S extends InteractorSpecification<E>> = 
 
 export type LocatorFn<E extends Element> = (element: E) => string;
 
+export type NullLocatorFn = () => null;
+
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
 export interface FilterObject<T, E extends Element> {
@@ -50,6 +52,6 @@ export type LocatorImplementation<E extends Element, S extends InteractorSpecifi
 export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E, S> & ActionImplementation<E, S>;
 
 export type InteractorConstructor<E extends Element, S extends InteractorSpecification<E>> =
-  (value: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>;
+  (value?: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>;
 
 export type InteractorType<E extends Element, S extends InteractorSpecification<E>> = InteractorConstructor<E, S> & LocatorImplementation<E, S>;

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -75,6 +75,36 @@ describe('@bigtest/interactor', () => {
     bigtestGlobals.defaultInteractorTimeout = 20;
   });
 
+  describe('instantiation', () => {
+    describe('no arguments', () => {
+      let MainNav = createInteractor('main nav')({
+        selector: 'nav'
+      });
+
+      it('just uses the selector to locate', async () => {
+        dom(`
+          <nav id="main-nav"></nav>
+        `);
+
+        await expect(MainNav().exists()).resolves.toBeUndefined();
+      });
+
+      it('throws an AmbiguousElementError if necessary', async () => {
+        dom(`
+          <nav id="main-nav"></nav>
+          <nav id="secondary-nav"></nav>
+        `);
+
+        await expect(MainNav().exists()).rejects.toHaveProperty('message', [
+          'main nav matches multiple elements:',
+          '',
+          '- <nav id="main-nav">',
+          '- <nav id="secondary-nav">'
+        ].join('\n'));
+      });
+    });
+  });
+
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`


### PR DESCRIPTION
## Motivation

Closes #505 

Interactors currently require that one passes a string value as the first argument, which gets used with the `defaultLocator`:

```ts
const Button = createInteractor('button')({
  selector: 'button',
  defaultLocator: element => element.textContent
});

Button('Click me').click();
```

What if we are trying to make an interactor for a component there is only ever one of on a page though? Let's also say that this component doesn't have a way to identify it other than, for example, an `id` or `data-test` attribute, which we may already be using in the `selector` property of the interactor definition. This is very common:

- Navigational menus
- Modals/dialogues
- Large tables that take up the whole page
- etc.

It is currently possible to circumvent the string argument requirement by making the `defaultLocator` return an empty string and passing an empty string to the interactor:

```ts
MainNav('').click('Widgets');
```

This is confusing and does not scale well.

## Approach

Allow nullary interactors:

```ts
const MainNav = createInteractor('button')({
  selector: '#main-nav'
});

MainNav().click('Widgets');
```

This assumes the `selector` matches a single element, otherwise we will get an `AmbiguousElementError`.