### PR TITLE
Harvest coverage metrics

### DIFF
--- a/.changeset/harvest-coverage-data.md
+++ b/.changeset/harvest-coverage-data.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/agent": minor
+---
+If the application under test generates a `__coverage__` object, then
+it will be harvested after each lane, and the aggregate coverage map
+will be sent back to the orchestrator inside the `run:end` event.

--- a/packages/agent/app/__coverage__.ts
+++ b/packages/agent/app/__coverage__.ts
@@ -1,0 +1,1 @@
+declare var __coverage__: unknown;

--- a/packages/agent/app/__coverage__.ts
+++ b/packages/agent/app/__coverage__.ts
@@ -1,1 +1,2 @@
+/* eslint-disable prefer-let/prefer-let, no-var */
 declare var __coverage__: unknown;

--- a/packages/agent/app/coverage.ts
+++ b/packages/agent/app/coverage.ts
@@ -1,0 +1,47 @@
+import './__coverage__';
+import { createCoverageMap, CoverageMap, CoverageMapData } from 'istanbul-lib-coverage';
+
+interface CoverageConfigurable {
+  coverageMap?: CoverageMap;
+}
+
+/**
+ * Get the coverage map associated with the scope designated by
+ *`Window`. By allowing scope to be an argument, we can access the coverage
+ * map from both the test _and_ the agent frame.
+ */
+export function getCoverageMap(window: Window): CoverageMap | undefined {
+  let context: typeof globalThis = window.window;
+  let bigtest: CoverageConfigurable = context.__bigtest as CoverageConfigurable;
+  if (!bigtest) {
+    bigtest = context.__bigtest = {};
+  }
+  return bigtest.coverageMap;
+}
+
+/**
+ * Set the coverage map associated with the scope designated by
+ *`Window`. By allowing scope to be an argument, we can access the coverage
+ * map from both the test _and_ the agent frame.
+ */
+export function setCoverageMap(window: Window, map?: CoverageMap): void {
+  let context: typeof globalThis = window.window;
+  let bigtest: CoverageConfigurable = context.__bigtest as CoverageConfigurable;
+  if (!bigtest) {
+    bigtest = context.__bigtest = {};
+  }
+  bigtest.coverageMap = map;
+}
+
+/**
+ * Call only from Test Frame. Grabs any coverage data off of the app frame
+ * and merge it into the coverage map store on the agent frame.
+ */
+export function addCoverageMap(appFrame?: HTMLIFrameElement): void {
+  let newCoverage = appFrame?.contentWindow?.window.__coverage__;
+  if (newCoverage) {
+    let coverage = getCoverageMap(window.parent) || createCoverageMap();
+    coverage.merge(newCoverage as CoverageMapData);
+    setCoverageMap(window.parent, coverage);
+  }
+}

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -13,6 +13,7 @@ import { serializeError } from './serialize-error';
 import { wrapConsole } from './wrap-console';
 import { setLogConfig, getLogConfig } from './log-config';
 import { clearPersistentStorage } from './clear-persistent-storage';
