### PR TITLE
abstract all output operations into @bigtest/reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "workspaces": {
     "packages": [
+      "packages/reporter",
       "packages/eslint-plugin",
       "packages/effection",
       "packages/client",

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -24,6 +24,7 @@
     "@babel/runtime": "^7.10.4",
     "@bigtest/effection": "^0.5.4",
     "@bigtest/project": "^0.9.0",
+    "@bigtest/reporter": "^0.1.0",
     "@effection/channel": "^0.6.7",
     "@effection/events": "^0.7.8",
     "@effection/node": "^0.8.0",
@@ -32,7 +33,7 @@
     "@rollup/plugin-node-resolve": "^8.1.0",
     "effection": "^0.7.0",
     "express": "^4.17.1",
-    "rollup": "^2.23.0",
+    "rollup": "^2.28.2",
     "rollup-plugin-inject-process-env": "^1.3.0"
   },
   "volta": {

--- a/packages/bundler/src/index.ts
+++ b/packages/bundler/src/index.ts
@@ -1,2 +1,1 @@
 export { Bundler } from './bundler';
-export { BundlerError, BundlerWarning } from './types';

--- a/packages/bundler/src/types.ts
+++ b/packages/bundler/src/types.ts
@@ -1,7 +1,4 @@
-import { RollupWarning, RollupError } from 'rollup';
-
-export type BundlerError = RollupError;
-export type BundlerWarning = RollupWarning;
+import type { BundlerError, BundlerWarning } from '@bigtest/reporter';
 
 export type BundlerMessage =
   | { type: 'START' }

--- a/packages/cli/tmp/bigtest-config-test.json
+++ b/packages/cli/tmp/bigtest-config-test.json
@@ -1,0 +1,16 @@
+{
+  "port": 1234,
+  "launch": [
+    "chrome.headless"
+  ],
+  "app": {
+    "command": "yarn run-my-app",
+    "env": {
+      "PORT": 9000
+    },
+    "url": "http://localhost:9000"
+  },
+  "testFiles": [
+    "test.ts"
+  ]
+}

--- a/packages/reporter/README.md
+++ b/packages/reporter/README.md
@@ -1,0 +1,5 @@
+# @bigtest/reporter
+
+## WIP
+
+Can update this if the approach is approved

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@bigtest/reporter",
+  "version": "0.1.0",
+  "description": "expressive logger for bigtest",
+  "main": "dist/index.js",
+  "author": "Frontside Engineering <engineering@frontside.com>",
+  "license": "MIT",
+  "private": false,
+  "keywords": [
+    "logger"
+  ],
+  "dependencies": {
+    "chalk": "^4.1.0",
+    "rollup": "^2.28.2"
+  },
+  "devDependencies": {
+    "@frontside/tsconfig": "*",
+    "@types/mocha": "^7.0.1",
+    "@types/node": "^13.13.4",
+    "mocha": "^6.2.2",
+    "ts-node": "*",
+    "typescript": "3.9.7"
+  },
+  "scripts": {
+    "lint": "eslint \"{src,test}/**/*.ts\"",
+    "prepack": "tsc --declaration --sourcemap",
+    "test": "mocha -r ts-node/register \"test/{,!(fixtures)/**}/*.test.ts\""
+  },
+  "files": [
+    "docs",
+    "dist"
+  ]
+}

--- a/packages/reporter/package.json
+++ b/packages/reporter/package.json
@@ -10,11 +10,13 @@
     "logger"
   ],
   "dependencies": {
+    "@babel/code-frame": "^7.10.4",
     "chalk": "^4.1.0",
     "rollup": "^2.28.2"
   },
   "devDependencies": {
     "@frontside/tsconfig": "*",
+    "@types/babel__code-frame": "^7.0.2",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "mocha": "^6.2.2",

--- a/packages/reporter/src/error/call-sites-helper.ts
+++ b/packages/reporter/src/error/call-sites-helper.ts
@@ -1,0 +1,57 @@
+/* Based on https://github.com/watson/error-callsites */
+const callsitesSym = Symbol("callsites");
+export { callsitesSym };
+
+const fallback:
+  | ((err: Error, stackTraces: NodeJS.CallSite[]) => unknown)
+  | undefined = Error.prepareStackTrace;
+
+let lastPrepareStackTrace:
+  | ((err: Error, stackTraces: NodeJS.CallSite[]) => unknown)
+  | undefined = fallback;
+
+function prepareStackTrace(
+  err: Error,
+  callsites: NodeJS.CallSite[]
+): NodeJS.CallSite[] | unknown {
+  // If the symbol has already been set it must mean that someone else has also
+  // overwritten `Error.prepareStackTrace` and retains a reference to this
+  // function that it's calling every time it's own `prepareStackTrace`
+  // function is being called. This would create an infinite loop if not
+  // handled.
+  if (Object.prototype.hasOwnProperty.call(err, callsitesSym)) {
+    return (fallback && fallback(err, callsites)) ?? err.toString();
+  }
+
+  Object.defineProperty(err, callsitesSym, {
+    enumerable: false,
+    configurable: true,
+    writable: false,
+    value: callsites,
+  });
+
+  return (
+    (lastPrepareStackTrace && lastPrepareStackTrace(err, callsites)) ??
+    err.toString()
+  );
+}
+
+Object.defineProperty(Error, "prepareStackTrace", {
+  configurable: true,
+  enumerable: true,
+  get: function () {
+    return prepareStackTrace;
+  },
+  set: function (fn?: (err: Error, stackTraces: NodeJS.CallSite[]) => unknown) {
+    // Don't set `lastPrepareStackTrace` to ourselves. If we did, we'd end up
+    // throwing a RangeError (Maximum call stack size exceeded).
+    lastPrepareStackTrace = fn === prepareStackTrace ? fallback : fn;
+  },
+});
+
+export function getCallSites(err: Error): NodeJS.CallSite[] {
+  err.stack;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  return err[callsitesSym];
+}

--- a/packages/reporter/src/error/stack.ts
+++ b/packages/reporter/src/error/stack.ts
@@ -1,0 +1,36 @@
+/* eslint-disable prefer-let/prefer-let */
+import * as path from 'path';
+
+const cwdPathParams = process.cwd().split(path.sep);
+
+export const cleanUpFilePath = (fileName: string | null): string | null => {
+  return fileName == null
+    ? fileName
+    : Object.entries(fileName.split(path.sep))
+        .reduce(
+          (cleanFileName, fileNamePart) =>
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            fileNamePart[1] !== cwdPathParams[fileNamePart[0] as any]
+              ? (cleanFileName += `${path.sep}${fileNamePart[1]}`)
+              : cleanFileName,
+          ""
+        )
+        .substring(1);
+}
+
+
+export const wrapStackFrame = (stackFrame: NodeJS.CallSite) => {
+  const filePath = stackFrame.getFileName();
+
+  return {
+    filePath: cleanUpFilePath(filePath) ?? "",
+    fullFilePath: filePath ?? "",
+    fileName: path.basename(stackFrame.getFileName() ?? ""),
+    lineNumber: stackFrame.getLineNumber(),
+    columnNumber: stackFrame.getColumnNumber(),
+    isConstructor: stackFrame.isConstructor(),
+    functionName: stackFrame.getFunctionName(),
+    typeName: stackFrame.getTypeName(),
+    methodName: stackFrame.getMethodName(),
+  } 
+}

--- a/packages/reporter/src/index.ts
+++ b/packages/reporter/src/index.ts
@@ -1,0 +1,17 @@
+import { Reporter } from './reporter';
+export type { BundlerError, BundlerWarning, Out, Std } from './types';
+import { OutOptions } from './types';
+import { ConsoleOut } from './out/console/console';
+
+export { Reporter } from './reporter';
+
+const DefaultOutOptions: OutOptions = {
+  out: process.stdout,
+  err: process.stderr
+}
+
+export const consoleReporter = (options: Partial<OutOptions>): Reporter => {
+  let out = new ConsoleOut({ ...DefaultOutOptions, ...options });
+
+  return new Reporter(out);
+}

--- a/packages/reporter/src/out/console/console.ts
+++ b/packages/reporter/src/out/console/console.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import os from 'os';
 import { isBundlerError, hasFields } from '../../utils';
 
-
 export class ConsoleOut implements Out {
   out: Std;
   err: Std;
@@ -19,7 +18,9 @@ export class ConsoleOut implements Out {
   }
 
   clear() {
-    this.out.write("\u001b[2J\u001b[0;0H");
+    this.out.write(
+      process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
+    );
   }
 
   write(category: LogCategory, ...args: unknown[]) {

--- a/packages/reporter/src/out/console/console.ts
+++ b/packages/reporter/src/out/console/console.ts
@@ -1,8 +1,14 @@
-import { Out, OutOptions, Std, LogCategory, BundlerError } from '../../types';
-import { logCategories } from './types';
+import { Out, OutOptions, Std, LogCategory } from '../../types';
+import { logCategories, ExtendedStackFrame } from './types';
 import chalk from 'chalk';
 import os from 'os';
 import { isBundlerError, hasFields } from '../../utils';
+import { codeFrameColumns } from '@babel/code-frame';
+import fs from 'fs';
+import path from 'path';
+import { wrapCallSite } from "source-map-support";
+import { getCallSites } from '../../error/call-sites-helper';
+import { wrapStackFrame } from '../../error/stack';
 
 export class ConsoleOut implements Out {
   out: Std;
@@ -21,6 +27,47 @@ export class ConsoleOut implements Out {
     this.out.write(
       process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H'
     );
+  }
+
+  printStack(stack: ExtendedStackFrame[]) {
+    for(let frame of stack) {
+      this.err.write(chalk.gray("• "));
+
+      if (frame.fileName) {
+        this.err.write(chalk.yellowBright(frame.fileName));
+      }
+
+      if (frame.lineNumber) {
+        this.err.write(chalk.gray(":"));
+        this.err.write(chalk.yellow(frame.lineNumber));
+      }
+
+      this.err.write(chalk.white(" " + (frame.functionName ?? "<anonymous>")));
+
+      if (
+        !!frame.filePath &&
+        !!frame.lineNumber &&
+        !!frame.columnNumber
+      ) {
+        this.err.write("\n    ");
+        this.err.write(path.normalize(
+            chalk.gray(`${frame.filePath}:${frame.lineNumber}:${frame.columnNumber}`)
+          )
+        );
+      }
+      this.newLine(this.err);
+      this.newLine(this.err);
+    }
+
+    this.newLine(this.err);
+  }
+
+  printStackTrace(error: Error) {
+    let errorCallSites = getCallSites(error) || [];
+  
+    let stack = Object.values(errorCallSites).map(frame => wrapStackFrame(wrapCallSite(frame)));
+
+    this.printStack(stack);
   }
 
   write(category: LogCategory, ...args: unknown[]) {
@@ -57,51 +104,44 @@ export class ConsoleOut implements Out {
   newLine(std: Std) {
     std.write(os.EOL);
   }
-
-  writeStackTrace(err: Error | BundlerError) {
-    if(!err.stack?.length) {
-      return;
-    }
-    
-    this.err.write(chalk.dim(err.stack));
-
-    this.newLine(this.err);
-  }
-
-  writeFrame(err: BundlerError) {
-    if(!err.frame) {
-      return;
-    }
-    
-    this.err.write(err.frame);
-    this.newLine(this.err);
-  }
   
-  error(err: string | Error | BundlerError): void {
-    if(typeof err === 'string') {
-      this.write('error', err);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error(error: any) {
+    this.newLine(this.err);
+    
+    if(typeof error === 'string') {
+      this.write('error', error);
       return;
     }
 
-    let description = err.name ? `${err.name}: ${err.message}` : err.message;
+    let description = error.name ? `${error.name}: ${error.message}` : error.message;
 
     this.write('error', description);
-
-    if(!isBundlerError(err)){
-      this.writeStackTrace(err);
+    
+    if(!isBundlerError(error) && error.stack){
+      this.printStack(error);
       return;
     } 
-
-    let loc = err.loc;
-
-		if(hasFields(loc)) {
-      this.err.write(`${(loc.file || err.id)} (${loc.line}:${loc.column})`)
-      this.newLine(this.err);
-			return;
-    }
     
-    this.writeFrame(err);
+    let loc = error.loc;
 
-    this.writeStackTrace(err);
+    
+    if (hasFields(loc)) {
+      this.newLine(this.err);
+      let {file, line, column} = loc;
+      let rawLines = fs.readFileSync(file, 'utf-8');
+      
+      let frame = codeFrameColumns(rawLines, 
+        { start: { line, column: column + 1 }},
+        { highlightCode: true }
+      );
+     
+      this.err.write(frame + '\n');
+      this.newLine(this.err);
+    } else if (error.codeFrame) {
+      this.err.write(error.codeFrame);
+    }
+
+    this.printStackTrace(error);
   }
 }

--- a/packages/reporter/src/out/console/console.ts
+++ b/packages/reporter/src/out/console/console.ts
@@ -1,0 +1,106 @@
+import { Out, OutOptions, Std, LogCategory, BundlerError } from '../../types';
+import { logCategories } from './types';
+import chalk from 'chalk';
+import os from 'os';
+import { isBundlerError, hasFields } from '../../utils';
+
+
+export class ConsoleOut implements Out {
+  out: Std;
+  err: Std;
+  setttings: OutOptions;
+  prefix?: string;
+
+  constructor(options: OutOptions) {
+    this.setttings = options;
+    this.out = options.out || process.stdout;
+    this.err = options.err || process.stderr;
+    this.prefix = options.prefix || '';
+  }
+
+  clear() {
+    this.out.write("\u001b[2J\u001b[0;0H");
+  }
+
+  write(category: LogCategory, ...args: unknown[]) {
+    let logCategory = logCategories[category];
+
+    let prefix = this.prefix ? ` ${(this.prefix)} ` : '';
+    let start = chalk[logCategory.bg].black(logCategory.msg.padEnd(7)); 
+    let message = chalk[logCategory.text](args);
+
+    let entry = `${start}${prefix}${message}`;
+
+    let writer: Std = category === 'error' ? this.err : this.out;
+
+    writer.write(entry);
+    this.newLine(writer);
+  }
+
+  info(...args: unknown[]): void {
+    this.write('info', args);
+  }
+  
+  warn(...args: unknown[]): void {
+    this.write('warn', args);
+  }
+
+  success(...args: unknown[]): void {
+    this.write('success', args);
+  }
+
+  debug(...args: unknown[]): void {
+    this.write('debug', args);
+  }
+
+  newLine(std: Std) {
+    std.write(os.EOL);
+  }
+
+  writeStackTrace(err: Error | BundlerError) {
+    if(!err.stack?.length) {
+      return;
+    }
+    
+    this.err.write(chalk.dim(err.stack));
+
+    this.newLine(this.err);
+  }
+
+  writeFrame(err: BundlerError) {
+    if(!err.frame) {
+      return;
+    }
+    
+    this.err.write(err.frame);
+    this.newLine(this.err);
+  }
+  
+  error(err: string | Error | BundlerError): void {
+    if(typeof err === 'string') {
+      this.write('error', err);
+      return;
+    }
+
+    let description = err.name ? `${err.name}: ${err.message}` : err.message;
+
+    this.write('error', description);
+
+    if(!isBundlerError(err)){
+      this.writeStackTrace(err);
+      return;
+    } 
+
+    let loc = err.loc;
+
+		if(hasFields(loc)) {
+      this.err.write(`${(loc.file || err.id)} (${loc.line}:${loc.column})`)
+      this.newLine(this.err);
+			return;
+    }
+    
+    this.writeFrame(err);
+
+    this.writeStackTrace(err);
+  }
+}

--- a/packages/reporter/src/out/console/types.ts
+++ b/packages/reporter/src/out/console/types.ts
@@ -1,0 +1,34 @@
+import type { BackgroundColor, ForegroundColor } from 'chalk';
+import { LogCategory } from '../../types';
+
+export type LoggerType = {
+  [key in LogCategory]: { bg: typeof BackgroundColor; msg: string; text: typeof ForegroundColor };
+};
+
+export const logCategories: LoggerType = {
+  warn: {
+    bg: 'bgYellow',
+    msg: ' WARNING ',
+    text: 'yellow',
+  },
+  debug: {
+    bg: 'bgWhite',
+    msg: ' DEBUG ',
+    text: 'white',
+  },
+  info: {
+    bg: 'bgCyan',
+    msg: ' INFO ',
+    text: 'cyan',
+  },
+  error: {
+    bg: 'bgRed',
+    msg: ' ERROR ',
+    text: 'red',
+  },
+  success: {
+    bg: 'bgGreen',
+    msg: ' DONE ',
+    text: 'green',
+  }
+};

--- a/packages/reporter/src/out/console/types.ts
+++ b/packages/reporter/src/out/console/types.ts
@@ -1,6 +1,18 @@
 import type { BackgroundColor, ForegroundColor } from 'chalk';
 import { LogCategory } from '../../types';
 
+export interface ExtendedStackFrame {
+  filePath: string;
+  fullFilePath: string;
+  fileName: string;
+  lineNumber: number | null;
+  columnNumber: number | null;
+  isConstructor: boolean | null;
+  functionName: string | null;
+  typeName: string | null;
+  methodName: string | null;
+}
+
 export type LoggerType = {
   [key in LogCategory]: { bg: typeof BackgroundColor; msg: string; text: typeof ForegroundColor };
 };

--- a/packages/reporter/src/reporter.ts
+++ b/packages/reporter/src/reporter.ts
@@ -1,0 +1,29 @@
+import type { BundlerError, Out, LogCategory } from './types';
+
+export class Reporter implements Pick<Out, LogCategory> {
+  constructor(private out: Out) {}
+
+  debug(...args: unknown[]) {
+    this.out.debug(args);
+  }
+
+  info(...args: unknown[]) {
+    this.out.info(args);
+  }
+
+  warn(...args: unknown[]) {
+    this.out.warn(args);
+  }
+
+  success(...args: unknown[]) {
+    this.out.success(args);
+  }
+
+  error(error: string | Error | BundlerError) {
+    this.out.error(error);
+  }
+
+  clear() {
+   this.out.clear(); 
+  }
+}

--- a/packages/reporter/src/types.ts
+++ b/packages/reporter/src/types.ts
@@ -1,0 +1,32 @@
+import type { RollupWarning, RollupError } from 'rollup';
+
+export type BundlerError = RollupError;
+export type BundlerWarning = RollupWarning;
+
+export interface Std {
+	write(...args: unknown[]): void;
+}
+
+export interface Out {
+  out: Std;
+  err: Std;
+  setttings: OutOptions;
+  debug(...args: unknown[]): void;
+  error(error: string | Error | BundlerError): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  success(...args: unknown[]): void;
+  clear(): void;
+  
+  silent?: boolean;
+}
+
+export type LogCategory = 'debug' | 'info' | 'warn' | 'error' | 'success';
+
+export interface OutOptions {
+  out: Std;
+  err: Std;
+  prefix?: string;
+}
+
+export type Nullable<T> = T extends NonNullable<T> ? never : T;

--- a/packages/reporter/src/utils.ts
+++ b/packages/reporter/src/utils.ts
@@ -1,0 +1,23 @@
+import { Nullable, BundlerError } from './types';
+import path from 'path';
+
+export const isNil = <T>(val: T): val is Nullable<T> => {
+  return typeof val === 'undefined' || val === null;
+}
+
+export const hasFields = <T>(o: T): o is NonNullable<T> & Required<T> => {
+  return isNil(o) === false && Object.values(o).find(isNil) === false;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isBundlerError = (err: any): err is BundlerError => {
+  return !!err.loc;
+}
+
+export const relativeFilePath = (filePath: string) => {
+  if(typeof process === 'undefined' || path.isAbsolute(filePath)) {
+    return filePath;
+  }
+
+  return path.relative(process.cwd(), filePath);
+}

--- a/packages/reporter/src/utils.ts
+++ b/packages/reporter/src/utils.ts
@@ -6,7 +6,7 @@ export const isNil = <T>(val: T): val is Nullable<T> => {
 }
 
 export const hasFields = <T>(o: T): o is NonNullable<T> & Required<T> => {
-  return isNil(o) === false && Object.values(o).find(isNil) === false;
+  return isNil(o) === false && !Object.values(o).find(isNil);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/reporter/tsconfig.json
+++ b/packages/reporter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@frontside/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "bin/*.ts"
+  ]
+}

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -61,5 +61,9 @@ main(createServer({
         }
       }
   },
-  launch: ['chrome.headless', 'firefox.headless']
+  launch: ['chrome.headless', 'firefox.headless'],
+  coverage: {
+    reports: ['json'],
+    directory: process.cwd()
+  }
 }));

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
     "@bigtest/todomvc": "^0.5.4",
     "@frontside/eslint-config": "^1.1.2",
     "@frontside/typescript": "^1.0.1",
+    "@types/babel__code-frame": "^7.0.2",
     "@types/express": "^4.17.3",
     "@types/graphql": "^14.5.0",
     "@types/http-proxy": "^1.17.0",
@@ -33,6 +34,8 @@
     "@types/node": "^13.13.4",
     "@types/node-fetch": "^2.5.3",
     "@types/rimraf": "3.0.0",
+    "@types/source-map-support": "^0.5.3",
+    "@types/stack-utils": "^2.0.0",
     "@types/websocket": "^1.0.0",
     "abort-controller": "^3.0.0",
     "expect": "^24.9.0",
@@ -42,6 +45,7 @@
     "ts-node": "^8.9.1"
   },
   "dependencies": {
+    "@babel/code-frame": "^7.10.4",
     "@babel/core": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
@@ -74,6 +78,8 @@
     "http-proxy": "^1.18.0",
     "nexus": "^0.12.0",
     "rimraf": "^3.0.0",
+    "source-map-support": "^0.5.19",
+    "stack-utils": "^2.0.2",
     "tempy": "^0.3.0",
     "trumpet": "^1.7.2",
     "websocket": "^1.0.30",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -55,6 +55,7 @@
     "@bigtest/globals": "^0.7.0",
     "@bigtest/logging": "^0.5.1",
     "@bigtest/project": "^0.9.0",
+    "@bigtest/reporter": "^0.1.0",
     "@bigtest/suite": "^0.9.0",
     "@bigtest/webdriver": "^0.6.2",
     "@effection/events": "^0.7.8",

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -14,7 +14,6 @@ export function* createLogger({ atom, reporter }: LoggerOptions) {
   yield subscribe(bundlerState).forEach(function* (event) {
     if(event.type === 'ERRORED'){
       reporter.clear();
-      reporter.error("build error:");
       reporter.error(event.error);
     }
     if(event.type === 'GREEN') {

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,22 +1,24 @@
 import { OrchestratorState } from './orchestrator/state';
 import { Atom } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';
+import { Reporter } from '@bigtest/reporter';
 
 export interface LoggerOptions {
   atom: Atom<OrchestratorState>;
-  out: <A extends unknown[]>(...args: A) => void;
+  reporter: Reporter;
 }
 
-export function* createLogger({ atom, out }: LoggerOptions) {
+export function* createLogger({ atom, reporter }: LoggerOptions) {
   let bundlerState = atom.slice('bundler');
 
   yield subscribe(bundlerState).forEach(function* (event) {
     if(event.type === 'ERRORED'){
-      out("[manifest builder] build error:");
-      out(event.error.message);
+      reporter.clear();
+      reporter.error("build error:");
+      reporter.error(event.error);
     }
-    if(event.type === 'GREEN'){
-      out("[manifest builder] build successful!");
+    if(event.type === 'GREEN') {
+      reporter.success("build successful!");
     }
   })
 }

--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -5,6 +5,7 @@ import { throwOnErrorEvent } from '@effection/events';
 import * as fs from 'fs';
 import * as globby from 'globby';
 import * as path from 'path';
+import { consoleReporter } from '@bigtest/reporter';
 
 const { writeFile, mkdir } = fs.promises;
 
@@ -44,6 +45,8 @@ module.exports = {
 }
 
 export function* createManifestGenerator(options: ManifestGeneratorOptions): Operation {
+  let reporter = consoleReporter({ prefix: '[manifest generator]' });
+
   let watcher = chokidar.watch(options.files, { ignoreInitial: true });
 
   yield ensure(() => watcher.close());
@@ -55,14 +58,14 @@ export function* createManifestGenerator(options: ManifestGeneratorOptions): Ope
   yield events.receive({ event: 'ready' });
   yield writeManifest(options);
 
-  console.debug("[manifest generator] manifest ready");
+  reporter.debug("manifest ready");
   options.delegate.send({ status: 'ready' });
 
   while(true) {
     yield events.receive();
     yield writeManifest(options);
 
-    console.debug("[manifest generator] manifest updated");
+    reporter.debug("manifest updated");
     options.delegate.send({ event: 'update' });
   }
 }

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -41,7 +41,7 @@ export type BundlerState =
   | { type: 'GREEN'; path: string;  warnings: BundlerWarning[] }
   | { type: 'ERRORED'; error: BundlerError }
 
-  export type BundlerTypes = Pick<BundlerState, 'type'>['type'];
+export type BundlerTypes = Pick<BundlerState, 'type'>['type'];
 
 export interface Manifest extends Test {
   fileName: string;

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -1,5 +1,5 @@
 import { Test, TestResult, ResultStatus, ErrorDetails } from '@bigtest/suite';
-import { BundlerError, BundlerWarning } from '@bigtest/bundler';
+import type { BundlerError, BundlerWarning } from '@bigtest/reporter';
 
 export type AgentState = {
   agentId: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2139,7 +2139,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -2701,6 +2706,11 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
+"@types/babel__code-frame@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.2.tgz#e0c0f1648cbc09a9d4e5b4ed2ae9a6f7c8f5aeb0"
+  integrity sha512-imO+jT/yjOKOAS5GQZ8SDtwiIloAGGr6OaZDKB0V5JVaSfGZLat5K5/ZRtyKW6R60XHV3RHYPTFfhYb+wDKyKg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -2984,10 +2994,22 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/source-map-support@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@types/source-map-support/-/source-map-support-0.5.3.tgz#acb6b3e499c20692552d16934c16162c84594e16"
+  integrity sha512-fvjMjVH8Rmokw2dWh1dkj90iX5R8FPjeZzjNH+6eFXReh0QnHFf1YBl3B0CF0RohIAA3SDRJsGeeUWKl6d7HqA==
+  dependencies:
+    source-map "^0.6.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/stack-utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
+  integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
 "@types/tough-cookie@*":
   version "4.0.0"
@@ -6206,7 +6228,7 @@ escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escape-string-regexp@2.0.0:
+escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
@@ -9518,7 +9540,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -13257,7 +13279,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
+source-map-support@^0.5.17, source-map-support@^0.5.19, source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -13407,6 +13429,13 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+stack-utils@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.2.tgz#5cf48b4557becb4638d0bc4f21d23f5d19586593"
+  integrity sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 stackframe@^1.1.1:
   version "1.2.0"
@@ -15180,10 +15209,41 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1, yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,7 +356,7 @@
   dependencies:
     "@babel/types" "^7.10.3"
 
-"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.7.4", "@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
   integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
@@ -1823,10 +1823,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.4", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.4.tgz#a6724f1a6b8d2f6ea5236dbfe58c7d7ea9c5eb99"
   integrity sha512-UpTN5yUJr9b4EX2CnGNWIvER7Ab83ibv0pcvvHc4UOdrBI5jb8bj+32cCwPX6xu0mt2daFNjYhoi+X7beH0RSw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.4":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2132,12 +2139,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -2549,17 +2551,17 @@
     physical-cpu-count "^2.0.0"
 
 "@rollup/plugin-babel@^5.0.4":
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.0.4.tgz#dbfcf86a0561e399579ceb1a534a83c970e76645"
-  integrity sha512-MBtNoi5gqBEbqy1gE9jZBfPsi10kbuK2CEu9bx53nk1Z3ATRvBOoZ/GsbhXOeVbS76xXi/DeYM+vYX6EGIDv9A==
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.2.1.tgz#20fc8f8864dc0eaa1c5578408459606808f72924"
+  integrity sha512-Jd7oqFR2dzZJ3NWANDyBjwTtX/lYbZpVcmkHrfQcpvawHs9E4c0nYk5U2mfZ6I/DZcIvy506KZJi54XK/jxH7A==
   dependencies:
-    "@babel/helper-module-imports" "^7.7.4"
-    "@rollup/pluginutils" "^3.0.8"
+    "@babel/helper-module-imports" "^7.10.4"
+    "@rollup/pluginutils" "^3.1.0"
 
 "@rollup/plugin-commonjs@^13.0.0":
-  version "13.0.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.0.tgz#8a1d684ba6848afe8b9e3d85649d4b2f6f7217ec"
-  integrity sha512-Anxc3qgkAi7peAyesTqGYidG5GRim9jtg8xhmykNaZkImtvjA7Wsqep08D2mYsqw1IF7rA3lYfciLgzUSgRoqw==
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-13.0.2.tgz#b7783f0db049450c72d60bc06cf48d4951515e58"
+  integrity sha512-9JXf2k8xqvMYfqmhgtB6eCgMN9fbxwF1XDF3mGKJc6pkAmt0jnsqurxQ0tC1akQKNSXCm7c3unQxa3zuxtZ7mQ==
   dependencies:
     "@rollup/pluginutils" "^3.0.8"
     commondir "^1.0.1"
@@ -2570,19 +2572,19 @@
     resolve "^1.11.0"
 
 "@rollup/plugin-node-resolve@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.1.0.tgz#1da5f3d0ccabc8f66f5e3c74462aad76cfd96c47"
-  integrity sha512-ovq7ZM3JJYUUmEjjO+H8tnUdmQmdQudJB7xruX8LFZ1W2q8jXdPUS6SsIYip8ByOApu4RR7729Am9WhCeCMiHA==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-8.4.0.tgz#261d79a680e9dc3d86761c14462f24126ba83575"
+  integrity sha512-LFqKdRLn0ShtQyf6SBYO69bGE1upV6wUhBX0vFOUnLAyzx5cwp8svA0eHUnu8+YU57XOkrMtfG63QOpQx25pHQ==
   dependencies:
-    "@rollup/pluginutils" "^3.0.8"
-    "@types/resolve" "0.0.8"
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
     builtin-modules "^3.1.0"
     deep-freeze "^0.0.1"
     deepmerge "^4.2.2"
     is-module "^1.0.0"
-    resolve "^1.14.2"
+    resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.0.8":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
@@ -2954,10 +2956,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -9516,7 +9518,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -12679,7 +12681,7 @@ resolve@1.15.0:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
+resolve@^1.1.5, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.15.1, resolve@^1.17.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -12781,10 +12783,10 @@ rollup-plugin-inject-process-env@^1.3.0:
   dependencies:
     magic-string "^0.25.7"
 
-rollup@^2.23.0:
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.23.0.tgz#b7ab1fee0c0e60132fd0553c4df1e9cdacfada9d"
-  integrity sha512-vLNmZFUGVwrnqNAJ/BvuLk1MtWzu4IuoqsH9UWK5AIdO3rt8/CSiJNvPvCIvfzrbNsqKbNzPAG1V2O4eTe2XZg==
+rollup@^2.28.2:
+  version "2.28.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.28.2.tgz#599ec4978144a82d8a8ec3d37670a8440cb04e4b"
+  integrity sha512-8txbsFBFLmm9Xdt4ByTOGa9Muonmc8MfNjnGAR8U8scJlF1ZW7AgNZa7aqBXaKtlvnYP/ab++fQIq9dB9NWUbg==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -15178,7 +15180,7 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1:
+yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
@@ -15246,7 +15248,7 @@ yargs@^14.0.0:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.0, yargs@^15.3.1:
+yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.1:
   version "15.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.3.1.tgz#9505b472763963e54afe60148ad27a330818e98b"
   integrity sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==
@@ -15262,6 +15264,23 @@ yargs@^15.0.2, yargs@^15.1.0, yargs@^15.3.0, yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yargs@^15.3.0:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
![aaa](https://user-images.githubusercontent.com/118328/94714078-87bdff00-0343-11eb-907e-02a97ab2b151.gif)

This is not a complete PR, I would appreciate feedback first before proceeding.

I've not written any tests until I know that this is an agreed approach.

While looking at #321 it became apparent that we need a reporting or logging abstraction.

If we want to stream logs, buffer or output to things other than console then we need an abstraction around outputting info.

I've created a `Reporter` class

```ts
export class Reporter implements Pick<Out, LogCategory> {
  constructor(private out: Out) {}

  debug(...args: unknown[]) {
    this.out.debug(args);
  }

  info(...args: unknown[]) {
    this.out.info(args);
  }

  warn(...args: unknown[]) {
    this.out.warn(args);
  }

  success(...args: unknown[]) {
    this.out.success(args);
  }

  error(error: string | Error | BundlerError) {
    this.out.error(error);
  }

  clear() {
   this.out.clear(); 
  }
}
```

The `Reporter` uses containment and not inheritance for different output options such as a console outputter. 

The `Reporter` takes an `out` object in its constructor that can output to the console or a Buffer or a whatever.

Currently, there is only a `ConsoleOut` class that abstracts away `stdout` and `stderr`.

The reporter would have methods such as `progressBar` also for console, HTML etc. 


