### PR TITLE
chore: test on mac

### DIFF
--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -1,0 +1,59 @@
+name: Test Mac
+
+on:
+  pull_request:
+    branches:
+      - 'v[0-9]+'
+
+jobs:
+  prepack:
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    name: prepack
+    strategy:
+      matrix:
+        platform: [macos-latest]
+        # keeping platform as a single item so test-*.yml files can be identical except for this value
+    steps:
+      - uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.cache/yarn/v6
+          key: cachekey-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn
+      - name: Run prepack
+        run: yarn prepack
+      - uses: actions/upload-artifact@v2
+        with:
+          name: bigtest.dist.${{ matrix.platform }}
+          path: ./packages/*/dist
+
+  test:
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 30
+    name: ${{ matrix.package }}
+    needs: prepack
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [macos-latest]
+        # keeping platform as a single item so test-*.yml files can be identical except for this value
+        package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
+    steps:
+      - uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.cache/yarn/v6
+          key: cachekey-v1-${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/download-artifact@v2
+        # this action will also unpack them for us
+        with:
+          name: bigtest.dist.${{ matrix.platform }}
+          path: ./packages
+      - name: Install dependencies
+        run: yarn
+      - name: Run tests
+        run: yarn workspace @bigtest/${{ matrix.package }} test

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Test Ubuntu
 
 on:
   pull_request:


### PR DESCRIPTION
This is a strict copy of our workflow to run on Mac. Copying because, as previously discussed, the prepack job can finish and continue to the test job separately for each OS.