### PR TITLE
Report coverage from the CLI

### DIFF
--- a/.changeset/coverage-reporting.md
+++ b/.changeset/coverage-reporting.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/server": minor
+"@bigtest/cli": minor
+"@bigtest/project": minor
+---
+produce coverage reports by passing the `--coverage` option to the
+`test` and `ci` commands

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,4 @@
+/tmp
 /node_modules
 /yarn-error.log
 .node-version

--- a/packages/cli/bigtest.json
+++ b/packages/cli/bigtest.json
@@ -4,5 +4,9 @@
     "url": "http://localhost:36000"
   },
   "testFiles": ["./test/fixtures/*.test.{ts,js}"],
-  "launch": ["chrome.headless"]
+  "launch": ["chrome.headless"],
+  "coverage": {
+    "directory": "./tmp/coverage",
+    "reports": ["lcov", "html"]
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,9 @@
     "@frontside/eslint-config": "^1.1.2",
     "@frontside/typescript": "^1.0.1",
     "@types/capture-console": "1.0.0",
+    "@types/istanbul-lib-coverage": "^2.0.3",
+    "@types/istanbul-lib-report": "^3.0.0",
+    "@types/istanbul-reports": "^3.0.0",
     "@types/json5": "^0.0.30",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
@@ -51,6 +54,9 @@
     "chalk": "^4.1.0",
     "deepmerge": "^4.2.2",
     "effection": "^0.7.0",
+    "istanbul-lib-coverage": "^3.0.0",
+    "istanbul-lib-report": "^3.0.0",
+    "istanbul-reports": "^3.0.2",
     "json5": "^2.1.3"
   },
   "volta": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -26,6 +26,7 @@ export function * CLI(argv: string[]): Operation {
       formatterName: args.formatter,
       showFullStack: false,
       showLog: false,
+      coverage: args.coverage
     });
   } else if (args.command === 'ci') {
     let config: ProjectOptions = yield loadConfig(args);
@@ -38,6 +39,7 @@ export function * CLI(argv: string[]): Operation {
       formatterName: args.formatter,
       showFullStack: false,
       showLog: false,
+      coverage: args.coverage
     });
   }
 }
@@ -51,6 +53,7 @@ interface StartOptions {
 }
 
 interface RunOptions {
+  coverage: boolean;
   formatter: string;
   files: string[];
 }
@@ -102,6 +105,11 @@ function parseOptions(argv: readonly string[]): Options {
         type: 'string',
         default: 'checks'
       })
