### PR TITLE
✨Add lists of steps in one go

### DIFF
--- a/.changeset/step-list.md
+++ b/.changeset/step-list.md
@@ -1,0 +1,13 @@
+---
+"@bigtest/suite": minor
+---
+Adds ability to add multiple steps in a single go with the dsl:
+```js
+test("multi-step")
+  .step(
+    App.visit('/users/preview/1'),
+    Button('Fees/fines').click(),
+    Link('Create fee/fine').click(),
+    Select('Fee/fine owner*').select('testOwner'),
+    Select('Fee/fine type*').select('testFineType'));
+```

--- a/packages/suite/test/dsl.test.ts
+++ b/packages/suite/test/dsl.test.ts
@@ -4,6 +4,8 @@ import * as expect from 'expect'
 import { test }from '../src';
 import example from './fixtures/example';
 
+const noop = () => undefined;
+
 describe('dsl', () => {
   it('returns a serialized test suite', async () => {
     expect(example.description).toEqual('a test');
@@ -22,16 +24,16 @@ describe('dsl', () => {
   it('can have multiple steps', () => {
     let { steps } = test('a test')
       .step(
-        { description: "hello", action() {} },
-        { description: "world", action() {} });
+        { description: "hello", action: noop },
+        { description: "world", action: noop });
 
     expect(steps.map(step => step.description)).toEqual(['hello', 'world']);
   });
   it('can have multiple assertions', () => {
     let { assertions } = test('an assertion').
       assertion(
-        { description: "hello", check() {} },
-        { description: "world", check() {} });
+        { description: "hello", check: noop },
+        { description: "world", check: noop });
 
     expect(assertions.map(assertion => assertion.description)).toEqual(['hello', 'world']);
   });

--- a/packages/suite/test/dsl.test.ts
+++ b/packages/suite/test/dsl.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect'
 
+import { test }from '../src';
 import example from './fixtures/example';
 
 describe('dsl', () => {
@@ -16,5 +17,22 @@ describe('dsl', () => {
     expect(example.children[0].assertions[0].description).toEqual('a child assertion');
 
     await expect(example.steps[0].action({})).resolves.toHaveProperty('foo', 'foo');
+  });
+
+  it('can have multiple steps', () => {
+    let { steps } = test('a test')
+      .step(
+        { description: "hello", action() {} },
+        { description: "world", action() {} });
+
+    expect(steps.map(step => step.description)).toEqual(['hello', 'world']);
+  });
+  it('can have multiple assertions', () => {
+    let { assertions } = test('an assertion').
+      assertion(
+        { description: "hello", check() {} },
+        { description: "world", check() {} });
+
+    expect(assertions.map(assertion => assertion.description)).toEqual(['hello', 'world']);
   });
 })

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -38,10 +38,10 @@ test('a test')
   })
 
 // Context Async
-test('a test')
+let t1 = test('a test')
   // should not be able to return non-object
   // $ExpectError
-  .step('return nonsense', async () => {
+  t.step('return nonsense', async () => {
     return "foo";
   })
 
@@ -53,10 +53,10 @@ test('a test')
   .step({ description: "consume from context", action: async () => {} })
 
 // Context Sync
-test('a test')
+let t2 = test('a test')
   // should not be able to return non-object
   // $ExpectError
-  .step('return nonsense', () => {
+  t.step('return nonsense', () => {
     return "foo";
   })
 
@@ -66,3 +66,19 @@ test('a test')
   // $ExpectError
   .step('consume from context', ({ helloX: string }) => { goodbye: helloX })
   .step({ description: "consume from context", action: () => {} })
+
+//Add multiple steps
+test('a test')
+  .step("add context", () => ({ hello: 'world' }))
+  .step(
+    { description: "hello", action: async ({ hello }) => { hello.charAt(0) } },
+    { description: "hello", action: ({ hello }) => { hello.charAt(0) } })
+  .step('consume context after multi-step', ({ hello }) => { hello.charAt(0) })
+
+//Add multiple assertions
+test('a test')
+  .step("add context", () => ({ hello: 'world' }))
+  .assertion(
+    { description: "hello", check: async ({ hello }) => { hello.charAt(0) } },
+    { description: "hello", check: ({ hello }) => { hello.charAt(0) } })
+  .assertion('consume context after multi-step', ({ hello }) => { hello.charAt(0) });


### PR DESCRIPTION
Motivation
-----------

One of the things we've noticed develoing large test suites is that it is very common to have sequences of three to four steps. For example, here is a real-life example of a multi-step interaction that represent navigation to a page, then a sub-page, and then setting some filters:

```js
.step(App.visit('/users/preview/1'))
.step(Button('Fees/fines').click())
.step(Link('Create fee/fine').click())
.step(Select('Fee/fine owner*').select('testOwner'))
.step(Select('Fee/fine type*').select('testFineType'))
```

the fact that we have to add each step with a `step` invocation is not
only annoying to the author of the step, it more importantly obscures
what is happening to the reader of the test case. 


Approach
----------
We can more simply express a list of steps using a `stepList` method where we add all the steps in a single shot:

```js
step(
  App.visit('/users/preview/1'),
  Button('Fees/fines').click(),
  Link('Create fee/fine').click(),
  Select('Fee/fine owner*').select('testOwner'),
  Select('Fee/fine type*').select('testFineType'));
```

Alternatives
------------

One thing to consider would be to just add yet another overload to the `step` method that would expect a list of steps. That way, there's less surface API and it's clear that a list of steps is just another type of step.