### PR TITLE
chore: timeout tests and checkout@v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,14 @@ on:
 jobs:
   prepack:
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
     name: prepack
     strategy:
       matrix:
         platform: [ubuntu-latest]
         # keeping platform as a single item so test-*.yml files can be identical except for this value
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: cache
         uses: actions/cache@v2
         with:
@@ -31,6 +32,7 @@ jobs:
 
   test:
     runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
     name: ${{ matrix.package }}
     needs: prepack
     strategy:
@@ -40,7 +42,7 @@ jobs:
         # keeping platform as a single item so test-*.yml files can be identical except for this value
         package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This is the last of the workflow changes besides the `node_modules` cache. Upgrading the checkout which is faster and improves functionality on reruns. It checks out the sha instead. The tests shouldn't really on a specfic git fetch depth so it shouldn't break anything.

Also adding a timeout as the default is 6hrs and this makes it less possible to accidentally swamp CI.