### PR TITLE
Atom slice unique state publish

### DIFF
--- a/.changeset/unique-state-publish-from-atom-slice.md
+++ b/.changeset/unique-state-publish-from-atom-slice.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/atom": minor
+---
+
+only publish from atom or slice if the state has changed

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -3,6 +3,7 @@ import { Channel } from '@effection/channel';
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Slice } from "./slice";
 import { Sliceable } from './sliceable';
+import { unique } from './unique';
 
 export class Atom<S> implements Subscribable<S,undefined> {
   private readonly initial: S;
@@ -53,6 +54,6 @@ export class Atom<S> implements Subscribable<S,undefined> {
   }
 
   *[SymbolSubscribable](): Operation<Subscription<S,undefined>> {
-    return yield subscribe(this.states);
+    return yield subscribe(this.states).filter(unique(this.initial));
   }
 }

--- a/packages/atom/src/slice.ts
+++ b/packages/atom/src/slice.ts
@@ -3,6 +3,7 @@ import { lensPath, view, set, dissoc, over, ManualLens } from "ramda";
 import { Atom } from "./atom";
 import { subscribe, Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Sliceable } from './sliceable';
+import { unique } from './unique';
 
 export class Slice<S, A> implements Subscribable<S, undefined> {
   lens: ManualLens<S, A>;
@@ -54,7 +55,7 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
           parentLens,
           array.filter((el) => el !== this.get()),
           state
-        ) as unknown) as A;
+        )) as A;
       });
     } else {
       let [property] = this.path.slice(-1);
@@ -63,7 +64,7 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
           parentLens,
           dissoc(property, parent as object),
           state
-        ) as unknown) as A;
+        )) as A;
       });
     }
   }
@@ -79,6 +80,8 @@ export class Slice<S, A> implements Subscribable<S, undefined> {
   }
 
   *[SymbolSubscribable](): Operation<Subscription<S, undefined>> {
-    return yield subscribe(this.atom).map((state) => view(this.lens)(state) as unknown as S);
+    return yield subscribe(this.atom)
+    .map((state) => view(this.lens)(state))
+    .filter(unique(this.get()));
   }
 }

--- a/packages/atom/src/unique.ts
+++ b/packages/atom/src/unique.ts
@@ -1,0 +1,8 @@
+export const unique = <S>(current: S) => (state: S) => {
+  if (current !== state) {
+    current = state;
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,4 @@
-import { OrchestratorState, BundlerTypes } from './orchestrator/state';
+import { OrchestratorState } from './orchestrator/state';
 import { Atom } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';
 
@@ -10,17 +10,13 @@ export interface LoggerOptions {
 export function* createLogger({ atom, out }: LoggerOptions) {
   let bundlerState = atom.slice('bundler');
 
-  let currentBundlerType: BundlerTypes;
   yield subscribe(bundlerState).forEach(function* (event) {
-    if(event.type !== currentBundlerType) {
-      currentBundlerType = event.type;
-      if(event.type === 'ERRORED'){
-        out("[manifest builder] build error:");
-        out(event.error.message);
-      }
-      if(event.type === 'GREEN'){
-        out("[manifest builder] build successful!");
-      }
+    if(event.type === 'ERRORED'){
+      out("[manifest builder] build error:");
+      out(event.error.message);
+    }
+    if(event.type === 'GREEN'){
+      out("[manifest builder] build successful!");
     }
   })
 }


### PR DESCRIPTION
This is to stop consecutive identical state updates from both slice and atom:

In the logger for example, if identical bundler events are received:

```javascript
{ type: 'GREEN' }
{ type: 'GREEN' }
```

Then the responsibility of filtering identical events is pushed to the logger or any other component that is affected by similar events being raised.  

The fix is to apply a unique filter function at the subscription level of atom and slice:

```ts
export const unique = <S>(current: S) => (state: S) => {
  if (current !== state) {
    current = state;
    return true;
  } else {
    return false;
  }
}
```

```ts
  *[SymbolSubscribable](): Operation<Subscription<S, undefined>> {
    return yield subscribe(this.atom)
    .map((state) => view(this.lens)(state))
    .filter(unique(this.get()));
  }
```

This ensures that only unique state updates happen.
