### PR TITLE
Allow formatters to be functions

### DIFF
--- a/.changeset/lovely-bears-roll.md
+++ b/.changeset/lovely-bears-roll.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/cli": minor
+---
+
+Formatters can be functions in addition to objects

--- a/packages/cli/src/format-helpers.ts
+++ b/packages/cli/src/format-helpers.ts
@@ -132,3 +132,5 @@ export type Formatter = {
   event(event: RunResultEvent): void;
   footer(result: TestResults): void;
 };
+
+export type FormatterConstructor = () => Formatter;

--- a/packages/cli/src/formatters/checks.ts
+++ b/packages/cli/src/formatters/checks.ts
@@ -1,20 +1,24 @@
-import { Formatter, statusIcon, standardFooter } from '../format-helpers';
+import { FormatterConstructor, statusIcon, standardFooter } from '../format-helpers';
 
-const formatter: Formatter = {
-  header() {
-    // no op
-  },
+const formatter: FormatterConstructor = () => {
+  let didGetResult = false;
+  return {
+    header() {
+      // no op
+    },
 
-  event(event) {
-    if((event.type === 'step:result' || event.type === 'assertion:result') && event.status) {
-      process.stdout.write(statusIcon(event.status));
-    }
-    if(event.type === 'testRun:result') {
-      process.stdout.write('\n\n');
-    }
-  },
+    event(event) {
+      if((event.type === 'step:result' || event.type === 'assertion:result') && event.status) {
+        didGetResult = true;
+        process.stdout.write(statusIcon(event.status));
+      }
+      if(event.type === 'testRun:result' && didGetResult) {
+        process.stdout.write('\n\n');
+      }
+    },
 
-  footer: standardFooter()
+    footer: standardFooter()
+  }
 };
 
 export default formatter;


### PR DESCRIPTION
If a formatter wants to maintain any internal state, it needs to have some context to bind this state to. For example: our `checks` formatter doesn't need to print any newlines if it never got any results.