### PR TITLE
fix: remove all single quotes in package.json scripts

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{app,bin,src,test}/**/*.ts'",
+    "lint": "eslint \"{app,bin,src,test}/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register",
     "start": "parcel serve --out-dir dist/app app/index.html app/harness.ts",

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "mocha": "mocha -r ts-node/register",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap"

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outDir dist --declaration --sourcemap --module commonjs"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test,bin}/**/*.ts'",
+    "lint": "eslint \"{src,test,bin}/**/*.ts\"",
     "test": "mocha -r ts-node/register \"test/{,!(fixtures)/**}/*.test.ts\"",
     "mocha": "mocha -r ts-node/register",
     "bigtest": "ts-node src/index.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "mocha": "mocha -r ts-node/register",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist/esm --sourcemap --module es2015 && tsc --outdir dist/cjs --sourcemap --module commonjs && tsc --outdir dist/types --emitDeclarationOnly"

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist"
   },

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register",
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "mocha": "mocha -r ts-node/register",
     "prepack": "tsc --outdir dist --declaration --sourcemap"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -17,9 +17,9 @@
     "ts-node": "*"
   },
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "prepack": "tsc --declaration --sourcemap",
-    "test": "mocha -r ts-node/register 'test/{,!(fixtures)/**}/*.test.ts'"
+    "test": "mocha -r ts-node/register \"test/{,!(fixtures)/**}/*.test.ts\""
   },
   "files": [
     "docs",

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -13,7 +13,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "mocha": "mocha -r ts-node/register",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist/esm --sourcemap --module es2015 && tsc --outdir dist/cjs --sourcemap --module commonjs && tsc --outdir dist/types --emitDeclarationOnly"

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -14,9 +14,9 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "mocha": "mocha -r ts-node/register",
-    "test:unit": "mocha -r ts-node/register 'test/**/*.test.ts'",
+    "test:unit": "mocha -r ts-node/register \"test/**/*.test.ts\"",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",
     "prepack": "tsc --outdir dist/esm --sourcemap --module es2015 && tsc --outdir dist/cjs --sourcemap --module commonjs && tsc --outdir dist/types --emitDeclarationOnly"

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -11,7 +11,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "true",
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
   },

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap --module commonjs"
   },

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,7 @@
     "start": "ts-node bin/start.ts",
     "query": "ts-node bin/query.ts",
     "query:live": "ts-node bin/live-query.ts",
-    "lint": "eslint '{src,bin,test}/**/*.ts'",
+    "lint": "eslint \"{src,bin,test}/**/*.ts\"",
     "test": "mocha ./test/setup test/**/*.test.ts",
     "mocha": "mocha ./test/setup",
     "test:app:start": "ts-node ./bin/todomvc.ts",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -14,7 +14,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test:unit": "mocha -r ts-node/register test/**/*.test.ts",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "start": "yarn prepack && ts-node dist/start.js",
-    "lint": "eslint 'src/**/*.ts' 'test/**/*.ts'",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "mocha -r ts-node/register test/**/*.test.ts",
     "build": "yarn prepack",
     "prepack": "rm -rf dist && yarn mkdirp dist -p && cd app && cp app.package.json package.json && react-scripts build && cd .. && mv app/build dist/app && tsc --outdir dist --module commonjs --declaration --sourcemap && chmod a+x dist/start.js"

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -12,7 +12,7 @@
     "README.md"
   ],
   "scripts": {
-    "lint": "eslint '{src,test}/**/*.ts'",
+    "lint": "eslint \"{src,test}/**/*.ts\"",
     "test": "mocha --timeout 60000 -r ts-node/register test/**/*.test.ts",
     "prepack": "tsc --outdir dist --declaration --sourcemap"
   },

--- a/website/package.json
+++ b/website/package.json
@@ -50,9 +50,9 @@
   "license": "MIT",
   "scripts": {
     "develop": "gatsby develop",
-    "format:ts": "prettier --write '**/*.{json,ts,tsx}'",
-    "lint:ts": "eslint '**/*.{ts,tsx}'",
-    "lint:styles": "stylelint './src/**/*.{ts,tsx}'",
+    "format:ts": "prettier --write \"**/*.{json,ts,tsx}\"",
+    "lint:ts": "eslint \"**/*.{ts,tsx}\"",
+    "lint:styles": "stylelint \"./src/**/*.{ts,tsx}\"",
     "lint": "yarn lint:ts && yarn lint:styles",
     "start": "npm run develop",
     "serve": "gatsby serve",


### PR DESCRIPTION
This is for windows compatibility reasons. It can only run scripts with the double quotes otherwise the terminal processes the globs which typically breaks the commands.