### PR TITLE
Restructure interactor definitions, remove custom locators

### DIFF
--- a/.changeset/funny-rats-shake.md
+++ b/.changeset/funny-rats-shake.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": patch
+---
+
+"did you mean" suggestions always render as a table, rather than an inline comma separated list

--- a/.changeset/green-pigs-swim.md
+++ b/.changeset/green-pigs-swim.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Remove support for custom locators

--- a/.changeset/nice-candles-listen.md
+++ b/.changeset/nice-candles-listen.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Filters can be passed to interactor even if locator is omitted, e.g. Button({ id: "foo" })

--- a/.changeset/selfish-feet-heal.md
+++ b/.changeset/selfish-feet-heal.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+InteractorSpecification is a concrete type, parameterized over its actions and filters, rather than an interface, disallows incorrect options in interactor definition

--- a/.changeset/tall-houses-pull.md
+++ b/.changeset/tall-houses-pull.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Rename defaultLocator to locator

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,5 +1,5 @@
 import { bigtestGlobals } from '@bigtest/globals';
-import { InteractorSpecification, FilterImplementation, InteractorInstance, InteractorType, LocatorFn, InteractorConstructor } from './specification';
+import { InteractorSpecification, FilterParams, Filters, Actions, InteractorInstance, LocatorFn } from './specification';
 import { Locator } from './locator';
 import { Filter } from './filter';
 import { Interactor } from './interactor';
