### PR TITLE
Improve interactor table formatting

### DIFF
--- a/.changeset/nasty-news-fly.md
+++ b/.changeset/nasty-news-fly.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": patch
+"bigtest": patch
+---
+
+Improve rendering of error table in interactors

--- a/packages/interactor/src/format-table.ts
+++ b/packages/interactor/src/format-table.ts
@@ -8,13 +8,17 @@ export function formatTable(options: TableOptions) {
     return Math.max(h.length, ...options.rows.map((r) => r[index].length));
   });
 
-  let formatRow = (cells: string[], padString = ' ') => {
-    return '| ' + cells.map((c, index) => c.padEnd(columnWidths[index], padString)).join(' | ') + ' |';
+  let formatRow = (cells: string[]) => {
+    return '┃ ' + cells.map((c, index) => c.padEnd(columnWidths[index])).join(' ┃ ') + ' ┃';
+  }
+
+  let spacerRow = () => {
+    return '┣━' + columnWidths.map((w) => "━".repeat(w)).join('━╋━') + '━┫';
   }
 
   return [
     formatRow(options.headers),
-    formatRow(options.headers.map(() => ""), '-'),
+    spacerRow(),
     ...options.rows.map((row) => formatRow(row))
   ].join('\n');
 }

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -102,10 +102,10 @@ describe('@bigtest/interactor', () => {
       await expect(Link('Foo Bar').exists()).resolves.toBeUndefined();
       await expect(Link('Blah').exists()).rejects.toHaveProperty('message', [
         'did not find link "Blah", did you mean one of:', '',
-        '| link        |',
-        '| ----------- |',
-        '| ⨯ "Foo Bar" |',
-        '| ⨯ "Quox"    |',
+        '┃ link        ┃',
+        '┣━━━━━━━━━━━━━┫',
+        '┃ ⨯ "Foo Bar" ┃',
+        '┃ ⨯ "Quox"    ┃',
       ].join('\n'));
     });
 
@@ -117,9 +117,9 @@ describe('@bigtest/interactor', () => {
       await expect(Link({ title: 'Monkey' }).exists()).resolves.toBeUndefined();
       await expect(Link({ title: 'Zebra' }).exists()).rejects.toHaveProperty('message', [
         'did not find link with title "Zebra", did you mean one of:', '',
-        '| title: "Zebra" |',
-        '| -------------- |',
-        '| ⨯ "Monkey"     |',
+        '┃ title: "Zebra" ┃',
+        '┣━━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "Monkey"     ┃',
       ].join('\n'));
     });
 
@@ -184,15 +184,15 @@ describe('@bigtest/interactor', () => {
       await expect(Div("bar").find(Link("Bar")).exists()).resolves.toBeUndefined();
       await expect(Div("foo").find(Link("Bar")).exists()).rejects.toHaveProperty('message', [
         'did not find link "Bar" within div "foo", did you mean one of:', '',
-        '| link    |',
-        '| ------- |',
-        '| ⨯ "Foo" |',
+        '┃ link    ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "Foo" ┃',
       ].join('\n'));
       await expect(Div("bar").find(Link("Foo")).exists()).rejects.toHaveProperty('message', [
         'did not find link "Foo" within div "bar", did you mean one of:', '',
-        '| link    |',
-        '| ------- |',
-        '| ⨯ "Bar" |',
+        '┃ link    ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "Bar" ┃',
       ].join('\n'));
     });
 
@@ -205,9 +205,9 @@ describe('@bigtest/interactor', () => {
 
       await expect(Div("blah").find(Link("Foo")).exists()).rejects.toHaveProperty('message', [
         'did not find div "blah", did you mean one of:', '',
-        '| div     |',
-        '| ------- |',
-        '| ⨯ "foo" |',
+        '┃ div     ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "foo" ┃',
       ].join('\n'));
     });
 
@@ -240,17 +240,17 @@ describe('@bigtest/interactor', () => {
 
       await expect(Div("test").find(Div("foo").find(Link("Bar"))).exists()).rejects.toHaveProperty('message', [
         'did not find link "Bar" within div "foo" within div "test", did you mean one of:', '',
-        '| link    |',
-        '| ------- |',
-        '| ⨯ "Foo" |',
+        '┃ link    ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "Foo" ┃',
       ].join('\n'));
 
       await expect(Div("test").find(Div("foo")).find(Link("Foo")).exists()).resolves.toBeUndefined();
       await expect(Div("test").find(Div("foo")).find(Link("Bar")).exists()).rejects.toHaveProperty('message', [
         'did not find link "Bar" within div "foo" within div "test", did you mean one of:', '',
-        '| link    |',
-        '| ------- |',
-        '| ⨯ "Foo" |',
+        '┃ link    ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "Foo" ┃',
       ].join('\n'));
     });
 
@@ -280,9 +280,9 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Email').is({ value: 'jonas@example.com' })).resolves.toBeUndefined();
       await expect(TextField('Email').is({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', [
         'text field "Email" does not match filters:', '',
-        '| value: "incorrect@example.com" | enabled: true |',
-        '| ------------------------------ | ------------- |',
-        '| ⨯ "jonas@example.com"          | ✓ true        |',
+        '┃ value: "incorrect@example.com" ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "jonas@example.com"          ┃ ✓ true        ┃',
       ].join('\n'))
     });
   });
