### PR TITLE
Default to launching headless chrome

### DIFF
--- a/.changeset/real-toys-attend.md
+++ b/.changeset/real-toys-attend.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/project": minor
+---
+
+Default to launching headless chrome

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -100,6 +100,6 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
         }
       },
     },
-    launch: []
+    launch: ['chrome.headless']
   }
 };


### PR DESCRIPTION
Our default settings currently do not specify a default for which browser to launch. While it would make sense to add an interface in the `bigtest init` command to prompt the user which browser they would like to launch (if any), actually building such an interface is a bit cumbersome, so let's punt on that.

It feels like a better default to be opinionated about a default browser to launch, rather than defaulting to not launching anything.