### PR TITLE
Show log events when running with `--show-log`

### DIFF
--- a/.changeset/few-rats-live.md
+++ b/.changeset/few-rats-live.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/cli": minor
+"bigtest": minor
+"@bigtest/agent": patch
+---
+
+Print log output when running with --show-log

--- a/packages/agent/app/serialize-error.ts
+++ b/packages/agent/app/serialize-error.ts
@@ -64,10 +64,10 @@ export function *serializeError(error: unknown): Operation<ErrorDetails> {
       return { name: error.name, message: error.message, stack: resolvedStackFrames };
     } else {
       return {
-        message: `${error}`
+        message: error ? `${error}` : 'unknown error'
       }
     }
   } catch {
-    return { message: "unknown error" }
+    return { message: 'unknown error' }
   }
 }

--- a/packages/cli/src/printer.ts
+++ b/packages/cli/src/printer.ts
@@ -2,14 +2,14 @@ import * as os from 'os';
 import * as chalk from 'chalk';
 import { Writable } from 'stream';
 
-type Color = 'red' | 'grey' | 'white' | 'yellow' | 'green';
+type Color = 'red' | 'grey' | 'white' | 'yellow' | 'green' | 'blue';
 
 export class Printer {
-  constructor(public stream: Writable, public linePrefix = '', public colorValue?: Color) {
+  constructor(public stream: Writable, public basePrefix = '', public trailingPrefix = basePrefix, public colorValue?: Color) {
   }
 
   write(...text: string[]) {
-    let result = text.join('').split(/\r?\n(?!$)/).map((l) => this.linePrefix + l).join(os.EOL).replace(/\r?\n$/, os.EOL);
+    let result = text.join('').split(/\r?\n(?!$)/).map((l, index) => (index === 0 ? this.basePrefix : this.trailingPrefix) + l).join(os.EOL).replace(/\r?\n$/, os.EOL);
     if(this.colorValue) {
       result = chalk[this.colorValue](result);
     }
@@ -24,8 +24,8 @@ export class Printer {
     this.write(words.filter(Boolean).join(' '), os.EOL);
   }
 
-  prefix(newPrefix: string): Printer {
-    return new Printer(this.stream, this.linePrefix + newPrefix, this.colorValue);
+  prefix(basePrefix: string, trailingPrefix = basePrefix): Printer {
+    return new Printer(this.stream, this.basePrefix + basePrefix, this.trailingPrefix + trailingPrefix, this.colorValue);
   }
 
   indent(count = 1): Printer {
@@ -33,7 +33,7 @@ export class Printer {
   }
 
   color(value: Color): Printer {
-    return new Printer(this.stream, this.linePrefix, value);
+    return new Printer(this.stream, this.basePrefix, this.trailingPrefix, value);
   }
 
   get red() { return this.color('red'); }
@@ -41,4 +41,5 @@ export class Printer {
   get white() { return this.color('white'); }
   get yellow() { return this.color('yellow'); }
   get green() { return this.color('green'); }
+  get blue() { return this.color('blue'); }
 }


### PR DESCRIPTION
We have all of the infrastructure for this in place, aside from actually printing them. The hardest part here is finding a design for this which is comprehensible and doesn't look like trash. Would love some feedback on this.

<img width="1202" alt="Screenshot 2020-10-09 at 11 40 43" src="https://user-images.githubusercontent.com/134/95568269-4ead1b00-0a24-11eb-9e3e-8873c65f780f.png">

The reason it prints "unknown error" is due to #589, if we fix that issue the error should be shown with its proper message and stack trace.