### PR TITLE
Prevent build error spam

### DIFF
--- a/.changeset/ten-cycles-cheat.md
+++ b/.changeset/ten-cycles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Don't spam the console when build errors happen

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,4 @@
-import { OrchestratorState } from './orchestrator/state';
+import { OrchestratorState, BundlerTypes } from './orchestrator/state';
 import { Atom } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';
 
@@ -10,11 +10,16 @@ export interface LoggerOptions {
 export function* createLogger({ atom, out }: LoggerOptions) {
   let bundlerState = atom.slice('bundler');
 
+  let currentBundlerType: BundlerTypes;
   yield subscribe(bundlerState).forEach(function* (event) {
-    if(event.type === 'ERRORED'){
-      out("[manifest builder] build error:", event.error);
-      if (event.error.frame) {
-        out("[manifest builder] build error frame:\n", event.error.frame);
+    if(event.type !== currentBundlerType) {
+      currentBundlerType = event.type;
+      if(event.type === 'ERRORED'){
+        out("[manifest builder] build error:");
+        out(event.error.message);
+      }
+      if(event.type === 'GREEN'){
+        out("[manifest builder] build successful!");
       }
     }
   })


### PR DESCRIPTION
Closes #532

This is a quick fix which ensures we only print the bundler error message when the state has actually changed, preventing the console from being spammed to death.

Additionally it only prints the error message, and not the stack trace, since that trace is completely useless.

While we will want a more elegant solution for this eventually, it'll do fine for now.