### PR TITLE
Fail run on build failed

### DIFF
--- a/.changeset/rare-snails-chew.md
+++ b/.changeset/rare-snails-chew.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": minor
+---
+
+Atom and Slice's `once` never returns undefined. The subscription never terminates, so an undefined value will never happen in practice.

--- a/.changeset/slow-singers-battle.md
+++ b/.changeset/slow-singers-battle.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Prevent race conditions in result stream by always streaming results even if the test run is already complete.

--- a/.changeset/tall-bobcats-crash.md
+++ b/.changeset/tall-bobcats-crash.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Start orchestrator even if bundle has errors.

--- a/.changeset/wild-rules-unite.md
+++ b/.changeset/wild-rules-unite.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": minor
+"@bigtest/server": minor
+---
+
+Fail test run if there are errors in the test files

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -30,12 +30,12 @@ export class Atom<S> implements Subscribable<S,undefined> {
     this.set(fn(this.get()));
   }
 
-  *once(predicate: (state: S) => boolean): Operation<S | undefined> {
+  *once(predicate: (state: S) => boolean): Operation<S> {
     if(predicate(this.state)) {
       return this.state;
     } else {
       let subscription = yield subscribe(this.states);
-      return yield subscription.filter(predicate).first();
+      return yield subscription.filter(predicate).expect();
     }
   }
 

--- a/packages/atom/src/slice.ts
+++ b/packages/atom/src/slice.ts
@@ -68,13 +68,13 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
     }
   }
 
-  *once(predicate: (state: S) => boolean): Operation<S | undefined> {
+  *once(predicate: (state: S) => boolean): Operation<S> {
     let currentState = this.get();
     if(predicate(currentState)) {
       return currentState;
     } else {
       let subscription = yield subscribe(this);
-      return yield subscription.filter(predicate).first();
+      return yield subscription.filter(predicate).expect();
     }
   }
 

--- a/packages/cli/.eslintignore
+++ b/packages/cli/.eslintignore
@@ -1,0 +1,1 @@
+test/fixtures/bad.broken.ts

--- a/packages/cli/src/format-helpers.ts
+++ b/packages/cli/src/format-helpers.ts
@@ -112,7 +112,13 @@ export function standardFooter() {
         recursiveChildrenResults(result);
       }
     });
