### PR TITLE
Don't watch test files when running CI command

### DIFF
--- a/.changeset/big-seals-unite.md
+++ b/.changeset/big-seals-unite.md
@@ -1,0 +1,8 @@
+---
+"@bigtest/bundler": minor
+"@bigtest/cli": minor
+"@bigtest/project": minor
+"@bigtest/server": minor
+---
+
+Don't watch test files when running CI command

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -1,8 +1,8 @@
-import { Operation, resource } from 'effection';
+import { Operation, resource, timeout } from 'effection';
 import { on } from '@effection/events';
 import { Subscribable, SymbolSubscribable } from '@effection/subscription';
 import { Channel } from '@effection/channel';
-import { watch, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
+import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import injectProcessEnv from 'rollup-plugin-inject-process-env';
@@ -15,31 +15,18 @@ interface BundleOptions {
   entry: string;
   outFile: string;
   globalName?: string;
+  watch?: boolean;
 };
 
-interface BundlerOptions {
-  mainFields: Array<"browser" | "main" | "module">;
-};
-
-function prepareRollupOptions(bundle: BundleOptions, channel: Channel<BundlerMessage>, { mainFields }: BundlerOptions = { mainFields: ["browser", "module", "main"] }): RollupWatchOptions {
+function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMessage>): InputOptions {
   return {
     input: bundle.entry,
-    output: {
-      file: bundle.outFile,
-      name: bundle.globalName || undefined,
-      sourcemap: true,
-      format: 'umd',
-    },
     onwarn(warning){
       channel.send({ type: 'WARN', warning })
     },
-    watch: {
-      // Rollup types are wrong; `watch.exclude` allows RegExp[]
-      exclude: [/node_modules/ as unknown as string]
-    },
     plugins: [
       resolve({
-        mainFields,
+        mainFields: ["browser", "module", "main"],
         extensions: ['.js', '.ts']
       }),
       commonjs(),
@@ -56,43 +43,85 @@ function prepareRollupOptions(bundle: BundleOptions, channel: Channel<BundlerMes
   }
 }
 
+function prepareOutputOptions(bundle: BundleOptions): OutputOptions {
+  return {
+    file: bundle.outFile,
+    name: bundle.globalName || undefined,
+    sourcemap: true,
+    format: 'umd',
+  }
+}
+
+function prepareWatchOptions(bundle: BundleOptions, channel: Channel<BundlerMessage>): RollupWatchOptions {
+  return {
+    ...prepareInputOptions(bundle, channel),
+    output: prepareOutputOptions(bundle),
+    watch: {
+      // Rollup types are wrong; `watch.exclude` allows RegExp[]
+      exclude: [/node_modules/ as unknown as string]
+    },
+  }
+}
+
 export class Bundler implements Subscribable<BundlerMessage, undefined> {
   private channel = new Channel<BundlerMessage>();
 
-  static *create(bundle: BundleOptions): Operation<Bundler> {
-    let bundler = new Bundler();
+  static *create(options: BundleOptions): Operation<Bundler> {
+    let bundler = new Bundler(options);
 
-    return yield resource(bundler, function* () {
-      let rollup: RollupWatcher = watch(prepareRollupOptions(bundle, bundler.channel));
-
-      try {
-        let messages = on(rollup, 'event')
-          .map(([event]) => event as RollupWatcherEvent)
-          .filter(event => ['START', 'END', 'ERROR'].includes(event.code))
-          .map(event => {
-            switch (event.code) {
-              case 'START':
-                return { type: 'START' } as const;
-              case 'END':
-                return { type: 'UPDATE' } as const;
-              case 'ERROR':
-                return { type: 'ERROR', error: event.error } as const;
-              default:
-                throw new Error(`unexpect event ${event.code}`);
-            }
-          });
-
-        yield messages.forEach(function* (message) {
-          bundler.channel.send(message);
-        });
-      } finally {
-        console.debug('[bundler] shutting down');
-        rollup.close();
-      }
-    });
+    if(options.watch) {
+      return yield resource(bundler, bundler.watch());
+    } else {
+      return yield resource(bundler, bundler.build());
+    }
   }
+
+  constructor(public options: BundleOptions) {};
 
   [SymbolSubscribable]() {
     return this.channel[SymbolSubscribable]();
+  }
+
+  private *watch() {
+    let { channel } = this;
+    let rollup: RollupWatcher = watch(prepareWatchOptions(this.options, channel));
+
+    try {
+      let messages = on(rollup, 'event')
+        .map(([event]) => event as RollupWatcherEvent)
+        .filter(event => ['START', 'END', 'ERROR'].includes(event.code))
+        .map(event => {
+          switch (event.code) {
+            case 'START':
+              return { type: 'START' } as const;
+            case 'END':
+              return { type: 'UPDATE' } as const;
+            case 'ERROR':
+              return { type: 'ERROR', error: event.error } as const;
+            default:
+              throw new Error(`unexpect event ${event.code}`);
+          }
+        });
+
+      yield messages.forEach(function* (message) {
+        channel.send(message);
+      });
+    } finally {
+      console.debug('[bundler] shutting down');
+      rollup.close();
+    }
+  }
+
+  private *build() {
+    yield timeout(0); // send start event asynchronously, so we have a chance to subscribe
+    this.channel.send({ type: 'START' });
+    try {
+      let result = yield rollup(prepareInputOptions(this.options, this.channel));
+      yield result.write(prepareOutputOptions(this.options));
+
+      this.channel.send({ type: 'UPDATE' });
+    } catch(error) {
+      this.channel.send({ type: 'ERROR', error });
+    }
   }
 }

--- a/packages/bundler/test/bundler.test.ts
+++ b/packages/bundler/test/bundler.test.ts
@@ -1,3 +1,4 @@
+import { timeout } from 'effection';
 import { describe } from 'mocha';
 import { promises as fs, existsSync } from 'fs';
 import expect from 'expect';
@@ -23,11 +24,12 @@ describe("Bundler", function() {
         await fs.writeFile("./build/test/sources/input.js", "const foo = 'bar';\nexport default foo;\n");
 
         bundler = await spawn(Bundler.create({
+          watch: true,
           entry: "./build/test/sources/input.js",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
         }));
-        
+
         await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
       });
 
@@ -52,6 +54,7 @@ describe("Bundler", function() {
         await fs.writeFile("./build/test/sources/input.js", "const foo - 'bar';\nexport default foo;\n");
 
         bundler = await spawn(Bundler.create({
+          watch: true,
           entry: "./build/test/sources/input.js",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
@@ -66,7 +69,8 @@ describe("Bundler", function() {
 
       describe('fixing the error', () => {
         beforeEach(async () => {
-          await spawn(subscribe(bundler).first());
+          await spawn(subscribe(bundler).match({ type: 'ERROR' }).first());
+          await spawn(timeout(10));
           await fs.writeFile("./build/test/sources/input.js", "const foo = 'bar';\nexport default foo;\n");
         });
 
@@ -85,11 +89,12 @@ describe("Bundler", function() {
         await fs.writeFile("./build/test/sources/input.ts", "const foo: string = 'bar';\nexport default foo;\n");
 
         bundler = await spawn(Bundler.create({
+          watch: true,
           entry: "./build/test/sources/input.ts",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
         }));
-        
+
         await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
       });
 
@@ -103,6 +108,7 @@ describe("Bundler", function() {
         await fs.writeFile("./build/test/sources/input.ts", "const foo: number = 'bar';\nexport default foo;\n");
 
         bundler = await spawn(Bundler.create({
+          watch: true,
           entry: "./build/test/sources/input.ts",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
@@ -122,11 +128,12 @@ describe("Bundler", function() {
       await fs.writeFile("./build/test/sources/input.ts", "const foo: string = 'bar';\nexport default foo;\n");
 
       bundler = await spawn(Bundler.create({
+        watch: true,
         entry: "./build/test/sources/input.ts",
         outFile: "./build/test/output/manifest.js",
         globalName: "__bigtestManifest"
       }));
-      
+
       await fs.writeFile("./build/test/sources/input.ts", "export default {hello: 'world'}\n");
     });
 
@@ -134,6 +141,45 @@ describe("Bundler", function() {
       let message = spawn(subscribe(bundler).match({ type: 'UPDATE' }).first())
 
       await expect(message).resolves.toHaveProperty('type', 'UPDATE');
+    });
+  });
+
+  describe("with watch: false", () => {
+    describe('success', () => {
+      beforeEach(async () => {
+        await fs.writeFile("./build/test/sources/input.js", "const foo = 'bar';\nexport default foo;\n");
+
+        bundler = await spawn(Bundler.create({
+          watch: false,
+          entry: "./build/test/sources/input.js",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
+
+        await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
+      });
+
+      it('builds the sources into the output directory', () => {
+        expect(existsSync("./build/test/output/manifest.js")).toEqual(true);
+      });
+    });
+
+    describe('error', () => {
+      beforeEach(async () => {
+        await fs.writeFile("./build/test/sources/input.js", "const foo - 'bar';\nexport default foo;\n");
+
+        bundler = await spawn(Bundler.create({
+          watch: false,
+          entry: "./build/test/sources/input.js",
+          outFile: "./build/test/output/manifest.js",
+          globalName: "__bigtestManifest",
+        }));
+      });
+
+      it('emits an error event', async () => {
+        let message = spawn(subscribe(bundler).match({ type: 'ERROR' }).first())
+        await expect(message).resolves.toHaveProperty('type', 'ERROR');
+      });
     });
   });
 })

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,7 @@ export function * CLI(argv: string[]): Operation {
     });
   } else if (args.command === 'ci') {
     let config: ProjectOptions = yield loadConfig(args);
+    config.watchTestFiles = false;
     yield startServer(config, {
       timeout: args.startTimeout,
     });

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -28,6 +28,7 @@ export type ProjectOptions = {
   port: number;
   testFiles: string[];
   cacheDir: string;
+  watchTestFiles: boolean;
   app: {
     url?: string;
     command?: string;
@@ -63,6 +64,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
     },
     testFiles: ["./test/**/*.test.{ts,js}"],
     cacheDir: path.resolve(path.dirname(configFilePath), '.bigtest'),
+    watchTestFiles: true,
     drivers: {
       chrome: {
         module: "@bigtest/webdriver",

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -23,6 +23,7 @@ main(createServer({
   },
   testFiles: ["./test/fixtures/*.t.js"],
   cacheDir: "./tmp/start",
+  watchTestFiles: true,
   drivers: {
       chrome: {
         module: "@bigtest/webdriver",

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -15,6 +15,7 @@ import { assertBundlerState, assertCanTransition } from '../src/assertions/bundl
 const { copyFile, mkdir, stat, appendFile, open } = fs.promises;
 
 interface ManifestBuilderOptions {
+  watch: boolean;
   atom: Atom<OrchestratorState>;
   srcPath: string;
   buildDir: string;
@@ -91,6 +92,7 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
   bundlerSlice.set({ type: 'UNBUNDLED' });
 
   let bundler: Bundler = yield Bundler.create({
+    watch: options.watch,
     entry: options.srcPath,
     globalName: bigtestGlobals.manifestProperty,
     outFile: path.join(options.buildDir, "manifest.js")
@@ -122,7 +124,7 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
         bundlerSlice.update(() => ({ type: 'ERRORED', error: message.error }));
         break;
       case 'WARN':
-        console.debug("received bundle warning");
+        console.debug("received bundle warning", message.warning);
 
         bundlerSlice.update((previous) => {
           assertBundlerState(previous.type, {is: ['BUILDING', 'GREEN']});

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -94,6 +94,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
   console.debug('[orchestrator] manifest generator ready');
 
   yield fork(createManifestBuilder({
+    watch: options.project.watchTestFiles,
     atom: options.atom,
     srcPath: manifestSrcPath,
     distDir: manifestDistDir,

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -67,6 +67,7 @@ export const actions = {
           port: 24102,
           testFiles: ["test/fixtures/*.t.js"],
           cacheDir: "./tmp/test/orchestrator",
+          watchTestFiles: true,
           manifest: {
             port: 24105,
           },

--- a/packages/server/test/manifest-builder.test.ts
+++ b/packages/server/test/manifest-builder.test.ts
@@ -36,6 +36,7 @@ describe('manifest builder', () => {
     actions.fork(function*() {
       yield createManifestBuilder({
         atom,
+        watch: true,
         srcPath: MANIFEST_PATH,
         buildDir: BUILD_DIR,
         distDir: DIST_DIR,
@@ -65,7 +66,7 @@ describe('manifest builder', () => {
 
     beforeEach(async () => {
       await copyFile(path.join(FIXTURES_DIR, 'empty.t.js'), MANIFEST_PATH);
-      
+
       let bundle = await actions.fork(atom.slice('bundler').once(({ type }) => type === 'GREEN'));
 
       resultPath = (!!bundle && bundle.type === 'GREEN' && bundle.path) as string;
@@ -108,7 +109,7 @@ describe('manifest builder', () => {
       expect(distMapURL).toMatch(/manifest-[0-9a-f]+\.js.map/);
     });
   });
-  
+
   describe('when manifest is generated in a different format', () => {
     let error: Error;
     let emptyFilePath: string;
@@ -152,10 +153,10 @@ describe('manifest builder', () => {
     it('should update the global state with the error detail', () => {
       let bundlerState = atom.get().bundler;
 
-      // this could be a custom expect 
+      // this could be a custom expect
       // assert is used to type narrow also and does more than just assert
       assertBundlerState(bundlerState.type, {is: 'ERRORED'})
-      
+
       let error = bundlerState.error;
 
       expect(error.frame).toBeTruthy();


### PR DESCRIPTION
This adds an option to the bundler whether to watch the test files or not. It then threads this option through the project options. Finally we always set this option to `false` when running the CI command.

Closes #445