+import { addCoverageMap } from './coverage';
 
 interface TestEvents {
   send(event: TestEvent): void;
@@ -44,6 +45,7 @@ export function* runLane(config: LaneConfig) {
     let test: TestImplementation = yield loadManifest(manifestUrl);
     yield runLaneSegment(test, path.slice(1), [], stepTimeout)
   } finally {
+    addCoverageMap(bigtestGlobals.testFrame);
     events.close();
   }
 

--- a/packages/agent/app/runner.ts
+++ b/packages/agent/app/runner.ts
@@ -8,12 +8,14 @@ import { Agent } from '../shared/agent';
 import { Run, TestEvent } from '../shared/protocol';
 
 import { setLaneConfigFromAgentFrame } from './lane-config';
+import { setCoverageMap, getCoverageMap } from './coverage';
 import { findIFrame } from './find-iframe';
 
 export function* run(agent: Agent, command: Run): Operation<void> {
   let { testRunId, tree } = command;
 
   try {
+    setCoverageMap(window, undefined);
     agent.send({ type: 'run:begin', testRunId });
     for (let lanePath of lanePaths(tree)) {
       console.log('[agent] running lane', lanePath);
@@ -24,7 +26,7 @@ export function* run(agent: Agent, command: Run): Operation<void> {
     }
   } finally {
     console.log('[agent] test run completed', testRunId);
-    agent.send({ type: 'run:end', testRunId });
+    agent.send({ type: 'run:end', testRunId, coverage: getCoverageMap(window)?.toJSON() });
   }
 }
 

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -31,6 +31,7 @@
     "@frontside/eslint-config": "^1.1.2",
     "@frontside/typescript": "^1.0.1",
     "@types/express": "^4.17.2",
+    "@types/istanbul-lib-coverage": "^2.0.3",
     "@types/localforage": "^0.0.34",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
@@ -39,6 +40,7 @@
     "classnames": "^2.2.5",
     "expect": "^24.9.0",
     "express": "^4.17.1",
+    "istanbul-lib-coverage": "^3.0.0",
     "localforage": "^1.9.0",
     "mocha": "^6.2.2",
     "node-fetch": "^2.6.0",
@@ -56,7 +58,8 @@
     "bowser": "^2.9.0",
     "effection": "^0.7.0",
     "error-stack-parser": "^2.0.6",
-    "get-source": "^2.0.11"
+    "get-source": "^2.0.11",
+    "istanbul-lib-coverage": "^3.0.0"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/agent/shared/protocol.ts
+++ b/packages/agent/shared/protocol.ts
@@ -22,6 +22,8 @@ export interface RunEnd {
   type: 'run:end';
   agentId?: string;
   testRunId: string;
+  coverage?: Record<string, unknown>;
+
 }
 
 export interface LaneBegin {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -10,10 +10,11 @@ import expect from 'expect';
 import fetch from 'node-fetch';
 import fixtureManifest from './fixtures/manifest';
 
-import { AgentServerConfig, TestEvent, createAgentHandler, AgentConnection, AssertionResult } from '../src/index';
+import { AgentServerConfig, TestEvent, createAgentHandler, AgentConnection, AssertionResult, RunEnd } from '../src/index';
 
 import { run } from './helpers';
 import { StepResult } from '@bigtest/suite';
+import { resource } from 'effection';
 
 function* staticServer(port: number) {
   let app = express();
@@ -223,6 +224,26 @@ describe("@bigtest/agent", function() {
             });
           });
         });
