### PR TITLE
Add Gherkin-style given-when-then as an alternative DSL

### DIFF
--- a/packages/suite/test/dsl.test.ts
+++ b/packages/suite/test/dsl.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from 'mocha';
 import * as expect from 'expect'
 
 import example from './fixtures/example';
+import givenWhenThen from './fixtures/given-when-then';
 
 describe('dsl', () => {
   it('returns a serialized test suite', async () => {
@@ -16,5 +17,19 @@ describe('dsl', () => {
     expect(example.children[0].assertions[0].description).toEqual('a child assertion');
 
     await expect(example.steps[0].action({})).resolves.toHaveProperty('foo', 'foo');
+  });
+
+  it('can use given when then format', async () => {
+    expect(givenWhenThen.description).toEqual('a test');
+    expect(givenWhenThen.steps[0].description).toEqual('given some step');
+    expect(givenWhenThen.steps[1].description).toEqual('when this does nothing');
+    expect(givenWhenThen.steps[2].description).toEqual('when another step');
+    expect(givenWhenThen.assertions[0].description).toEqual('then this is an assertion');
+    expect(givenWhenThen.assertions[1].description).toEqual('then this is another assertion');
+    expect(givenWhenThen.children[0].description).toEqual('a child test');
+    expect(givenWhenThen.children[0].steps[0].description).toEqual('when a child step');
+    expect(givenWhenThen.children[0].assertions[0].description).toEqual('then a child assertion');
+
+    await expect(givenWhenThen.steps[0].action({})).resolves.toHaveProperty('foo', 'foo');
   });
 })

--- a/packages/suite/test/fixtures/given-when-then.ts
+++ b/packages/suite/test/fixtures/given-when-then.ts
@@ -1,0 +1,26 @@
+import { test } from '../../src/index';
+import { strict as assert } from 'assert';
+
+export default test('a test')
+  .given('some step', async () => {
+    return { foo: 'foo' }
+  })
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  .when('this does nothing', async() => {})
+  .when('another step', async ({ foo }) => {
+    return { bar: foo.toUpperCase() + 'bar' }
+  })
+  .then('this is an assertion', async ({ foo }) => {
+    assert.equal(foo, 'foo');
+  })
+  .then('this is another assertion', async ({ bar }) => {
+    assert.equal(bar, 'foobar');
+  })
+  .test('a child test', child => child
+    .when('a child step', async ({ foo }) => {
+      return { quox: foo.toUpperCase() + 'blah' }
+    })
+    .then('a child assertion', async ({ quox }) => {
+      assert.equal(quox, 'FOOblah');
+    })
+  );


### PR DESCRIPTION
The current nomenclature of `step`/`assertion` is a bit technical, this is a slightly friendlier alternative, which should be familiar to anyone who has used cucumber, or something like rspec-given.

One downside of this is that the lexical difference between `when` and `then` is rather small, so it can be pretty hard to spot which is a step and which is an assertion. This could be solved via editor plugins and syntax highlighting, but it is definitely not ideal.

This may be less of a problem with Gherkin, since there is no functional difference between `When` and `Then`, it only affects how a person reads the test, not how the test runner does, so getting it wrong has lessened consequences.