+      .option('coverage', {
+        describe: 'output coverage reports for the test run',
+        type: 'boolean',
+        default: false
+      });
   };
 
   let parsed = yargs({})

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -80,11 +80,13 @@ export function test() {
       $showInternalStackTrace: Boolean! = true,
       $showDependenciesStackTrace: Boolean! = true,
       $showStackTraceCode: Boolean! = true,
-      $showLog: Boolean! = true
+      $showLog: Boolean! = true,
+      $coverage: Boolean! = false
     ) {
       testRun(id: $testRunId) {
         status
         error { ...ErrorDetails }
+        coverage @include(if: $coverage)
         agents {
           agent {
             agentId
@@ -155,6 +157,7 @@ export type TestResults = {
   testRun: {
     status: ResultStatus;
     error?: ErrorDetails;
+    coverage?: string;
     agents: {
       status: ResultStatus;
       agent: {
@@ -168,4 +171,3 @@ export type TestResults = {
     }[];
   };
 }
-

--- a/packages/cli/src/report-coverage.ts
+++ b/packages/cli/src/report-coverage.ts
@@ -11,7 +11,7 @@ import { TestResults } from './query';
 export function* reportCoverage(config: ProjectOptions, results: TestResults): Operation<void> {
   let coverageData = results.testRun.coverage;
   if (!coverageData) {
-    console.warn("\u26a0️" + chalk.yellowBright('  coverage reporting was requested, but no coverage metrics were present in your application, which usually means that it has not been instrumented. See https://github.com/thefrontside/bigtest/issues/569 for details on how to integrate code coverage with BigTest'))
+    console.warn("\u26a0️" + chalk.yellowBright('  coverage reporting was requested, but no coverage metrics were present in your application. This usually means that it has not been instrumented. See https://github.com/thefrontside/bigtest/issues/569 for details on how to integrate code coverage with BigTest'))
   } else if (config.coverage.reports.length < 1) {
     console.warn("\u26a0️" + chalk.yellowBright('  coverage reporting was requested, but no reports were specified in your project config. To enable reporting, add at least one report to the coverage.reports field of bigtest.json, e.g. ["lcov", "json"]'));
   } else {

--- a/packages/cli/src/report-coverage.ts
+++ b/packages/cli/src/report-coverage.ts
@@ -1,0 +1,37 @@
+import { join } from 'path';
+import * as chalk from 'chalk';
+import { Operation } from 'effection';
+import { ProjectOptions } from '@bigtest/project';
+import { createContext, ReportBase } from 'istanbul-lib-report';
+import { createCoverageMap } from 'istanbul-lib-coverage';
+import { create as createReport } from 'istanbul-reports';
+
+import { TestResults } from './query';
+
+export function* reportCoverage(config: ProjectOptions, results: TestResults): Operation<void> {
+  let coverageData = results.testRun.coverage;
+  if (!coverageData) {
+    console.warn("\u26a0️" + chalk.yellowBright('  coverage reporting was requested, but no coverage metrics were present in your application, which usually means that it has not been instrumented. See https://github.com/thefrontside/bigtest/issues/569 for details on how to integrate code coverage with BigTest'))
+  } else if (config.coverage.reports.length < 1) {
+    console.warn("\u26a0️" + chalk.yellowBright('  coverage reporting was requested, but no reports were specified in your project config. To enable reporting, add at least one report to the coverage.reports field of bigtest.json, e.g. ["lcov", "json"]'));
+  } else {
+    yield renderReports(config, coverageData);
+    console.log(
+      chalk.cyan.bold('@bigtest/coverage') + ': ' +
+        chalk.cyan(`${config.coverage.reports.join(',')} reported to -> ${config.coverage.directory}`))
+  }
+}
+
+function * renderReports(config: ProjectOptions, data: string): Operation<void> {
+  let { reports, directory } = config.coverage;
+
+  let coverageMap = createCoverageMap(JSON.parse(data));
+
+  for (let reportName of reports) {
+    let report = createReport(reportName) as unknown as ReportBase;
+    report.execute(createContext({
+      dir: join(directory, reportName),
+      coverageMap
+    }));
+  }
+}

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -5,6 +5,7 @@ import { Client } from '@bigtest/client';
 import { MainError } from '@effection/node';
 import * as query from './query';
 import { Formatter, FormatterConstructor } from './format-helpers';
+import { reportCoverage } from './report-coverage';
 
 import checks from './formatters/checks';
 import lines from './formatters/lines';
@@ -14,6 +15,7 @@ interface Options {
   files: string[];
   showFullStack: boolean;
   showLog: boolean;
+  coverage: boolean;
 }
 
 const BUILTIN_FORMATTERS: Record<string, Formatter | FormatterConstructor> = { checks, lines };
@@ -86,9 +88,15 @@ export function* runTest(config: ProjectOptions, options: Options): Operation<vo
     showInternalStackTrace: options.showFullStack,
     showStackTraceCode: options.showFullStack,
     showLog: options.showLog,
+    coverage: options.coverage
   });
 
+
   formatter.footer(treeQuery);
+
+  if (options.coverage) {
+    yield reportCoverage(config, treeQuery);
+  }
 
   if(treeQuery.testRun.status !== 'ok') {
     throw new MainError({ exitCode: 1 });

--- a/packages/cli/test/fixtures/coverage-data.js
+++ b/packages/cli/test/fixtures/coverage-data.js
@@ -1,0 +1,500 @@
+export const coverageData = {
+  "src/Signin.js": {
+    "path": "src/Signin.js",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 4,
+          "column": 12
+        },
+        "end": {
+          "line": 35,
+          "column": 1
+        }
+      },
+      "1": {
+        "start": {
+          "line": 5,
+          "column": 40
+        },
+        "end": {
+          "line": 5,
+          "column": 55
+        }
+      },
+      "2": {
+        "start": {
+          "line": 6,
+          "column": 48
+        },
+        "end": {
+          "line": 6,
+          "column": 63
+        }
+      },
+      "3": {
+        "start": {
+          "line": 7,
+          "column": 40
+        },
+        "end": {
+          "line": 7,
+          "column": 52
+        }
+      },
+      "4": {
+        "start": {
+          "line": 9,
+          "column": 19
+        },
+        "end": {
+          "line": 13,
+          "column": 3
+        }
+      },
+      "5": {
+        "start": {
+          "line": 10,
+          "column": 4
+        },
+        "end": {
+          "line": 10,
+          "column": 29
+        }
+      },
+      "6": {
+        "start": {
+          "line": 11,
+          "column": 4
+        },
+        "end": {
+          "line": 11,
+          "column": 26
+        }
+      },
+      "7": {
+        "start": {
+          "line": 12,
+          "column": 4
+        },
+        "end": {
+          "line": 12,
+          "column": 43
+        }
+      },
+      "8": {
+        "start": {
+          "line": 15,
+          "column": 2
+        },
+        "end": {
+          "line": 34,
+          "column": 4
+        }
+      },
+      "9": {
+        "start": {
+          "line": 37,
+          "column": 14
+        },
+        "end": {
+          "line": 76,
+          "column": 1
+        }
+      },
+      "10": {
+        "start": {
+          "line": 40,
+          "column": 34
+        },
+        "end": {
+          "line": 40,
+          "column": 46
+        }
+      },
+      "11": {
+        "start": {
+          "line": 41,
+          "column": 34
+        },
+        "end": {
+          "line": 41,
+          "column": 46
+        }
+      },
+      "12": {
+        "start": {
+          "line": 43,
+          "column": 2
+        },
+        "end": {
+          "line": 75,
+          "column": 3
+        }
+      },
+      "13": {
+        "start": {
+          "line": 46,
+          "column": 8
+        },
+        "end": {
+          "line": 46,
+          "column": 27
+        }
+      },
+      "14": {
+        "start": {
+          "line": 47,
+          "column": 8
+        },
+        "end": {
+          "line": 47,
+          "column": 36
+        }
+      },
+      "15": {
+        "start": {
+          "line": 56,
+          "column": 23
+        },
+        "end": {
+          "line": 56,
+          "column": 50
+        }
+      },
+      "16": {
+        "start": {
+          "line": 64,
+          "column": 23
+        },
+        "end": {
+          "line": 64,
+          "column": 50
+        }
+      }
+    },
+    "fnMap": {
+      "0": {
+        "name": "(anonymous_0)",
+        "decl": {
+          "start": {
+            "line": 4,
+            "column": 12
+          },
+          "end": {
+            "line": 4,
+            "column": 13
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 4,
+            "column": 18
+          },
+          "end": {
+            "line": 35,
+            "column": 1
+          }
+        },
+        "line": 4
+      },
+      "1": {
+        "name": "(anonymous_1)",
+        "decl": {
+          "start": {
+            "line": 9,
+            "column": 19
+          },
+          "end": {
+            "line": 9,
+            "column": 20
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 9,
+            "column": 43
+          },
+          "end": {
+            "line": 13,
+            "column": 3
+          }
+        },
+        "line": 9
+      },
+      "2": {
+        "name": "(anonymous_2)",
+        "decl": {
+          "start": {
+            "line": 37,
+            "column": 14
+          },
+          "end": {
+            "line": 37,
+            "column": 15
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 39,
+            "column": 6
+          },
+          "end": {
+            "line": 76,
+            "column": 1
+          }
+        },
+        "line": 39
+      },
+      "3": {
+        "name": "(anonymous_3)",
+        "decl": {
+          "start": {
+            "line": 45,
+            "column": 16
+          },
+          "end": {
+            "line": 45,
+            "column": 17
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 45,
+            "column": 21
+          },
+          "end": {
+            "line": 48,
+            "column": 7
+          }
+        },
+        "line": 45
+      },
+      "4": {
+        "name": "(anonymous_4)",
+        "decl": {
+          "start": {
+            "line": 56,
+            "column": 18
+          },
+          "end": {
+            "line": 56,
+            "column": 19
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 56,
+            "column": 23
+          },
+          "end": {
+            "line": 56,
+            "column": 50
+          }
+        },
+        "line": 56
+      },
+      "5": {
+        "name": "(anonymous_5)",
+        "decl": {
+          "start": {
+            "line": 64,
+            "column": 18
+          },
+          "end": {
+            "line": 64,
+            "column": 19
+          }
+        },
+        "loc": {
+          "start": {
+            "line": 64,
+            "column": 23
+          },
+          "end": {
+            "line": 64,
+            "column": 50
+          }
+        },
+        "line": 64
+      }
+    },
+    "branchMap": {
+      "0": {
+        "loc": {
+          "start": {
+            "line": 17,
+            "column": 7
+          },
+          "end": {
+            "line": 20,
+            "column": 12
+          }
+        },
+        "type": "binary-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 17,
+              "column": 7
+            },
+            "end": {
+              "line": 17,
+              "column": 22
+            }
+          },
+          {
+            "start": {
+              "line": 18,
+              "column": 8
+            },
+            "end": {
+              "line": 20,
+              "column": 12
+            }
+          }
+        ],
+        "line": 17
+      },
+      "1": {
+        "loc": {
+          "start": {
+            "line": 25,
+            "column": 26
+          },
+          "end": {
+            "line": 25,
+            "column": 61
+          }
+        },
+        "type": "cond-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 25,
+              "column": 45
+            },
+            "end": {
+              "line": 25,
+              "column": 52
+            }
+          },
+          {
+            "start": {
+              "line": 25,
+              "column": 55
+            },
+            "end": {
+              "line": 25,
+              "column": 61
+            }
+          }
+        ],
+        "line": 25
+      },
+      "2": {
+        "loc": {
+          "start": {
+            "line": 30,
+            "column": 7
+          },
+          "end": {
+            "line": 32,
+            "column": 8
+          }
+        },
+        "type": "binary-expr",
+        "locations": [
+          {
+            "start": {
+              "line": 30,
+              "column": 7
+            },
+            "end": {
+              "line": 30,
+              "column": 18
+            }
+          },
+          {
+            "start": {
+              "line": 30,
+              "column": 22
+            },
+            "end": {
+              "line": 32,
+              "column": 8
+            }
+          }
+        ],
+        "line": 30
+      }
+    },
+    "s": {
+      "0": 1,
+      "1": 1,
+      "2": 1,
+      "3": 1,
+      "4": 1,
+      "5": 0,
+      "6": 0,
+      "7": 0,
+      "8": 1,
+      "9": 1,
+      "10": 0,
+      "11": 0,
+      "12": 0,
+      "13": 0,
+      "14": 0,
+      "15": 0,
+      "16": 0
+    },
+    "f": {
+      "0": 1,
+      "1": 0,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "5": 0
+    },
+    "b": {
+      "0": [
+        1,
+        0
+      ],
+      "1": [
+        1,
+        0
+      ],
+      "2": [
+        1,
+        0
+      ]
+    },
+    "_coverageSchema": "43e27e138ebf9cfc5966b082cf9a028302ed4184",
+    "hash": "3548561dd067761ad319a925fc80b2dcb9eec399"
+  },
+  "src/index.js": {
+    "path": "src/index.js",
+    "statementMap": {
+      "0": {
+        "start": {
+          "line": 5,
+          "column": 0
+        },
+        "end": {
+          "line": 5,
+          "column": 58
+        }
+      }
+    },
+    "fnMap": {},
+    "branchMap": {},
+    "s": {
+      "0": 1
+    },
+    "f": {},
+    "b": {},
+    "_coverageSchema": "43e27e138ebf9cfc5966b082cf9a028302ed4184",
+    "hash": "6d1d2ef67e3789df0449b0b0eb1531530ccfbe2c"
+  }
+}

