### PR TITLE
🐛Workaround React > 15.6 monkey-patching input.value

### DIFF
--- a/.changeset/fillin-react.md
+++ b/.changeset/fillin-react.md
@@ -1,0 +1,9 @@
+---
+"@bigtest/interactor": patch
+"bigtest": patch
+---
+
+Workaround the fact that React > 15.6 monkey-patches the
+HTMLInputElement `value` property as an optimization causing the
+`fillIn()` action not to work. See
+https://github.com/thefrontside/bigtest/issues/596

--- a/packages/interactor/src/fill-in.ts
+++ b/packages/interactor/src/fill-in.ts
@@ -12,7 +12,7 @@ function clearText(element: HTMLInputElement) {
   let InputEvent = element.ownerDocument.defaultView?.InputEvent || window.InputEvent;
 
   if(element.value.length) {
-    element.value = ""
+    setValue(element, "");
     element.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: false, inputType: 'deleteContentBackward', data: null }));
   }
 }
@@ -25,12 +25,33 @@ function enterText(element: HTMLInputElement, value: string) {
     let keydownEvent = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: letter, code: guessCode(letter) });
     if(element.dispatchEvent(keydownEvent)) {
       // don't change the value if the keydown event was stopped
-      element.value += letter;
+      setValue(element, element.value + letter);
       // input is not dispatched if the keydown event was stopped
       element.dispatchEvent(new InputEvent('input', { bubbles: true, cancelable: false, inputType: 'insertText', data: letter }));
     }
     // keyup is always dispatched
     element.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true, cancelable: true, key: letter, code: guessCode(letter) }));
+  }
+}
+
+
+/**
+ * Use the prototype setter of the element in order to set the value, that way any behavior that monkey patches
+ * the element itself is circumvented. This has the effect of the value just "magically" appearing on the input
+ * element just like it does when the browser sets the value because of the default action of an event.
+ * We have to do this because React actually does do this monkey-patching as an optimization. Basically, they
+ * short-circuit syncing the react state whenever someone sets input.value and then ignore the next `change` event.
+ *
+ * See https://github.com/cypress-io/cypress/issues/536
+ */
+function setValue(element: HTMLInputElement, value: string): void {
+  let property = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value');
+  if (property && property.set) {
+    property.set.call(element, value);
+  } else {
+    // if the value property on the HTMLInputElement protoype is not present
+    // then there are worse problems. But this is very typesafe!
+    element.value = value;
   }
 }
 


### PR DESCRIPTION
> resolves #596

Motivation
-----------
In React > 15.6 an optimization implemented by monkey-patching the `value` property of HTMLInputElement. It's not exactly clear why not, but when setting the `value` property from JavaScript, it causes the DOM to be updated, but the internal React listener for the onChange event not to be fired. This results in the DOM value being correct, but the React component representing the DOM element to not be.


Approach
----------
This works around the issue by always invoking the setter from the HTMLInputElement.prototype. That way, no matter what monkey-patches are in place, the `value` property just magically appears. Similar to what happen when the browser performs the default action.