+
+        describe('coverage', () => {
+          let end: RunEnd;
+          beforeEach(async () => {
+            end = await run(events.match({
+              type: 'run:end'
+            }).expect()) as RunEnd;
+          });
+
+          it('is reported with the run:end event', () => {
+            expect(end).toMatchObject({
+              type: 'run:end',
+              coverage: {
+                'one.js': { data: {} },
+                'two.js': { data: {} }
+              }
+            })
+          });
+        });
+
       });
 
       describe('closing browser connection', () => {

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -235,10 +235,7 @@ describe("@bigtest/agent", function() {
           it('is reported with the run:end event', () => {
             expect(end).toMatchObject({
               type: 'run:end',
-              coverage: {
-                'one.js': { data: {} },
-                'two.js': { data: {} }
-              }
+              coverage: require('./fixtures/coverage-data').coverageData
             })
           });
         });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -14,7 +14,6 @@ import { AgentServerConfig, TestEvent, createAgentHandler, AgentConnection, Asse
 
 import { run } from './helpers';
 import { StepResult } from '@bigtest/suite';
-import { resource } from 'effection';
 
 function* staticServer(port: number) {
   let app = express();

--- a/packages/agent/test/fixtures/coverage-data.js
+++ b/packages/agent/test/fixtures/coverage-data.js
@@ -1,0 +1,502 @@
+module.exports = {
+  coverageData: {
+    "src/Signin.js": {
+      "path": "src/Signin.js",
+      "statementMap": {
+        "0": {
+          "start": {
+            "line": 4,
+            "column": 12
+          },
+          "end": {
+            "line": 35,
+            "column": 1
+          }
+        },
+        "1": {
+          "start": {
+            "line": 5,
+            "column": 40
+          },
+          "end": {
+            "line": 5,
+            "column": 55
+          }
+        },
+        "2": {
+          "start": {
+            "line": 6,
+            "column": 48
+          },
+          "end": {
+            "line": 6,
+            "column": 63
+          }
+        },
+        "3": {
+          "start": {
+            "line": 7,
+            "column": 40
+          },
+          "end": {
+            "line": 7,
+            "column": 52
+          }
+        },
+        "4": {
+          "start": {
+            "line": 9,
+            "column": 19
+          },
+          "end": {
+            "line": 13,
+            "column": 3
+          }
+        },
+        "5": {
+          "start": {
+            "line": 10,
+            "column": 4
+          },
+          "end": {
+            "line": 10,
+            "column": 29
+          }
+        },
+        "6": {
+          "start": {
+            "line": 11,
+            "column": 4
+          },
+          "end": {
+            "line": 11,
+            "column": 26
+          }
+        },
+        "7": {
+          "start": {
+            "line": 12,
+            "column": 4
+          },
+          "end": {
+            "line": 12,
+            "column": 43
+          }
+        },
+        "8": {
+          "start": {
+            "line": 15,
+            "column": 2
+          },
+          "end": {
+            "line": 34,
+            "column": 4
+          }
+        },
+        "9": {
+          "start": {
+            "line": 37,
+            "column": 14
+          },
+          "end": {
+            "line": 76,
+            "column": 1
+          }
+        },
+        "10": {
+          "start": {
+            "line": 40,
+            "column": 34
+          },
+          "end": {
+            "line": 40,
+            "column": 46
+          }
+        },
+        "11": {
+          "start": {
+            "line": 41,
+            "column": 34
+          },
+          "end": {
+            "line": 41,
+            "column": 46
+          }
+        },
+        "12": {
+          "start": {
+            "line": 43,
+            "column": 2
+          },
+          "end": {
+            "line": 75,
+            "column": 3
+          }
+        },
+        "13": {
+          "start": {
+            "line": 46,
+            "column": 8
+          },
+          "end": {
+            "line": 46,
+            "column": 27
+          }
+        },
+        "14": {
+          "start": {
+            "line": 47,
+            "column": 8
+          },
+          "end": {
+            "line": 47,
+            "column": 36
+          }
+        },
+        "15": {
+          "start": {
+            "line": 56,
+            "column": 23
+          },
+          "end": {
+            "line": 56,
+            "column": 50
+          }
+        },
+        "16": {
+          "start": {
+            "line": 64,
+            "column": 23
+          },
+          "end": {
+            "line": 64,
+            "column": 50
+          }
+        }
+      },
+      "fnMap": {
+        "0": {
+          "name": "(anonymous_0)",
+          "decl": {
+            "start": {
+              "line": 4,
+              "column": 12
+            },
+            "end": {
+              "line": 4,
+              "column": 13
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 18
+            },
+            "end": {
+              "line": 35,
+              "column": 1
+            }
+          },
+          "line": 4
+        },
+        "1": {
+          "name": "(anonymous_1)",
+          "decl": {
+            "start": {
+              "line": 9,
+              "column": 19
+            },
+            "end": {
+              "line": 9,
+              "column": 20
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 9,
+              "column": 43
+            },
+            "end": {
+              "line": 13,
+              "column": 3
+            }
+          },
+          "line": 9
+        },
+        "2": {
+          "name": "(anonymous_2)",
+          "decl": {
+            "start": {
+              "line": 37,
+              "column": 14
+            },
+            "end": {
+              "line": 37,
+              "column": 15
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 39,
+              "column": 6
+            },
+            "end": {
+              "line": 76,
+              "column": 1
+            }
+          },
+          "line": 39
+        },
+        "3": {
+          "name": "(anonymous_3)",
+          "decl": {
+            "start": {
+              "line": 45,
+              "column": 16
+            },
+            "end": {
+              "line": 45,
+              "column": 17
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 45,
+              "column": 21
+            },
+            "end": {
+              "line": 48,
+              "column": 7
+            }
+          },
+          "line": 45
+        },
+        "4": {
+          "name": "(anonymous_4)",
+          "decl": {
+            "start": {
+              "line": 56,
+              "column": 18
+            },
+            "end": {
+              "line": 56,
+              "column": 19
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 56,
+              "column": 23
+            },
+            "end": {
+              "line": 56,
+              "column": 50
+            }
+          },
+          "line": 56
+        },
+        "5": {
+          "name": "(anonymous_5)",
+          "decl": {
+            "start": {
+              "line": 64,
+              "column": 18
+            },
+            "end": {
+              "line": 64,
+              "column": 19
+            }
+          },
+          "loc": {
+            "start": {
+              "line": 64,
+              "column": 23
+            },
+            "end": {
+              "line": 64,
+              "column": 50
+            }
+          },
+          "line": 64
+        }
+      },
+      "branchMap": {
+        "0": {
+          "loc": {
+            "start": {
+              "line": 17,
+              "column": 7
+            },
+            "end": {
+              "line": 20,
+              "column": 12
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 17,
+                "column": 7
+              },
+              "end": {
+                "line": 17,
+                "column": 22
+              }
+            },
+            {
+              "start": {
+                "line": 18,
+                "column": 8
+              },
+              "end": {
+                "line": 20,
+                "column": 12
+              }
+            }
+          ],
+          "line": 17
+        },
+        "1": {
+          "loc": {
+            "start": {
+              "line": 25,
+              "column": 26
+            },
+            "end": {
+              "line": 25,
+              "column": 61
+            }
+          },
+          "type": "cond-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 25,
+                "column": 45
+              },
+              "end": {
+                "line": 25,
+                "column": 52
+              }
+            },
+            {
+              "start": {
+                "line": 25,
+                "column": 55
+              },
+              "end": {
+                "line": 25,
+                "column": 61
+              }
+            }
+          ],
+          "line": 25
+        },
+        "2": {
+          "loc": {
+            "start": {
+              "line": 30,
+              "column": 7
+            },
+            "end": {
+              "line": 32,
+              "column": 8
+            }
+          },
+          "type": "binary-expr",
+          "locations": [
+            {
+              "start": {
+                "line": 30,
+                "column": 7
+              },
+              "end": {
+                "line": 30,
+                "column": 18
+              }
+            },
+            {
+              "start": {
+                "line": 30,
+                "column": 22
+              },
+              "end": {
+                "line": 32,
+                "column": 8
+              }
+            }
+          ],
+          "line": 30
+        }
+      },
+      "s": {
+        "0": 1,
+        "1": 1,
+        "2": 1,
+        "3": 1,
+        "4": 1,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 1,
+        "9": 1,
+        "10": 0,
+        "11": 0,
+        "12": 0,
+        "13": 0,
+        "14": 0,
+        "15": 0,
+        "16": 0
+      },
+      "f": {
+        "0": 1,
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0
+      },
+      "b": {
+        "0": [
+          1,
+          0
+        ],
+        "1": [
+          1,
+          0
+        ],
+        "2": [
+          1,
+          0
+        ]
+      },
+      "_coverageSchema": "43e27e138ebf9cfc5966b082cf9a028302ed4184",
+      "hash": "3548561dd067761ad319a925fc80b2dcb9eec399"
+    },
+    "src/index.js": {
+      "path": "src/index.js",
+      "statementMap": {
+        "0": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 58
+          }
+        }
+      },
+      "fnMap": {},
+      "branchMap": {},
+      "s": {
+        "0": 1
+      },
+      "f": {},
+      "b": {},
+      "_coverageSchema": "43e27e138ebf9cfc5966b082cf9a028302ed4184",
+      "hash": "6d1d2ef67e3789df0449b0b0eb1531530ccfbe2c"
+    }
+  }
+}

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -1,8 +1,10 @@
 const { test } = require('@bigtest/suite');