--- a/packages/cli/test/fixtures/coverage.test.ts
+++ b/packages/cli/test/fixtures/coverage.test.ts
@@ -1,0 +1,15 @@
+import { test } from '@bigtest/suite';
+import { bigtestGlobals } from '@bigtest/globals';
+
+import { coverageData } from './coverage-data';
+
+interface CoverageHolder {
+  __coverage__: Record<string, unknown>;
+}
+
+export default test('Coverage Test')
+  .step("add coverage data", async() => {
+    let window: Window = bigtestGlobals.testFrame.contentWindow.window;
+    let holder = window as unknown as CoverageHolder;
+    holder.__coverage__ = coverageData
+  })

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -24,6 +24,17 @@ export function *loadConfigFile(configFilePath: string): Operation<ProjectOption
   return JSON.parse(contents) as ProjectOptions;
 }
 
+export type CoverageReportName =
+  'clover' |
+  'cobertura' |
+  'html-spa' |
+  'html' |
+  'json' |
+  'json-summary' |
+  'lcov'|
+  'lcovonly' |
+  'teamcity';
+
 export type ProjectOptions = {
   port: number;
   testFiles: string[];
@@ -46,6 +57,10 @@ export type ProjectOptions = {
   };
   drivers: Record<string, DriverSpec>;
   launch: string[];
+  coverage: {
+    reports: CoverageReportName[]
+    directory: string;
+  }
 }
 
 export function defaultConfig(configFilePath: string): ProjectOptions {
@@ -102,6 +117,10 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
         }
       },
     },
