### PR TITLE
Add visibily filter using `element-is-visible`

### DIFF
--- a/.changeset/new-shoes-confess.md
+++ b/.changeset/new-shoes-confess.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Add visibility filter to interactors using element-is-visible

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@bigtest/globals": "^0.7.0",
     "@bigtest/performance": "^0.5.0",
-    "change-case": "^4.1.1"
+    "change-case": "^4.1.1",
+    "element-is-visible": "^1.0.0"
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",

--- a/packages/interactor/src/definitions/button.ts
+++ b/packages/interactor/src/definitions/button.ts
@@ -1,4 +1,5 @@
 import { createInteractor, perform } from '../index';
+import { isVisible } from 'element-is-visible';
 
 function isButtonElement(element: HTMLInputElement | HTMLButtonElement): element is HTMLButtonElement {
   return element.tagName === 'BUTTON';
@@ -22,6 +23,7 @@ export const Button = createInteractor<HTMLInputElement | HTMLButtonElement>('bu
   filters: {
     title: (element) => element.title,
     id: (element) => element.id,
+    visible: { apply: isVisible, default: true },
     disabled: {
       apply: (element) => element.disabled,
       default: false

--- a/packages/interactor/src/definitions/heading.ts
+++ b/packages/interactor/src/definitions/heading.ts
@@ -1,4 +1,5 @@
 import { createInteractor } from '../create-interactor';
+import { isVisible } from 'element-is-visible';
 
 export const Heading = createInteractor<HTMLHeadingElement>('heading')({
   selector: 'h1,h2,h3,h4,h5,h6',
@@ -6,6 +7,7 @@ export const Heading = createInteractor<HTMLHeadingElement>('heading')({
     byId: (element) => element.id
   },
   filters: {
-    level: (element) => parseInt(element.tagName[1])
+    level: (element) => parseInt(element.tagName[1]),
+    visible: { apply: isVisible, default: true },
   }
 });

--- a/packages/interactor/src/definitions/link.ts
+++ b/packages/interactor/src/definitions/link.ts
@@ -1,4 +1,5 @@
 import { createInteractor, perform } from '../index';
+import { isVisible } from 'element-is-visible';
 
 export const Link = createInteractor<HTMLLinkElement>('link')({
   selector: 'a[href]',
@@ -10,6 +11,7 @@ export const Link = createInteractor<HTMLLinkElement>('link')({
     title: (element) => element.title,
     href: (element) => element.href,
     id: (element) => element.id,
+    visible: { apply: isVisible, default: true },
   },
   actions: {
     click: perform((element) => { element.click(); })

--- a/packages/interactor/src/definitions/text-field.ts
+++ b/packages/interactor/src/definitions/text-field.ts
@@ -1,4 +1,5 @@
 import { createInteractor, perform, fillIn } from '../index';
+import { isVisible } from 'element-is-visible';
 
 export const TextField = createInteractor<HTMLInputElement>('text field')({
   selector: 'input:not([type]),input[type=text]',
@@ -11,6 +12,7 @@ export const TextField = createInteractor<HTMLInputElement>('text field')({
   filters: {
     title: (element) => element.title,
     id: (element) => element.id,
+    visible: { apply: isVisible, default: true },
     value: (element) => element.value,
     placeholder: (element) => element.placeholder,
     valid: (element) => element.validity.valid,

--- a/packages/interactor/test/definitions/heading.test.ts
+++ b/packages/interactor/test/definitions/heading.test.ts
@@ -27,5 +27,29 @@ describe('@bigtest/interactor', () => {
         await expect(Heading('Foo', { level: 3 }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
+
+    describe('filter `visible`', () => {
+      it('filters heading tags by their visibility', async () => {
+        dom(`
+          <h1 style="display:none;">Foo</h1>
+          <h2>Bar</h2>
+        `);
+
+        await expect(Heading('Foo', { visible: false }).exists()).resolves.toBeUndefined();
+        await expect(Heading('Bar', { visible: true }).exists()).resolves.toBeUndefined();
+        await expect(Heading('Foo', { visible: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(Heading('Bar', { visible: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+
+      it('defaults to `true`', async () => {
+        dom(`
+          <h1 style="display:none;">Foo</h1>
+          <h2>Bar</h2>
+        `);
+
+        await expect(Heading('Bar').exists()).resolves.toBeUndefined();
+        await expect(Heading('Foo').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
   });
 });

--- a/packages/interactor/test/definitions/link.test.ts
+++ b/packages/interactor/test/definitions/link.test.ts
@@ -66,6 +66,30 @@ describe('@bigtest/interactor', () => {
       });
     });
 
+    describe('filter `visible`', () => {
+      it('filters `a` tags by their visibility', async () => {
+        dom(`
+          <p><a href="/foo" style="display:none;">Foo</a></p>
+          <p><a href="/bar">Bar</a></p>
+        `);
+
+        await expect(Link('Foo', { visible: false }).exists()).resolves.toBeUndefined();
+        await expect(Link('Bar', { visible: true }).exists()).resolves.toBeUndefined();
+        await expect(Link('Foo', { visible: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(Link('Bar', { visible: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+
+      it('defaults to `true`', async () => {
+        dom(`
+          <p><a href="/foo" style="display:none;">Foo</a></p>
+          <p><a href="/bar">Bar</a></p>
+        `);
+
+        await expect(Link('Bar').exists()).resolves.toBeUndefined();
+        await expect(Link('Foo').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+      });
+    });
+
     describe('filter `title`', () => {
       it('filters `a` tags by their title', async () => {
         dom(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -6023,6 +6023,11 @@ electron-to-chromium@^1.3.481:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.481.tgz#0d59e72a0aaeb876b43fb1d6e84bf0dfc99617e8"
   integrity sha512-q2PeCP2PQXSYadDo9uNY+uHXjdB9PcsUpCVoGlY8TZOPHGlXdevlqW9PkKeqCxn2QBkGB8b6AcMO++gh8X82bA==
 
+element-is-visible@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/element-is-visible/-/element-is-visible-1.0.0.tgz#c58f3e7e747615c5528a9594ab3b948067bd5a42"
+  integrity sha512-OegdS3Zoz+LOcLlZhPEnE8K0DKhxfcbN2JHTDSiH5jTZQgaUk/Dl+nkQ8d8eJzs/qZ21apeS3ezEIHfu6SzyDQ==
+
 elliptic@^6.0.0, elliptic@^6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"


### PR DESCRIPTION
This sets up a filter for our built in interactors which checks element visibility. This filter is enabled by default, so our interactors default to only matching visible elements.

The advantage to this is that it makes our interactors more robust. It is quite common to hide elements via CSS, and while they then technically exist, they aren't usable by an actual user, and so filtering out these elements makes sense. Additionally, since we require our interactors to be unambiguous, it can sometimes help in matching an element if another match exists but is invisible.

There are some downsides, however. The first is obviously performance. Checking the visibility of every element we match is going to take up processing cycles. The algorithm in element-is-visible is pretty comprehensive and in my opinion is glaringly unoptimized in some spots.

It's worth noting though that Capybara defaults to doing this, and even actually does an additional request to fetch the visibility state for each found element sequentially, and it is *still* decently fast. I suspect that the performance hit this creates is only going to be visible in microbenchmarks, when running against an actual app it is going to get completely drowned out by the performance of the app under test.

Another downside is the nature of a filter which is enabled by default. If we do want to find an element which is hidden, we can do `Link("Foo", { visible: false })`, however there is currently no way to disable the filter entirely, that is there is no way to find an element regardless of visibility state. Capybara works around this by providing the rather awkward `Link("Foo", { visible: "all" })`. What we really want is the tri-state boolean yes/no/maybe ;)

Depends on https://github.com/thefrontside/element-is-visible/issues/1