### PR TITLE
Exclude 'app/' sources from the typescript build

### DIFF
--- a/.changeset/spicy-bugs-flow.md
+++ b/.changeset/spicy-bugs-flow.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/agent": minor
+---
+
+Exclude 'app/' sources from the typescript build which was causing a corrupted harness.js to be distributed.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -17,7 +17,7 @@
     "mocha": "mocha -r ts-node/register",
     "start": "parcel serve --out-dir dist/app app/index.html app/harness.ts",
     "prepack:app": "parcel build --public-url ./ --no-minify --out-dir dist/app app/index.html app/test-frame.html app/harness.ts",
-    "prepack:tsc": "tsc --outdir dist --declaration --sourcemap",
+    "prepack:tsc": "tsc --project tsconfig.dist.json --outdir dist --declaration --sourcemap",
     "prepack": "yarn prepack:app && yarn prepack:tsc",
     "pretest:manifest": "parcel build test/fixtures/manifest.js test/fixtures/app.html --out-dir tmp/test --no-minify --global __bigtestManifest",
     "pretest:app": "parcel build --public-url ./ --no-minify --out-dir tmp/test app/index.html app/test-frame.html app/harness.ts",

--- a/packages/agent/tsconfig.dist.json
+++ b/packages/agent/tsconfig.dist.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "app/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Motivation
-----------

> fixes #526 

The typescript compile was overwriting `dist/app/harness.js` because we had the `app/` directory in the `tsconfig.json` in order to make the IDE's more friendly with our sources. Unfortunately, this breaks the distributed harness.js.


Approach
----------

This breaks out the distribution config into a `tsconfig.dist.json` which explicitly excludes the `app/` directory, so that now what is distributed is the harness built by parcel.

Open Questions
----------------

How could we test this to prevent something like this happening again?
