### PR TITLE
Update return type of Interactor#has to match Interactor#is

### DIFF
--- a/.changeset/interactor-has-type.md
+++ b/.changeset/interactor-has-type.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+---
+
+Update return type of Interactor#has to match Interactor#is.

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -92,7 +92,7 @@ export class Interactor<E extends Element, S extends InteractorSpecification<E>>
     });
   }
 
-  has(filters: FilterImplementation<E, S>): Interaction<void> {
+  has(filters: FilterImplementation<E, S>): ReadonlyInteraction<void> {
     return this.is(filters);
   }
 }


### PR DESCRIPTION
## Motivation

Return type is annotated incorrectly for `Interactor#has`. This appears to just be a mistake.

## Approach

Update the return type to match `#is`, a `ReadonlyInteraction`.