### PR TITLE
Allow steps actions/assertion checks to be sync

### DIFF
--- a/.changeset/lemon-boats-trade.md
+++ b/.changeset/lemon-boats-trade.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/suite": minor
+"@bigtest/agent": minor
+---
+
+Allow step actions and assertion checks to return values synchronously

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -67,7 +67,7 @@ export function* runLane(config: LaneConfig) {
         originalConsole.debug('[agent] running step', step);
         events.send({ testRunId, type: 'step:running', path: stepPath });
 
-        let result: TestContext | void = yield timebox(step.action(context), stepTimeout)
+        let result: TestContext | void = yield timebox(Promise.resolve(step.action(context)), stepTimeout)
 
         if (result != null) {
           context = {...context, ...result};
@@ -112,7 +112,7 @@ export function* runLane(config: LaneConfig) {
             originalConsole.debug('[agent] running assertion', assertion);
             events.send({ testRunId, type: 'assertion:running', path: assertionPath });
 
-            yield timebox(assertion.check(context), stepTimeout)
+            yield timebox(Promise.resolve(assertion.check(context)), stepTimeout)
 
             events.send({
               testRunId,

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -141,6 +141,15 @@ describe("@bigtest/agent", function() {
           expect(checkContext).toMatchObject({ status: 'ok' });
         });
 
+        it('preserves test context all the way down the entire test run without async', async () => {
+          let checkContext = await run(events.match({
+            type: 'assertion:result',
+            path: ['tests', 'tests that track context without async', 'contains entire context from all steps']
+          }).first());
+
+          expect(checkContext).toMatchObject({ status: 'ok' });
+        });
+
         describe('steps that timeout', () => {
           let longStep: StepResult;
           beforeEach(async () => {

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -79,6 +79,14 @@ module.exports = test("tests")
         assert.deepEqual(context, { username: "tyrion", hello: "tyrion" });
       }))
   .child(
+    "tests that track context without async", test => test
+      .step("creates initial context", () => ({ username: "tyrion" }))
+      .step("contributes nothing to context", () => {})
+      .step("extends existing context", ({ username }) => ({ hello: username }))
+      .assertion("contains entire context from all steps", context => {
+        assert.deepEqual(context, { username: "tyrion", hello: "tyrion" });
+      }))
+  .child(
     "test step timeouts", test => test
       .step("this takes literally forever", async () => await new Promise(() => {})))
   .child(

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -9,8 +9,8 @@ export function test<C extends Context>(description: string): TestBuilder<C> {
   });
 }
 
-export type Action<C extends Context, R extends Context | void> = (context: C) => Promise<R>;
-export type Check<C extends Context> = (context: C) => Promise<void>;
+export type Action<C extends Context, R extends Context | void> = (context: C) => Promise<R> | R;
+export type Check<C extends Context> = (context: C) => Promise<void> | void;
 
 export interface StepDefinition<C extends Context, R extends Context | void> {
   description: string;

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -37,6 +37,7 @@ test('a test')
     Math.abs(foo);
   })
 
+// Context Async
 test('a test')
   // should not be able to return non-object
   // $ExpectError
@@ -50,3 +51,18 @@ test('a test')
   // $ExpectError
   .step('consume from context', async({ helloX: string }) => { goodbye: helloX })
   .step({ description: "consume from context", action: async () => {} })
+
+// Context Sync
+test('a test')
+  // should not be able to return non-object
+  // $ExpectError
+  .step('return nonsense', () => {
+    return "foo";
+  })
+
+test('a test')
+  .step({ description: "a description", action: () => {} })
+  .step('add to context', () => ({ hello: "world" }))
+  // $ExpectError
+  .step('consume from context', ({ helloX: string }) => { goodbye: helloX })
+  .step({ description: "consume from context", action: () => {} })


### PR DESCRIPTION
Currently they must return a promise, this makes it possible for them to return sync values instead.

Closes #423