### PR TITLE
Reexport from `bigtest` package.

### DIFF
--- a/.changeset/sixty-geese-mix.md
+++ b/.changeset/sixty-geese-mix.md
@@ -1,0 +1,5 @@
+---
+"bigtest": minor
+---
+
+Reexport @bigtest/interactor and @bigtest/suite from bigtest package

--- a/packages/bigtest/package.json
+++ b/packages/bigtest/package.json
@@ -1,15 +1,37 @@
 {
   "name": "bigtest",
   "version": "0.1.5",
+  "description": "Tests that speed up development, not slow it down",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
+  "files": [
+    "dist/**/*",
+    "src/**/*",
+    "README.md"
+  ],
   "scripts": {
+    "lint": "eslint \"src/**/*.ts\"",
     "test": "echo no-op",
-    "lint": "echo no-op",
-    "prepack": "echo no-op"
+    "prepack": "tsc --outDir dist --declaration --sourcemap"
+  },
+  "devDependencies": {
+    "@frontside/eslint-config": "^1.1.2",
+    "@frontside/typescript": "^1.0.1",
+    "@types/node": "^13.13.4",
+    "ts-node": "*",
+    "typescript": "3.9.7"
   },
   "dependencies": {
-    "@bigtest/cli": "0.12.0"
+    "@bigtest/cli": "0.12.0",
+    "@bigtest/interactor": "0.17.0",
+    "@bigtest/suite": "0.9.0"
+  },
+  "volta": {
+    "node": "12.16.0",
+    "yarn": "1.19.1"
   }
 }

--- a/packages/bigtest/src/index.ts
+++ b/packages/bigtest/src/index.ts
@@ -1,0 +1,2 @@
+export * from '@bigtest/interactor';
+export * from '@bigtest/suite';

--- a/packages/bigtest/tsconfig.json
+++ b/packages/bigtest/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@frontside/tsconfig",
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts"
+  ]
+}


### PR DESCRIPTION
This adds exports to the `bigtest` package, exporting the contents of the @bigtest/interactor and @bigtest/suite packages. This way, there is only one package to install and a simple `yarn add -D bigtest` is needed to get going.