+const { bigtestGlobals } = require('@bigtest/globals');
 const { strict: assert } = require('assert');
 const { createInteractor, App } = require('@bigtest/interactor');
 
 const localforage = require('localforage');
+const libCoverage = require('istanbul-lib-coverage');
 
 globalThis.fetch = async function(url) {
   assert.equal(url, '/greeting');
@@ -50,6 +52,17 @@ function indexedDBTest(test) {
     )
 }
 
+function coverageTest(filename) {
+  return test => test
+    .step(`add coverage data from ${filename}`, async () => {
+      let map = libCoverage.createCoverageMap();
+      map.addFileCoverage(filename);
+      bigtestGlobals.testFrame.contentWindow.window.__coverage__ = map.toJSON();
+    })
+}
+
+
+
 module.exports = test("tests")
   .step(App.visit('/app.html'))
   .child(
@@ -96,3 +109,5 @@ module.exports = test("tests")
   .child("local storage and session storage 2", storageTest)
   .child("indexedDB 1", indexedDBTest)
   .child("indexedDB 2", indexedDBTest)
+  .child("add coverage 1", coverageTest('one.js'))
+  .child("add coverage 2", coverageTest('two.js'))

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -4,7 +4,8 @@ const { strict: assert } = require('assert');
 const { createInteractor, App } = require('@bigtest/interactor');
 
 const localforage = require('localforage');
-const libCoverage = require('istanbul-lib-coverage');
+
+const { coverageData } = require('./coverage-data');
 
 globalThis.fetch = async function(url) {
   assert.equal(url, '/greeting');
@@ -52,12 +53,13 @@ function indexedDBTest(test) {
     )
 }
 
-function coverageTest(filename) {
+function coverageTest(filepath) {
   return test => test
-    .step(`add coverage data from ${filename}`, async () => {
-      let map = libCoverage.createCoverageMap();
-      map.addFileCoverage(filename);
-      bigtestGlobals.testFrame.contentWindow.window.__coverage__ = map.toJSON();
+    .step(`add coverage data from ${filepath}`, async () => {
+      if (!coverageData[filepath]) {
+        throw new Error(`bad test! no fixture coverage data for filepath ${filepath}`);
+      }
+      bigtestGlobals.testFrame.contentWindow.window.__coverage__ = { [filepath]: coverageData[filepath]};
     })
 }
 
@@ -109,5 +111,5 @@ module.exports = test("tests")
   .child("local storage and session storage 2", storageTest)
   .child("indexedDB 1", indexedDBTest)
   .child("indexedDB 2", indexedDBTest)
-  .child("add coverage 1", coverageTest('one.js'))
-  .child("add coverage 2", coverageTest('two.js'))
+  .child("add coverage 1", coverageTest("src/Signin.js"))
+  .child("add coverage 2", coverageTest("src/index.js"))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -2819,7 +2824,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
@@ -8555,6 +8560,11 @@ istanbul-lib-coverage@^2.0.2, istanbul-lib-coverage@^2.0.5:
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
   integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
 
+istanbul-lib-coverage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz#f5944a37c70b550b02a78a5c3b2055b280cec8ec"
+  integrity sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+
 istanbul-lib-instrument@^3.0.1, istanbul-lib-instrument@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
@@ -9506,7 +9516,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Motivation
----------
> part of #446 

One of the key use-cases is to be able to collect coverage data to determine exactly how well your tests are doing, and what you might need to do to improve the reliability of it. Because BigTest makes no assumptions about how an app is the build, this part needs to be handled by the actual app. That said, once there _is_ instrumentation, BigTest can harvest the metrics for you and help you inject them into your build pipeline at the appropriate point.

Approach
----------

This PR is a first step in that process. It only handles harvesting of coverage metrics from the agent and making sure that they are sent back to to the orchestrator. It does not deal with integrating that coverage into the test run state, or writing it out to a file from the cli.

To do this, the `__coverage__` object is checked after each lane run, and if present, is merged into any prior coverage maps from previous lanes. Once the test run is completed, the coverage data is added to the `run:end`