### PR TITLE
Improve formatting of stack traces

### DIFF
--- a/.changeset/serious-feet-hunt.md
+++ b/.changeset/serious-feet-hunt.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": patch
+"bigtest": patch
+---
+
+Improve formatting of stack traces

--- a/packages/cli/src/format-helpers.ts
+++ b/packages/cli/src/format-helpers.ts
@@ -49,9 +49,9 @@ export function errorLines(error: ErrorDetails): string[] {
       if(stackFrame.name) {
         stackLine += ` @ ${stackFrame.name}`;
       }
-      errorLines.push(stackLine);
+      errorLines.push(chalk.grey(stackLine));
       if(stackFrame.code) {
-        errorLines.push('  > ' + stackFrame.code.trim());
+        errorLines.push(chalk.white('    ' + stackFrame.code.trim()));
       }
     }
   }


### PR DESCRIPTION
Make stack traces easier to read by using better spacing and color.

Before

<img width="879" alt="Screenshot 2020-10-05 at 13 46 30" src="https://user-images.githubusercontent.com/134/95075857-39c54480-0711-11eb-934d-1773981eba54.png">

After

<img width="895" alt="Screenshot 2020-10-05 at 13 46 36" src="https://user-images.githubusercontent.com/134/95075870-3d58cb80-0711-11eb-8075-793c6f95a88a.png">
