### PR TITLE
Introduce Printer, an abstraction to simplify formatters

### DIFF
--- a/.changeset/spotty-buttons-appear.md
+++ b/.changeset/spotty-buttons-appear.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/cli": minor
+---
+
+Introduce printer to simplify formatting code, formatter constructor takes printer as an argument

--- a/packages/cli/src/formatters/checks.ts
+++ b/packages/cli/src/formatters/checks.ts
@@ -1,6 +1,6 @@
-import { FormatterConstructor, statusIcon, standardFooter } from '../format-helpers';
+import { FormatterConstructor, statusIcon, printStandardFooter } from '../format-helpers';
 
-const formatter: FormatterConstructor = () => {
+const formatter: FormatterConstructor = (printer) => {
   let didGetResult = false;
   return {
     header() {
@@ -10,14 +10,17 @@ const formatter: FormatterConstructor = () => {
     event(event) {
       if((event.type === 'step:result' || event.type === 'assertion:result') && event.status) {
         didGetResult = true;
-        process.stdout.write(statusIcon(event.status));
+        printer.write(statusIcon(event.status));
       }
       if(event.type === 'testRun:result' && didGetResult) {
-        process.stdout.write('\n\n');
+        printer.line();
+        printer.line();
       }
     },
 
-    footer: standardFooter()
+    footer(results) {
+      printStandardFooter(printer, results);
+    }
   }
 };
 

--- a/packages/cli/src/formatters/lines.ts
+++ b/packages/cli/src/formatters/lines.ts
@@ -1,21 +1,25 @@
 import * as chalk from 'chalk';
-import { Formatter, stepStatusIcon, assertionStatusIcon, standardFooter } from '../format-helpers';
+import { FormatterConstructor, stepStatusIcon, assertionStatusIcon, printStandardFooter } from '../format-helpers';
 
-const formatter: Formatter = {
-  header() {
-    // no op
-  },
+const formatter: FormatterConstructor = (printer) => {
+  return {
+    header() {
+      // no op
+    },
 
-  event(event) {
-    if(event.type === 'step:result' && event.status) {
-      console.log(`${stepStatusIcon(event.status)} ${chalk.grey(event.agentId + ':')} ${event.path?.slice(1).join(chalk.grey(' → '))}`);
+    event(event) {
+      if(event.type === 'step:result' && event.status) {
+        printer.words(stepStatusIcon(event.status), chalk.grey(event.agentId + ':'), event.path?.slice(1).join(chalk.grey(' → ')));
+      }
+      if(event.type === 'assertion:result' && event.status) {
+        printer.words(assertionStatusIcon(event.status), chalk.grey(event.agentId + ':'), event.path?.slice(1).join(chalk.grey(' → ')));
+      }
+    },
+
+    footer(results) {
+      printStandardFooter(printer, results);
     }
-    if(event.type === 'assertion:result' && event.status) {
-      console.log(`${assertionStatusIcon(event.status)} ${chalk.grey(event.agentId + ':')} ${event.path?.slice(1).join(chalk.grey(' → '))}`);
-    }
-  },
-
-  footer: standardFooter()
+  }
 };
 
 export default formatter;

--- a/packages/cli/src/printer.ts
+++ b/packages/cli/src/printer.ts
@@ -1,0 +1,44 @@
+import * as os from 'os';
+import * as chalk from 'chalk';
+import { Writable } from 'stream';
+
+type Color = 'red' | 'grey' | 'white' | 'yellow' | 'green';
+
+export class Printer {
+  constructor(public stream: Writable, public linePrefix = '', public colorValue?: Color) {
+  }
+
+  write(...text: string[]) {
+    let result = text.join('').split(/\r?\n(?!$)/).map((l) => this.linePrefix + l).join(os.EOL).replace(/\r?\n$/, os.EOL);
+    if(this.colorValue) {
+      result = chalk[this.colorValue](result);
+    }
+    this.stream.write(result);
+  }
+
+  line(...lines: string[]) {
+    this.write(lines.join(os.EOL) + os.EOL);
+  }
+
+  words(...words: (string | undefined)[]) {
+    this.write(words.filter(Boolean).join(' '), os.EOL);
+  }
+
+  prefix(newPrefix: string): Printer {
+    return new Printer(this.stream, this.linePrefix + newPrefix, this.colorValue);
+  }
+
+  indent(count = 1): Printer {
+    return this.prefix('  '.repeat(count));
+  }
+
+  color(value: Color): Printer {
+    return new Printer(this.stream, this.linePrefix, value);
+  }
+
+  get red() { return this.color('red'); }
+  get grey() { return this.color('grey'); }
+  get white() { return this.color('white'); }
+  get yellow() { return this.color('yellow'); }
+  get green() { return this.color('green'); }
+}

--- a/packages/cli/src/run-test.ts
+++ b/packages/cli/src/run-test.ts
@@ -4,6 +4,7 @@ import { ProjectOptions } from '@bigtest/project';
 import { Client } from '@bigtest/client';
 import { MainError } from '@effection/node';
 import * as query from './query';
+import { Printer } from './printer';
 import { Formatter, FormatterConstructor } from './format-helpers';
 import { reportCoverage } from './report-coverage';
 import { RunArgs } from './cli';
@@ -23,7 +24,8 @@ const BUILTIN_FORMATTERS: Record<string, Formatter | FormatterConstructor> = { c
 
 function initFormatter(input: Formatter | FormatterConstructor): Formatter {
   if(typeof(input) === 'function') {
-    return input();
+    let printer = new Printer(process.stdout);
+    return input(printer);
   } else {
     return input;
   }


### PR DESCRIPTION
Currently, all of the code in `format-helpers` is a bit of a mess, because it needs to manually keep track of prefixes, since we work very heavily with indenting code. This results in a lot of manual jiggling to get everything to print correctly. Also, there are probably a bunch of edge cases that we currently don't handle very well, where newlines show up in unexpected places.

This introduces the concept of a printer, which can write to a writable stream (usually stdout), and has an internal prefix. When we print to the printer it will prefix all printed lines. This also makes it very easy to write recursive code, or to reuse the same code in different context with different prefixes.

The resulting output looks completely identical as far as I can tell.