### PR TITLE
add @bigtest/eslint-plugin

### DIFF
--- a/.changeset/eslint-plugin.md
+++ b/.changeset/eslint-plugin.md
@@ -1,5 +1,5 @@
 ---
-"@bigtest/eslint-plugin": major
+"@bigtest/eslint-plugin": minor
 ---
 
 add @bigtest/eslint-plugin

--- a/.changeset/nine-weeks-compare.md
+++ b/.changeset/nine-weeks-compare.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/eslint-plugin": major
+---
+
+add @bigtest/eslint-plugin

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "workspaces": {
     "packages": [
+      "packages/eslint-plugin",
       "packages/effection",
       "packages/client",
       "packages/effection-express",

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -1,0 +1,39 @@
+# @bigtest/eslint-plugin
+
+## Installation
+
+```bash
+yarn add --dev eslint @bigtest/eslint-plugin
+```
+
+## Usage
+
+Add `@bigtest` to the plugins section of your `.eslintrc` configuration file.
+```json
+{
+  "plugins": ["@bigtest"]
+}
+```
+
+## Shareable configurations
+
+### Recommended
+
+This plugin exports a recommended configuration.
+
+To enable this configuration use the `extends` property in your `.eslintrc`
+config file:
+
+```json
+{
+  "extends": ["plugin:@bigtest/recommended"]
+}
+```
+
+## Rules
+
+<!-- begin rules list -->
+
+| Rule                                                                         | Description                                                     | Configurations   | Fixable      |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------- | ---------------- | ------------ |
+| [require-default-export](docs/rules/require-default-test-export)                       | Each test file must have a default export. 

--- a/packages/eslint-plugin/docs/rules/require-default-test-export.md
+++ b/packages/eslint-plugin/docs/rules/require-default-test-export.md
@@ -1,0 +1,32 @@
+# Require all test files to have a default export (`require-default-export`)
+
+Bigtest test files must have a default export
+
+## Rule Details
+
+This rule triggers a warning if a test file does not have a default export.
+
+```typescript
+import { test } from '@bigtest/suite';
+
+const delay = (time = 50) =>
+  async () => { await new Promise(resolve => setTimeout(resolve, time)) };
+
+export default test('Passing Test')
+  .step("first step", delay())
+```
+
+Named exports will not be exported:
+
+```typescript
+import { test } from '@bigtest/suite';
+
+const delay = (time = 50) =>
+  async () => { await new Promise(resolve => setTimeout(resolve, time)) };
+
+export const tests = test('Passing Test')
+  .step("first step", delay())
+```
+## When Not To Use It
+
+Don't use this rule on non-bigtest test files.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@bigtest/eslint-plugin",
+  "version": "0.1.0",
+  "description": "eslint rules for bigtest",
+  "main": "dist/index.js",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "license": "MIT",
+  "private": false,
+  "keywords": [
+    "eslint"
+  ],
+  "devDependencies": {
+    "@frontside/tsconfig": "*",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.13.4",
+    "mocha": "^6.2.2",
+    "ts-node": "*"
+  },
+  "scripts": {
+    "lint": "eslint '{src,test}/**/*.ts'",
+    "prepack": "tsc --declaration --sourcemap",
+    "test": "mocha -r ts-node/register 'test/{,!(fixtures)/**}/*.test.ts'"
+  },
+  "files": [
+    "docs",
+    "dist"
+  ]
+}

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -1,0 +1,14 @@
+import { requireDefaultTextExport } from './rules/require-default-export';
+
+export const rules = {
+  'require-default-export': requireDefaultTextExport
+};
+
+export const configs = {
+  root: true,
+  recommended: {
+    rules: {
+      'bigtest/require-default-export': 2
+    }
+  }
+}

--- a/packages/eslint-plugin/src/rules/require-default-export.ts
+++ b/packages/eslint-plugin/src/rules/require-default-export.ts
@@ -1,0 +1,86 @@
+import {
+  TSESTree,
+  AST_NODE_TYPES
+} from '@typescript-eslint/experimental-utils';
+import { createRule } from './utils';
+
+export const requireDefaultTextExport = createRule({
+  name: __filename,
+  meta: {
+    docs: {
+      category: 'Possible Errors',
+      description: 'Require a BigTest test file to have a default export',
+      recommended: 'error',
+    },
+    messages: {
+      exportIsNotTest: 'The test file does not have a default export',
+      namedExport: 'Test files must have a default export'
+    },
+    type: 'problem',
+    schema: [],
+  },
+  defaultOptions: [],
+  create(context) {
+    // ignore non-modules
+    if (context.parserOptions.sourceType !== 'module') {
+      return {}
+    }
+    
+    let defaultExport: TSESTree.ExportDefaultDeclaration;
+    let namedExport: TSESTree.ExportNamedDeclaration;
+    let hasDefaultTestDeclaration = false;
+
+     return {
+      'Program:exit'() {
+        if(hasDefaultTestDeclaration){
+          return;
+        }
+        
+        if (defaultExport) {
+          context.report({ node: defaultExport || namedExport, messageId: 'exportIsNotTest'});
+          return;
+        }
+
+        context.report({ node: context.getSourceCode().ast, messageId: 'namedExport' })
+      },
+
+      ExportNamedDeclaration(
+        node: TSESTree.ExportNamedDeclaration
+      ) {
+        namedExport = node;
+      },
+      // commonjs
+      // module.exports =
+      // exports =
+      MemberExpression(node) {
+        if (node.type !== AST_NODE_TYPES.MemberExpression ||
+            node.object.type !== AST_NODE_TYPES.Identifier) {
+          return;
+        }
+
+        if (node.object.name !== 'module' && node.object.name !== 'exports' || !node.parent) {
+          return;
+        }
+
+        if(node.parent.type !== AST_NODE_TYPES.AssignmentExpression) {
+          return;
+        }
+        
+        if(node.parent.operator !== '=') {
+          return;
+        }
+
+        hasDefaultTestDeclaration = true;
+      },
+      ExportDefaultDeclaration(
+        node: TSESTree.ExportDefaultDeclaration,
+      ) {
+        if( [AST_NODE_TYPES.CallExpression, AST_NODE_TYPES.ObjectExpression].includes(node.declaration.type)) {
+          hasDefaultTestDeclaration = true;
+        } else {
+          defaultExport = node;
+        }
+      },
+    };
+  },
+});

--- a/packages/eslint-plugin/src/rules/utils.ts
+++ b/packages/eslint-plugin/src/rules/utils.ts
@@ -1,0 +1,15 @@
+import {
+  ESLintUtils,
+} from '@typescript-eslint/experimental-utils';
+import * as path from 'path';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { version } = require('../../package.json');
+
+const REPO_URL = 'https://github.com/thefrontside/bigtest/eslint-plugin';
+
+export const createRule = ESLintUtils.RuleCreator(name => {
+  let ruleName = path.parse(name).name;
+
+  return `${REPO_URL}/blob/v${version}/docs/rules/${ruleName}.md`;
+});

--- a/packages/eslint-plugin/src/types.ts
+++ b/packages/eslint-plugin/src/types.ts
@@ -1,0 +1,16 @@
+export type ValidationException = {
+  code?: string;
+  frame?: string;
+  message: string;
+  displayMessage: string;
+	loc?: {
+		column: number;
+		file?: string;
+		line: number;
+	};
+}
+
+export type ValidationWarning = ValidationException;
+export type ValidationError = ValidationException & {
+  stack?: string;
+}

--- a/packages/eslint-plugin/test/require-default-test.test.ts
+++ b/packages/eslint-plugin/test/require-default-test.test.ts
@@ -1,0 +1,66 @@
+import { TSESLint } from '@typescript-eslint/experimental-utils';
+import { requireDefaultTextExport } from '../src/rules/require-default-export';
+
+const ruleTester = new TSESLint.RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('require-default-export', requireDefaultTextExport, {
+  valid: [
+`
+import { test } from '@bigtest/suite';
+
+const delay = (time = 50) =>
+  async () => { await new Promise(resolve => setTimeout(resolve, time)) };
+
+export default test('Failing Test')
+  .step("first step", delay())
+  .assertion("check the thing", delay(3))`
+,
+`
+export default {
+  description: "Signing In",
+  steps: [
+    {
+      description: "given a user",
+      action: async (context) => ({ ...context, user: { username: "cowboyd" } })
+    },
+  ],
+  assertions: [
+    {
+      description: "then I am logged in",
+      check: async () => true
+    },
+  ]
+}
+`,
+`
+module.exports = {
+  description: "An empty test with no steps and no children",
+  steps: [],
+  assertions: [],
+  children: []
+}
+`
+  ],
+
+  invalid: [
+    {
+      code: `
+import { test } from '@bigtest/suite';
+
+const delay = (time = 50) =>
+  async () => { await new Promise(resolve => setTimeout(resolve, time)) };
+
+export const NoDefaultExportTest = test('Failing Test')
+  .step("first step", delay());
+      `,
+      parserOptions: { sourceType: 'module' },
+      errors: [{ messageId: 'namedExport' }],
+    },
+  ],
+});  

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@frontside/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts"
+  ]
+}


### PR DESCRIPTION
The first part of validating that the test files are in a correct structure.

Firsts and foremost, we need eslint to check for things like a bigtest test file has a default export as eslint is an integral part of most devs and most CI pipeline's workflow.

I personally would prefer static analysis for a default export rather than requiring an object and looking for a default property.

This check also has to happen before the bundler as the bundler deals with the manifest that is generated from the manifest-generator.  We want the user to know as soon as possible that their test file is not in the correct structure.

Waiting for the bundler is a bad experience in my opinion and also too late.

In a later PR, I run the eslnit `CLIEngine` at runtime using the same rule and the user does not progress to the bundling state unless their test files are correct.

## Eslint Ruleset

There is currently only 1 rule  `@bigtest/require-default-test-export` that checks for a default export like the following:

```typescript
export default test('a test')
```
or
```javascript
module.exports = test('a test'); 
```
or even
```javascript
exports = test(' a test');
```