@@ -9,8 +9,8 @@ import { converge } from './converge';
 const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
 
 export function createInteractor<E extends Element>(interactorName: string) {
-  return function<S extends InteractorSpecification<E>>(specification: S): InteractorType<E, S> {
-    let InteractorClass = class extends Interactor<E, S> {};
+  return function<F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>) {
+    let InteractorClass = class extends Interactor<E, F, A> {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {
@@ -34,27 +34,20 @@ export function createInteractor<E extends Element>(interactorName: string) {
       });
     }
 
-    let result: InteractorConstructor<E, S> = function(value?: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
-      let locator = value ? new Locator(specification.defaultLocator || defaultLocator, value) : new Locator();
-      let filter = new Filter(specification, filters || {});
-      let interactor = new InteractorClass(interactorName, specification, locator, filter);
-      return interactor as InteractorInstance<E, S>;
+    function initInteractor(filters?: FilterParams<E, F>): InteractorInstance<E, F, A>;
+    function initInteractor(value: string, filters?: FilterParams<E, F>): InteractorInstance<E, F, A>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function initInteractor(...args: any[]) {
+      let locator, filter;
+      if(typeof(args[0]) === 'string') {
+        locator = new Locator(specification.locator || defaultLocator, args[0]);
+        filter = new Filter(specification, args[1] || {});
+      } else {
+        filter = new Filter(specification, args[0] || {});
+      }
+      return new InteractorClass(interactorName, specification, filter, locator) as InteractorInstance<E, F, A>;
     }
 
-    for(let [locatorName, locatorFn] of Object.entries(specification.locators || {})) {
-      Object.defineProperty(result, locatorName, {
-        value: function(value: string, filters?: FilterImplementation<E, S>): InteractorInstance<E, S> {
-          let locator = new Locator(locatorFn, value, locatorName);
-          let filter = new Filter(specification, filters || {});
-          let interactor = new InteractorClass(interactorName, specification, locator, filter);
-          return interactor as InteractorInstance<E, S>;
-        },
-        configurable: true,
-        writable: true,
-        enumerable: false,
-      });
-    }
-
-    return result as InteractorType<E, S>;
+    return initInteractor;
   }
 }

--- a/packages/interactor/src/definitions/button.ts
+++ b/packages/interactor/src/definitions/button.ts
@@ -6,7 +6,7 @@ function isButtonElement(element: HTMLInputElement | HTMLButtonElement): element
 
 export const Button = createInteractor<HTMLInputElement | HTMLButtonElement>('button')({
   selector: 'button,input[type=button],input[type=submit],input[type=reset],input[type=image]',
-  defaultLocator(element) {
+  locator(element) {
     if(isButtonElement(element)) {
       return element.textContent || '';
     } else if(element.type === 'image') {
@@ -14,10 +14,6 @@ export const Button = createInteractor<HTMLInputElement | HTMLButtonElement>('bu
     } else {
       return element.value;
     }
-  },
-  locators: {
-    byId: (element) => element.id,
-    byTitle: (element) => element.title,
   },
   filters: {
     title: (element) => element.title,

--- a/packages/interactor/src/definitions/heading.ts
+++ b/packages/interactor/src/definitions/heading.ts
@@ -2,9 +2,6 @@ import { createInteractor } from '../create-interactor';
 
 export const Heading = createInteractor<HTMLHeadingElement>('heading')({
   selector: 'h1,h2,h3,h4,h5,h6',
-  locators: {
-    byId: (element) => element.id
-  },
   filters: {
     level: (element) => parseInt(element.tagName[1])
   }

--- a/packages/interactor/src/definitions/link.ts
+++ b/packages/interactor/src/definitions/link.ts
@@ -2,10 +2,6 @@ import { createInteractor, perform } from '../index';
 
 export const Link = createInteractor<HTMLLinkElement>('link')({
   selector: 'a[href]',
-  locators: {
-    byId: (element) => element.id,
-    byTitle: (element) => element.title,
-  },
   filters: {
     title: (element) => element.title,
     href: (element) => element.href,

--- a/packages/interactor/src/definitions/text-field.ts
+++ b/packages/interactor/src/definitions/text-field.ts
@@ -2,12 +2,7 @@ import { createInteractor, perform, fillIn } from '../index';
 
 export const TextField = createInteractor<HTMLInputElement>('text field')({
   selector: 'input:not([type]),input[type=text]',
-  defaultLocator: (element) => element.labels ? (Array.from(element.labels)[0]?.textContent || '') : '',
-  locators: {
-    byId: (element) => element.id,
-    byTitle: (element) => element.title,
-    byPlaceholder: (element) => element.placeholder,
-  },
+  locator: (element) => element.labels ? (Array.from(element.labels)[0]?.textContent || '') : '',
   filters: {
     title: (element) => element.title,
     id: (element) => element.id,

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -1,11 +1,11 @@
 export type LocatorFn<E extends Element> = (element: E) => string;
-import { FilterImplementation, InteractorSpecification } from './specification';
+import { Filters, FilterFn, FilterObject, Actions, FilterParams, InteractorSpecification } from './specification';
 import { noCase } from 'change-case';
 
-export class Filter<E extends Element, S extends InteractorSpecification<E>> {
+export class Filter<E extends Element, F extends Filters<E>, A extends Actions<E>> {
   constructor(
-    public specification: S,
-    public filters: FilterImplementation<E, S>
+    public specification: InteractorSpecification<E, F, A>,
+    public filters: FilterParams<E, F>,
   ) {};
 
   get description(): string {
@@ -27,15 +27,15 @@ export class Filter<E extends Element, S extends InteractorSpecification<E>> {
     }
   }
 
-  get all(): FilterImplementation<E, S> {
+  get all(): FilterParams<E, F> {
     let filter: Record<string, unknown> = Object.assign({}, this.filters);
     for(let key in this.specification.filters) {
-      let definition = this.specification.filters[key];
+      let definition = this.specification.filters[key] as FilterFn<unknown, E> | FilterObject<unknown, E>;
       if(!(key in this.filters) && typeof(definition) !== 'function' && 'default' in definition) {
         filter[key] = definition.default;
       }
     }
-    return filter as FilterImplementation<E, S>;
+    return filter as FilterParams<E, F>;
   }
 
   asTableHeader(): string[] {

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,26 +1,9 @@
-import { LocatorFn, NullLocatorFn } from './specification';
-import { noCase } from 'change-case';
+import { LocatorFn } from './specification';
 
 export class Locator<E extends Element> {
-  public locatorFn: LocatorFn<E> | NullLocatorFn;
-  public value: string | null;
-  public name: string | null;
-  public isNull: boolean;
-
-  constructor();
-  constructor(locatorFn: LocatorFn<E>, value: string, name?: string);
-  constructor(locatorFn?: LocatorFn<E>, value?: string | null, name?: string) {
-    this.locatorFn = locatorFn || (() => null);
-    this.value = value || null;
-    this.name = name || null;
-    this.isNull = this.value == null;
-  }
+  constructor(public locatorFn: LocatorFn<E>, public value: string) {}
 
   get description(): string {
-    if(this.name) {
-      return `${noCase(this.name)} ${JSON.stringify(this.value)}`;
-    } else {
-      return `${JSON.stringify(this.value)}`;
-    }
+    return `${JSON.stringify(this.value)}`;
   }
 }

--- a/packages/interactor/src/perform.ts
+++ b/packages/interactor/src/perform.ts
@@ -1,10 +1,10 @@
 import { Interactor } from "./interactor";
-import { InteractorSpecification } from "./specification";
+import { Filters, Actions } from "./specification";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function perform<E extends Element, S extends InteractorSpecification<E>, A extends any[]>(fn: (element: E, ...args: A) => void) {
+export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends any[]>(fn: (element: E, ...args: T) => void) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (interactor: Interactor<E, S>, ...args: A) => interactor.perform(element => {
+  return (interactor: Interactor<E, F, A>, ...args: T) => interactor.perform(element => {
     fn(element, ...args);
   });
 }

--- a/packages/interactor/src/resolve.ts
+++ b/packages/interactor/src/resolve.ts
@@ -6,10 +6,9 @@ import { formatTable } from './format-table';
 const defaultSelector = 'div';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function resolve(parentElement: Element, interactor: Interactor<any, any>) {
+export function resolve(parentElement: Element, interactor: Interactor<any, any, any>) {
   let elements = Array.from(parentElement.querySelectorAll(interactor.specification.selector || defaultSelector));
-  let matches = elements.map((e) => new Match(interactor.locator, interactor.filter, e));
-  let located = matches.filter((m) => m.matchLocator.matches);
+  let matches = elements.map((e) => new Match(e, interactor.filter, interactor.locator));
   let matching = matches.filter((m) => m.matches);
 
   if(matching.length === 1) {
@@ -17,22 +16,13 @@ export function resolve(parentElement: Element, interactor: Interactor<any, any>
   } else if(matching.length > 1) {
     let alternatives = matching.map((m) => '- ' + m.elementDescription());
     throw new AmbiguousElementError(`${interactor.description} matches multiple elements:\n\n${alternatives.join('\n')}`);
-  } else if(elements.length === 0) {
+  } else if(matches.length === 0) {
     throw new NoSuchElementError(`did not find ${interactor.description}`);
   } else {
-    if(located.length === 0) {
-      if(matches.length === 1) {
-        throw new NoSuchElementError(`did not find ${interactor.description}, did you mean ${matches[0].matchLocator.formatActual()}?`);
-      } else {
-        let alternatives = matches.map((m) => m.matchLocator.formatActual()).join(', ');
-        throw new NoSuchElementError(`did not find ${interactor.description}, did you mean one of ${alternatives}?`);
-      }
-    } else {
-      let table = formatTable({
-        headers: [interactor.name, ...interactor.filter.asTableHeader()],
-        rows: matches.slice().sort((a, b) => b.sortWeight - a.sortWeight).map((m) => m.asTableRow()),
-      });
-      throw new NoSuchElementError(`did not find ${interactor.description}, did you mean one of:\n\n${table}`);
-    }
+    let table = formatTable({
+      headers: interactor.locator ? [interactor.name, ...interactor.filter.asTableHeader()] : interactor.filter.asTableHeader(),
+      rows: matches.slice().sort((a, b) => b.sortWeight - a.sortWeight).map((m) => m.asTableRow()),
+    });
+    throw new NoSuchElementError(`did not find ${interactor.description}, did you mean one of:\n\n${table}`);
   }
 }

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -1,56 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { Interactor } from './interactor';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type ActionFn<E extends Element, S extends InteractorSpecification<E>> = (interactor: InteractorInstance<E, S>, ...args: any[]) => unknown;
-
-export type LocatorFn<E extends Element> = (element: E) => string;
-
-export type NullLocatorFn = () => null;
+export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}>, ...args: any[]) => unknown;
 
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
-export interface FilterObject<T, E extends Element> {
+export type LocatorFn<E extends Element> = (element: E) => string;
+
+export type FilterObject<T, E extends Element> = {
   apply: FilterFn<T, E>;
   default?: T;
 }
 
-export type LocatorSpecification<E extends Element> = Record<string, LocatorFn<E>>;
+export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>
 
-export type FilterSpecification<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>
+export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 
-export type ActionSpecification<E extends Element, S extends InteractorSpecification<E>> = Record<string, ActionFn<E, S>>;
-
-export interface InteractorSpecification<E extends Element> {
+export type InteractorSpecification<E extends Element, F extends Filters<E>, A extends Actions<E>> = {
   selector?: string;
-  defaultLocator?: LocatorFn<E>;
-  locators?: LocatorSpecification<E>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actions?: ActionSpecification<E, any>;
-  filters?: FilterSpecification<E>;
+  actions?: A;
+  filters?: F;
+  locator?: LocatorFn<E>;
 }
 
-export type ActionImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['actions']]: S['actions'][P] extends ((interactor: InteractorInstance<E, S>, ...args: infer TArgs) => infer TReturn)
+export type ActionMethods<E extends Element, A extends Actions<E>> = {
+  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}>, ...args: infer TArgs) => infer TReturn)
     ? ((...args: TArgs) => TReturn)
     : never;
 }
 
-export type FilterImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['filters']]?:
-    S['filters'][P] extends FilterFn<infer TArg, E> ?
+export type FilterParams<E extends Element, F extends Filters<E>> = {
+  [P in keyof F]?:
+    F[P] extends FilterFn<infer TArg, E> ?
     TArg :
-    S['filters'][P] extends FilterObject<infer TArg, E> ?
+    F[P] extends FilterObject<infer TArg, E> ?
     TArg :
     never;
 }
 
-export type LocatorImplementation<E extends Element, S extends InteractorSpecification<E>> = {
-  [P in keyof S['locators']]: (value: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>
-}
-
-export type InteractorInstance<E extends Element, S extends InteractorSpecification<E>> = Interactor<E, S> & ActionImplementation<E, S>;
-
-export type InteractorConstructor<E extends Element, S extends InteractorSpecification<E>> =
-  (value?: string, filters?: FilterImplementation<E, S>) => InteractorInstance<E, S>;
-
-export type InteractorType<E extends Element, S extends InteractorSpecification<E>> = InteractorConstructor<E, S> & LocatorImplementation<E, S>;
+export type InteractorInstance<E extends Element, F extends Filters<E>, A extends Actions<E>> = Interactor<E, F, A> & ActionMethods<E, A>;

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -30,7 +30,7 @@ export type ActionMethods<E extends Element, A extends Actions<E>> = {
     : never;
 }
 
-export type FilterParams<E extends Element, F extends Filters<E>> = {
+export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {
   [P in keyof F]?:
     F[P] extends FilterFn<infer TArg, E> ?
     TArg :

--- a/packages/interactor/test/definitions/button.test.ts
+++ b/packages/interactor/test/definitions/button.test.ts
@@ -55,31 +55,6 @@ describe('@bigtest/interactor', () => {
       await expect(Button('Does not Exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
-    describe('.byId', () => {
-      it('finds `button` and `input` tags by id', async () => {
-        dom(`
-          <p><button id="foo-button">Foo</a></p>
-          <p><input type="button" id="bar-button" value="bar"/></p>
-        `);
-
-        await expect(Button.byId('foo-button').exists()).resolves.toBeUndefined();
-        await expect(Button.byId('bar-button').exists()).resolves.toBeUndefined();
-        await expect(Button.byId('does-not-exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
-    describe('.byTitle', () => {
-      it('finds `button` tags by their title', async () => {
-        dom(`
-          <p><button title="My Foo Button">Foo</button></p>
-          <p><input type="button" title="My Bar Button" value="Bar"/></p>
-        `);
-
-        await expect(Button.byTitle('My Foo Button').exists()).resolves.toBeUndefined();
-        await expect(Button.byTitle('Does not exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
     describe('.click', () => {
       it('clicks on button', async () => {
         dom(`

--- a/packages/interactor/test/definitions/link.test.ts
+++ b/packages/interactor/test/definitions/link.test.ts
@@ -23,30 +23,6 @@ describe('@bigtest/interactor', () => {
       await expect(Link('Foo').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
-    describe('.byId', () => {
-      it('finds `a` tags by id', async () => {
-        dom(`
-          <p><a href="/foo" id="foo-link">Foo</a></p>
-          <p><a href="/bar" id="bar-link">Bar</a></p>
-        `);
-
-        await expect(Link.byId('foo-link').exists()).resolves.toBeUndefined();
-        await expect(Link.byId('does-not-exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
-    describe('.byTitle', () => {
-      it('finds `a` tags by their title', async () => {
-        dom(`
-          <p><a href="/foo" title="My Foo Link">Foo</a></p>
-          <p><a href="/bar" title="My Bar Link">Bar</a></p>
-        `);
-
-        await expect(Link.byTitle('My Foo Link').exists()).resolves.toBeUndefined();
-        await expect(Link.byTitle('Does not exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
     describe('.click', () => {
       it('clicks on link', async () => {
         dom(`

--- a/packages/interactor/test/definitions/text-field.test.ts
+++ b/packages/interactor/test/definitions/text-field.test.ts
@@ -34,39 +34,6 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Designation').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
-    describe('.byId', () => {
-      it('finds `input` tags by id', async () => {
-        dom(`
-          <p><input type="text" id="name-field"/></p>
-        `);
-
-        await expect(TextField.byId('name-field').exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('does-not-exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
-    describe('.byTitle', () => {
-      it('finds `input` tags by their title', async () => {
-        dom(`
-          <p><input type="text" title="My Name Field" value="Bar"/></p>
-        `);
-
-        await expect(TextField.byTitle('My Name Field').exists()).resolves.toBeUndefined();
-        await expect(TextField.byTitle('Does not exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
-    describe('.byPlaceholder', () => {
-      it('finds `input` tags by their placeholder', async () => {
-        dom(`
-          <p><input type="text" placeholder="My Name Field" value="Bar"/></p>
-        `);
-
-        await expect(TextField.byPlaceholder('My Name Field').exists()).resolves.toBeUndefined();
-        await expect(TextField.byPlaceholder('Does not exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-      });
-    });
-
     describe('.click', () => {
       it('clicks on field', async () => {
         dom(`
@@ -157,10 +124,10 @@ describe('@bigtest/interactor', () => {
           <p><input id="address-field"/></p>
         `);
 
-        await expect(TextField.byId('name-field', { disabled: true }).exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('address-field', { disabled: false }).exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('name-field', { disabled: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-        await expect(TextField.byId('address-field', { disabled: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(TextField({ id: 'name-field', disabled: true }).exists()).resolves.toBeUndefined();
+        await expect(TextField({ id: 'address-field', disabled: false }).exists()).resolves.toBeUndefined();
+        await expect(TextField({ id: 'name-field', disabled: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(TextField({ id: 'address-field', disabled: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
 
       it('defaults to only enabled', async () => {
@@ -169,8 +136,8 @@ describe('@bigtest/interactor', () => {
           <p><input id="address-field"/></p>
         `);
 
-        await expect(TextField.byId('address-field').exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('name-field').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(TextField({ id: 'address-field' }).exists()).resolves.toBeUndefined();
+        await expect(TextField({ id: 'name-field' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
 
@@ -225,10 +192,10 @@ describe('@bigtest/interactor', () => {
           </p>
         `);
 
-        await expect(TextField.byId('name-field', { valid: true }).exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('address-field', { valid: false }).exists()).resolves.toBeUndefined();
-        await expect(TextField.byId('name-field', { valid: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
-        await expect(TextField.byId('address-field', { valid: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(TextField({ id: 'name-field', valid: true }).exists()).resolves.toBeUndefined();
+        await expect(TextField({ id: 'address-field', valid: false }).exists()).resolves.toBeUndefined();
+        await expect(TextField({ id: 'name-field', valid: false }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+        await expect(TextField({ id: 'address-field', valid: true }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
   });

--- a/packages/interactor/types/create-interactor.ts
+++ b/packages/interactor/types/create-interactor.ts
@@ -2,10 +2,6 @@ import { createInteractor, perform } from '../src/index';
 
 const Link = createInteractor<HTMLLinkElement>('link')({
   selector: 'a',
-  locators: {
-    byHref: (element) => element.href,
-    byTitle: (element) => element.title
-  },
   actions: {
     click: perform(element => { element.click() }),
     setHref: perform((element, value: string) => { element.href = value })
@@ -13,8 +9,12 @@ const Link = createInteractor<HTMLLinkElement>('link')({
 });
 
 const Div = createInteractor('div')({
-  defaultLocator: (element) => element.id || "",
+  locator: (element) => element.id || "",
 });
+
+// cannot pass invalid options
+// $ExpectError
+createInteractor<HTMLLinkElement>('whatever')({ foo: "bar" });
 
 Link('foo').click();
 
@@ -29,17 +29,7 @@ Link('foo').setHref(123);
 Div('foo').click();
 
 // $ExpectError
+Link('foo').blah();
+
+// $ExpectError
 Div('foo').blah();
-
-Link.byHref('foobar');
-
-// cannot use wrong type argument on locator
-// $ExpectError
-Link.byHref(123);
-
-// cannot use locator which is not defined
-// $ExpectError
-Div.byHref('foobar');
-
-// $ExpectError
-Div.moo('foobar');

--- a/packages/interactor/types/dsl.ts
+++ b/packages/interactor/types/dsl.ts
@@ -3,7 +3,7 @@ import { createInteractor, perform } from '../src/index';
 
 const TextField = createInteractor<HTMLInputElement>('text field')({
   selector: 'input',
-  defaultLocator: (element) => element.id,
+  locator: (element) => element.id,
   filters: {
     enabled: {
       apply: (element) => !element.disabled,

--- a/packages/interactor/types/filters.ts
+++ b/packages/interactor/types/filters.ts
@@ -72,5 +72,5 @@ TextField('foo').has({ value: 123 });
 TextField('foo').has({ blah: 'thing' });
 
 // cannot use filter on interactor which has no filters
-// FIXME: this should be disallowed!
+// $ExpectError
 Div('foo').has({ blah: 'thing' });

--- a/packages/interactor/types/filters.ts
+++ b/packages/interactor/types/filters.ts
@@ -2,7 +2,7 @@ import { createInteractor, perform } from '../src/index';
 
 const TextField = createInteractor<HTMLInputElement>('text field')({
   selector: 'input',
-  defaultLocator: (element) => element.id,
+  locator: (element) => element.id,
   filters: {
     enabled: {
       apply: (element) => !element.disabled,
@@ -13,6 +13,10 @@ const TextField = createInteractor<HTMLInputElement>('text field')({
   actions: {
     fillIn: perform((element, value: string) => { element.value = value })
   }
+});
+
+const Div = createInteractor('div')({
+  locator: (element) => element.id || "",
 });
 
 TextField('foo', { enabled: true, value: 'thing' });
@@ -35,6 +39,9 @@ TextField('foo', { value: 123 });
 
 // $ExpectError
 TextField('foo', { blah: 'thing' });
+
+// $ExpectError
+TextField({ blah: 'thing' });
 
 // cannot use wrong type of filter with is
 
@@ -63,3 +70,7 @@ TextField('foo').has({ value: 123 });
 
 // $ExpectError
 TextField('foo').has({ blah: 'thing' });
+
+// cannot use filter on interactor which has no filters
+// FIXME: this should be disallowed!
+Div('foo').has({ blah: 'thing' });


### PR DESCRIPTION
Closes #573
Closes #513

This makes a number of changes to interactors:

- Removes support for custom locators
- Rename `defaultLocator` to `locator`
- Filters can be passed to interactor even if locator is omitted, e.g. `Button({ id: "foo" })`
- InteractorSpecification is a concrete type, parameterized over its actions and filters, rather than an interface, disallows incorrect options in interactor definition
- "did you mean" suggestions always render as a table, rather than an inline comma separated list