-    launch: []
+    launch: [],
+    coverage: {
+      reports: [],
+      directory: "./coverage"
+    }
   }
 };

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -58,9 +58,9 @@ export type ProjectOptions = {
   drivers: Record<string, DriverSpec>;
   launch: string[];
   coverage: {
-    reports: CoverageReportName[]
+    reports: CoverageReportName[];
     directory: string;
-  }
+  };
 }
 
 export function defaultConfig(configFilePath: string): ProjectOptions {

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -61,5 +61,9 @@ main(createServer({
         }
       }
   },
-  launch: ['chrome.headless', 'firefox.headless']
+  launch: ['chrome.headless', 'firefox.headless'],
+  coverage: {
+    directory: "./coverage",
+    reports: []
+  }
 }));

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -27,12 +27,14 @@ export type TestRunState = {
   status: ResultStatus;
   agents: Record<string, TestRunAgentState>;
   error?: ErrorDetails;
+  coverage?: unknown;
 }
 
 export type TestRunAgentState = {
   status: ResultStatus;
   agent: AgentState;
   result: TestResult;
+  coverage?: unknown;
 }
 
 export type BundlerState =

--- a/packages/server/src/schema.ts
+++ b/packages/server/src/schema.ts
@@ -236,6 +236,10 @@ export const schema = makeSchema({
         t.id("testRunId");
         t.string("status");
         t.field("error", { type: "Error", nullable: true });
+        t.string("coverage", {
+          nullable: true,
+          resolve: testRun => JSON.stringify(testRun.coverage)
+        })
         t.list.field("agents", {
           type: "TestRunAgent",
           resolve: (testRun) => Object.values(testRun.agents)

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -48,7 +48,7 @@ describe('command processor', () => {
     }));
   });
 
-  describe('when sent a `run` message with a valid manifest', () => {
+  describe.only('when sent a `run` message with a valid manifest', () => {
     let pendingMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     let testRun: TestRunState;
 
@@ -56,6 +56,7 @@ describe('command processor', () => {
       atom.slice('bundler', 'type').set('GREEN');
       commands.send({ type: 'run', id: 'test-id-1', files: [] });
       pendingMessage = await actions.fork(delegate.receive({ type: 'run' }));
+      events.send({type: 'run:end', testRunId: 'test-id-1', agentId: 'agent-1' });
       testRun = await actions.fork(atom.slice('testRuns', 'test-id-1').once((testRun) => testRun?.status === 'ok'));
     });
 

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -48,7 +48,7 @@ describe('command processor', () => {
     }));
   });
 
-  describe.only('when sent a `run` message with a valid manifest', () => {
+  describe('when sent a `run` message with a valid manifest', () => {
     let pendingMessage: any; // eslint-disable-line @typescript-eslint/no-explicit-any
     let testRun: TestRunState;
 

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -78,7 +78,8 @@ export const actions = {
             port: 24103,
           },
           drivers: {},
-          launch: []
+          launch: [],
+          coverage: { reports: [], directory: "" }
         }
       }));
 

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -360,6 +360,10 @@ describe('running tests on an agent', () => {
           status: 'ok',
           testRunId: runCommand.testRunId,
           path: ['All tests', 'Signing In', 'when I go to the main navigation page', 'I see my username']
+        });
+        agent.send({
+          type: 'run:end',
+          testRunId: runCommand.testRunId
         })
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2829,7 +2829,7 @@
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
   integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
-"@types/istanbul-lib-report@*":
+"@types/istanbul-lib-report@*", "@types/istanbul-lib-report@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
   integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
@@ -2842,6 +2842,13 @@
   integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jsdom@^16.2.3":
@@ -8587,6 +8594,15 @@ istanbul-lib-report@^2.0.4:
     make-dir "^2.1.0"
     supports-color "^6.1.0"
 
+istanbul-lib-report@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#7518fe52ea44de372f460a76b5ecda9ffb73d8a6"
+  integrity sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^3.0.0"
+    supports-color "^7.1.0"
+
 istanbul-lib-source-maps@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
@@ -8604,6 +8620,14 @@ istanbul-reports@^2.2.6:
   integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
     html-escaper "^2.0.0"
+
+istanbul-reports@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
+  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 iterall@^1.2.2:
   version "1.3.0"
@@ -9597,7 +9621,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -15178,10 +15202,41 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
> closes #446 

Motivation
-----------
We need [coverage reporting][1] in BigTest, and this is the front half of the changes needed to implement it.

Approach
----------

With coverage data [being harvested][2] from the web agents, we can now take it and aggregate it on the server into a single coverage map that spans coverage of the same application over multiple browsers. This means that if you have code like the following:

```js
if (isFireFox()) {
  // some browser specific code.
}
```

The coverage metrics will change as you run begin to add different browsers to your test suite, which is a very good thing.

Once the aggregate coverage data is integrated into the atom and associated with the highest level `TestRunState`, it can be queried over graphql.

On the client end, this adds a `coverage` field to the project which has the output directory for the reports and the list of report formats to output. That way when you pass the `--coverage` option to the cli command, it knows what to do. For example, if your bigtest.json looks like:

```json
{
  "coverage": {
    "reports": ["lcov", "html"],
    "directory": "./coverage"
  }
}
```

Then running the tests with the `--coverage` option

```
$ bigtest test --coverage
```

will render both the `lcov` and the `html` report to the `./coverage` directory. Without specifically requesting coverage reports with the `--coverage` flag, the coverage data will not be requested via graphql at all.

One thing that did significantly change is the timing of when an agent run was considered complete. We had been "short circuiting" the run at the moment all of the steps and assertions were reported either passing, failing, or disregared. However, in order to make sure that we get the coverage data we cannot exit early. Instead, we have to explicitly wait for the `run:end` event to be sent by the agent since that is the event bearing the raw coverage metrics. This shouldn't be a problem, but it does pass control of "done-ness" of a test run over to the agent from the orchestrator which is a significant shift. On the whole this makes sense since the amount of metadata likely to be passed back about a test run from the agent is only likely to grow, and only the agent can determine when it is time to report that data.

Screenshots
-------------

Using the `--coverage` option on a test suite that has coverage metrics, and the reports are generated in the requested format

![informational message is display showing coverage successfully reported](https://user-images.githubusercontent.com/4205/94310368-2828b380-ff3f-11ea-9ac4-e225b2422549.gif)

Using the `---coverage` option, but there are no coverage metrics generated by the test run (usually caused by the build being improperly instrumented)

![A warning is show because coverage is requested, but no coverage metrics were present in the application](https://user-images.githubusercontent.com/4205/94310461-455d8200-ff3f-11ea-8233-477bcc6f2eb9.gif)




Open Questions
----------------

* We could add configuration flags for the `reports` and `directory` fields of the config, but this change is already significant, and while this PR adopts a "wait and see" approach, we could do either.

* I'm not super thrilled that the orchestrator and CLI are coupled directly to the instanbul coverage library since I don't know it to be a standard, and in order to generate coverage for different platforms, we'll need to make it generic. I feel like coverage is a pretty good use-case for having a plugin and it pretty much touches on every single thing where we need to have an extension point.
1. to stash cross-lane data on the agent
1. extend the run:end event to report metadata
1. to extend the orchestrator state to house the metadata
1. extend the run command to aggregate coverage data
1. extend the GraphQL schema to add the coverage field
1. extend CLI to add --coverage option
1. extend the project config to have a "coverage" section
1. add a custom reporter to handle test results and render reports to
1. report configuration errors and runtime errors to the user

If we can implement coverage and application logging events via a plugin, we've got something really powerful.

[1]: https://github.com/thefrontside/bigtest/issues/446
[2]: https://github.com/thefrontside/bigtest/pull/554