### PR TITLE
Improve build error formatting

### DIFF
--- a/.changeset/purple-hornets-suffer.md
+++ b/.changeset/purple-hornets-suffer.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Improve build error formatting

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -74,7 +74,21 @@ function* run({ id: testRunId, files }: RunMessage, options: CommandProcessorOpt
       testRunId: testRunId,
       status: 'failed',
       agents: {},
-      error: { name: 'BundlerError', message: 'Cannot run tests due to build errors in the test suite:\n' + bundler.error.message }
+      error: {
+        name: 'BundlerError',
+        message: [
+          'Cannot run tests due to build errors in the test suite:',
+          bundler.error.message,
+          bundler.error.frame,
+        ].filter(Boolean).join('\n'),
+        stack: bundler.error.loc && [
+          {
+            fileName: bundler.error.loc.file,
+            line: bundler.error.loc.line,
+            column: bundler.error.loc.column,
+          }
+        ]
+      }
     });
   }
 }


### PR DESCRIPTION
This is sort of a hybrid approach compared to what was discussed in #594. The `frame` part of the build error is included in the message, whereas the source file/line/column is added as a stack frame.

IMO the `frame` part doesn't really stand on its own. It's confusingly named and not formatted in a way which makes it easy to reuse. With this change we don't need to add this field to our GraphQL, which IMO feels better.