-    console.log(chalk.grey('────────────────────────────────────────────────────────────────────────────────'));
+    if(testRun.agents.length) {
+      console.log(chalk.grey('────────────────────────────────────────────────────────────────────────────────'));
+    }
+    if(testRun.status === 'failed' && testRun.error) {
+      errorLines(testRun.error).forEach((line) => console.log(chalk.red(line)));
+      console.log('');
+    }
     console.log(
       testRun.status === 'ok'
         ? chalk.green('✓ SUCCESS')

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -83,6 +83,7 @@ export function test() {
     ) {
       testRun(id: $testRunId) {
         status
+        error { ...ErrorDetails }
         agents {
           agent {
             agentId
@@ -152,6 +153,7 @@ export type ResultSummary = { stepCounts: ResultCounts; assertionCounts: ResultC
 export type TestResults = {
   testRun: {
     status: ResultStatus;
+    error?: ErrorDetails;
     agents: {
       status: ResultStatus;
       agent: {

--- a/packages/cli/test/fixtures/bad.broken.ts
+++ b/packages/cli/test/fixtures/bad.broken.ts
@@ -1,0 +1,1 @@
+class class

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -60,7 +60,7 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
       testRunId: testRunId,
       status: 'failed',
       agents: {},
-      error: { name: "BundlerError", message: bundler.error.message }
+      error: { name: 'BundlerError', message: 'Cannot run tests due to build errors in the test suite:\n' + bundler.error.message }
     });
   }
 }

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -3,7 +3,7 @@ import { Mailbox } from '@bigtest/effection';
 import { Test, TestResult } from '@bigtest/suite';
 import { Atom } from '@bigtest/atom';
 import { AgentEvent, Command as AgentCommand } from '@bigtest/agent';
-import { AgentState, OrchestratorState } from './orchestrator/state';
+import { AgentState, OrchestratorState, BundlerState } from './orchestrator/state';
 import { TestRunAggregator } from './result-aggregator/test-run';
 import { CommandMessage } from './command-server';
 
@@ -21,33 +21,48 @@ function* run(testRunId: string, options: CommandProcessorOptions): Operation {
 
   let stepTimeout = 60_000;
   let testRunSlice = options.atom.slice('testRuns', testRunId);
-  let manifest = options.atom.get().manifest;
 
-  let appUrl = `http://localhost:${options.proxyPort}`;
-  let manifestUrl = `http://localhost:${options.manifestPort}/${manifest.fileName}`;
+  let bundlerSlice = options.atom.slice('bundler');
 
-  // todo: we should perform filtering of the agents here
-  let agents: AgentState[] = Object.values(options.atom.get().agents);
+  let bundler: BundlerState = yield bundlerSlice.once((state) => state.type === 'GREEN' || state.type === 'ERRORED');
 
-  // todo: we should perform filtering of the manifest here
-  let result = resultsFor(manifest);
+  if(bundler.type === 'GREEN') {
+    let manifest = options.atom.get().manifest;
 
-  testRunSlice.set({
-    testRunId: testRunId,
-    status: 'pending',
-    agents: Object.fromEntries(agents.map((agent) => [agent.agentId, { agent, result, status: 'pending' }])),
-  });
+    let appUrl = `http://localhost:${options.proxyPort}`;
+    let manifestUrl = `http://localhost:${options.manifestPort}/${manifest.fileName}`;
 
-  for (let agent of agents) {
-    let { agentId } = agent;
+    // todo: we should perform filtering of the agents here
+    let agents: AgentState[] = Object.values(options.atom.get().agents);
 
-    console.debug(`[command processor] starting test run ${testRunId} on agent ${agentId}`);
-    options.delegate.send({ type: 'run', agentId, appUrl, manifestUrl, testRunId, tree: manifest, stepTimeout });
+    // todo: we should perform filtering of the manifest here
+    let result = resultsFor(manifest);
+
+    testRunSlice.set({
+      testRunId: testRunId,
+      status: 'pending',
+      agents: Object.fromEntries(agents.map((agent) => [agent.agentId, { agent, result, status: 'pending' }])),
+    });
+
+    for (let agent of agents) {
+      let { agentId } = agent;
+
+      console.debug(`[command processor] starting test run ${testRunId} on agent ${agentId}`);
+      options.delegate.send({ type: 'run', agentId, appUrl, manifestUrl, testRunId, tree: manifest, stepTimeout });
+    }
+
+    let aggregator = new TestRunAggregator(testRunSlice, { testRunId, ...options });
+
+    yield aggregator.run();
   }
-
-  let aggregator = new TestRunAggregator(testRunSlice, { testRunId, ...options });
-
-  yield aggregator.run();
+  if(bundler.type === 'ERRORED') {
+    testRunSlice.set({
+      testRunId: testRunId,
+      status: 'failed',
+      agents: {},
+      error: { name: "BundlerError", message: bundler.error.message }
+    });
+  }
 }
 
 export function* createCommandProcessor(options: CommandProcessorOptions): Operation {

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -122,7 +122,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
       console.debug('[orchestrator] app server ready');
     });
     yield fork(function* () {
-      yield options.atom.slice('bundler').once(({ type }) => type === 'GREEN');
+      yield options.atom.slice('bundler').once(({ type }) => type === 'GREEN' || type === 'ERRORED');
       console.debug('[orchestrator] manifest builder ready');
     });
     yield fork(function* () {

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -1,4 +1,4 @@
-import { Test, TestResult, ResultStatus } from '@bigtest/suite';
+import { Test, TestResult, ResultStatus, ErrorDetails } from '@bigtest/suite';
 import { BundlerError, BundlerWarning } from '@bigtest/bundler';
 
 export type AgentState = {
@@ -26,6 +26,7 @@ export type TestRunState = {
   testRunId: string;
   status: ResultStatus;
   agents: Record<string, TestRunAgentState>;
+  error?: ErrorDetails;
 }
 
 export type TestRunAgentState = {

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -227,6 +227,7 @@ export const schema = makeSchema({
       definition(t) {
         t.id("testRunId");
         t.string("status");
+        t.field("error", { type: "Error", nullable: true });
         t.list.field("agents", {
           type: "TestRunAgent",
           resolve: (testRun) => Object.values(testRun.agents)

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -98,7 +98,7 @@ describe('command processor', () => {
 
     it('marks test run as failed', () => {
       expect(testRun.status).toEqual('failed');
-      expect(testRun.error?.message).toEqual('it broke');
+      expect(testRun.error?.message).toEqual('Cannot run tests due to build errors in the test suite:\nit broke');
       expect(Object.values(testRun.agents).length).toEqual(0);
     });
   });

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -11,7 +11,7 @@ import { createCommandProcessor } from '../src/command-processor';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { CommandMessage } from '../src/command-server';
 
-import { OrchestratorState } from '../src/orchestrator/state';
+import { OrchestratorState, TestRunState } from '../src/orchestrator/state';
 
 describe('command processor', () => {
   let delegate: Mailbox<AgentCommand & { agentId: string }>;
@@ -48,11 +48,15 @@ describe('command processor', () => {
     }));
   });
 
-  describe('when sent a `run` message', () => {
+  describe('when sent a `run` message with a valid manifest', () => {
     let pendingMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+    let testRun: TestRunState;
+
     beforeEach(async () => {
+      atom.slice('bundler', 'type').set('GREEN');
       commands.send({ type: 'run', id: 'test-id-1' });
       pendingMessage = await actions.fork(delegate.receive({ type: 'run' }));
+      testRun = await actions.fork(atom.slice('testRuns', 'test-id-1').once((testRun) => testRun?.status === 'ok'));
     });
 
     it('runs on the available agents', () => {
@@ -76,10 +80,26 @@ describe('command processor', () => {
     });
 
     it('adds agent and test tree to manifest', () => {
-      let testRun = atom.slice('testRuns', 'test-id-1').get();
+      expect(testRun.status).toEqual('ok');
       expect(Object.values(testRun.agents).length).toEqual(1);
       expect(testRun.agents['agent-1'].agent.agentId).toEqual('agent-1');
       expect(testRun.agents['agent-1'].result.description).toEqual('the manifest');
+    });
+  });
+
+  describe('when sent a `run` message with a broken manifest', () => {
+    let testRun: TestRunState;
+
+    beforeEach(async () => {
+      atom.slice('bundler').set({ type: 'ERRORED', error: { message: 'it broke' }});
+      commands.send({ type: 'run', id: 'test-id-1' });
+      testRun = await actions.fork(atom.slice('testRuns', 'test-id-1').once((testRun) => testRun?.status === 'failed'));
+    });
+
+    it('marks test run as failed', () => {
+      expect(testRun.status).toEqual('failed');
+      expect(testRun.error?.message).toEqual('it broke');
+      expect(Object.values(testRun.agents).length).toEqual(0);
     });
   });
 });

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -10,10 +10,11 @@ import { World } from './helpers/world';
 import { createOrchestrator } from '../src/index';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { AppOptions } from '../src/orchestrator/state';
-import { Manifest } from '../src/orchestrator/state';
+import { Manifest, BundlerState } from '../src/orchestrator/state';
 
 let orchestratorPromise: Context;
 let manifest: Manifest;
+let bundler: BundlerState = { type: 'UNBUNDLED' };
 
 export const actions = {
   atom: createOrchestratorAtom({
@@ -84,6 +85,7 @@ export const actions = {
     }
     return orchestratorPromise.then(cxt => {
       manifest = actions.atom.get().manifest;
+      bundler = actions.atom.get().bundler;
       return cxt;
     });
   }
@@ -97,7 +99,7 @@ after(async function() {
 });
 
 beforeEach(() => {
-  actions.atom.reset(initial => ({ ...initial, manifest }));
+  actions.atom.reset(initial => ({ ...initial, manifest, bundler }));
 
   currentWorld = new World();
 });

--- a/packages/server/test/subscription.test.ts
+++ b/packages/server/test/subscription.test.ts
@@ -67,8 +67,7 @@ describe('running tests with subscription on an agent', () => {
       });
 
       it('sends a running event', async () => {
-
-        let event = await actions.fork(results.expect());
+        let event = await actions.fork(results.match({ event: { type: 'testRunAgent:running' } }).expect());
         expect(event).toMatchObject({ event: { type: 'testRunAgent:running', agentId, testRunId } });
       });
     });
@@ -84,7 +83,7 @@ describe('running tests with subscription on an agent', () => {
       });
 
       it('sends an event for that step', async () => {
-        let event = await actions.fork(results.first());
+        let event = await actions.fork(results.match({ event: { type: 'step:result' } }).expect());
         expect(event).toMatchObject({
           event: {
             type: 'step:result',


### PR DESCRIPTION
If there are any build failures in the test files causing the manifest build to fail, fail the test run and print the failure that caused the build error in the first place.

Closes #279
Closes #421