@@ -296,9 +296,9 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Email').has({ value: 'jonas@example.com' })).resolves.toBeUndefined();
       await expect(TextField('Email').has({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', [
         'text field "Email" does not match filters:', '',
-        '| value: "incorrect@example.com" | enabled: true |',
-        '| ------------------------------ | ------------- |',
-        '| ⨯ "jonas@example.com"          | ✓ true        |',
+        '┃ value: "incorrect@example.com" ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "jonas@example.com"          ┃ ✓ true        ┃',
       ].join('\n'))
     });
   });
@@ -428,9 +428,9 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Email', { value: 'jonas@example.com' }).exists()).resolves.toBeUndefined();
       await expect(TextField('Email', { value: 'incorrect@example.com' }).exists()).rejects.toHaveProperty('message', [
         'did not find text field "Email" with value "incorrect@example.com", did you mean one of:', '',
-        '| text field | value: "incorrect@example.com" | enabled: true |',
-        '| ---------- | ------------------------------ | ------------- |',
-        '| ✓ "Email"  | ⨯ "jonas@example.com"          | ✓ true        |',
+        '┃ text field ┃ value: "incorrect@example.com" ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Email"  ┃ ⨯ "jonas@example.com"          ┃ ✓ true        ┃',
       ].join('\n'))
     });
 
@@ -442,17 +442,17 @@ describe('@bigtest/interactor', () => {
 
       await expect(TextField('Password').exists()).rejects.toHaveProperty('message', [
         'did not find text field "Password", did you mean one of:', '',
-        '| text field   | enabled: true |',
-        '| ------------ | ------------- |',
-        '| ✓ "Password" | ⨯ false       |',
-        '| ⨯ "Email"    | ✓ true        |',
+        '┃ text field   ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Password" ┃ ⨯ false       ┃',
+        '┃ ⨯ "Email"    ┃ ✓ true        ┃',
       ].join('\n'))
       await expect(TextField('Password', { enabled: true }).exists()).rejects.toHaveProperty('message', [
         'did not find text field "Password" which is enabled, did you mean one of:', '',
-        '| text field   | enabled: true |',
-        '| ------------ | ------------- |',
-        '| ✓ "Password" | ⨯ false       |',
-        '| ⨯ "Email"    | ✓ true        |',
+        '┃ text field   ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Password" ┃ ⨯ false       ┃',
+        '┃ ⨯ "Email"    ┃ ✓ true        ┃',
       ].join('\n'))
       await expect(TextField('Password', { enabled: false }).exists()).resolves.toBeUndefined();
     });
@@ -465,17 +465,17 @@ describe('@bigtest/interactor', () => {
 
       await expect(TextField('Password', { enabled: false, value: 'incorrect' }).exists()).rejects.toHaveProperty('message', [
         'did not find text field "Password" which is not enabled and with value "incorrect", did you mean one of:', '',
-        '| text field   | enabled: false | value: "incorrect"    |',
-        '| ------------ | -------------- | --------------------- |',
-        '| ✓ "Password" | ✓ false        | ⨯ "test1234"          |',
-        '| ⨯ "Email"    | ⨯ true         | ⨯ "jonas@example.com" |',
+        '┃ text field   ┃ enabled: false ┃ value: "incorrect"    ┃',
+        '┣━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Password" ┃ ✓ false        ┃ ⨯ "test1234"          ┃',
+        '┃ ⨯ "Email"    ┃ ⨯ true         ┃ ⨯ "jonas@example.com" ┃',
       ].join('\n'))
       await expect(TextField('Password', { enabled: true, value: 'test1234' }).exists()).rejects.toHaveProperty('message', [
         'did not find text field "Password" which is enabled and with value "test1234", did you mean one of:', '',
-        '| text field   | enabled: true | value: "test1234"     |',
-        '| ------------ | ------------- | --------------------- |',
-        '| ✓ "Password" | ⨯ false       | ✓ "test1234"          |',
-        '| ⨯ "Email"    | ✓ true        | ⨯ "jonas@example.com" |',
+        '┃ text field   ┃ enabled: true ┃ value: "test1234"     ┃',
+        '┣━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Password" ┃ ⨯ false       ┃ ✓ "test1234"          ┃',
+        '┃ ⨯ "Email"    ┃ ✓ true        ┃ ⨯ "jonas@example.com" ┃',
       ].join('\n'))
       await expect(TextField('Password', { enabled: false, value: 'test1234' }).exists()).resolves.toBeUndefined();
     });


### PR DESCRIPTION
During our demo I was thinking about how the tables rendered by the interactors when something goes wrong look a bit *meh*, let's spruce them up a bit 💅

Before:

<img width="635" alt="Screenshot 2020-10-08 at 22 29 46" src="https://user-images.githubusercontent.com/134/95559676-6f6f7380-0a18-11eb-8e29-d12df20f3e72.png">

After:

<img width="660" alt="Screenshot 2020-10-08 at 22 29 52" src="https://user-images.githubusercontent.com/134/95559697-76968180-0a18-11eb-9ee8-95da42258243.png">
