### PR TITLE
TextField interactor matches wider range of inputs

### DIFF
--- a/.changeset/purple-students-double.md
+++ b/.changeset/purple-students-double.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+TextField interactor matches any input which is not a special input

--- a/packages/interactor/src/definitions/text-field.ts
+++ b/packages/interactor/src/definitions/text-field.ts
@@ -1,8 +1,13 @@
 import { createInteractor, perform, fillIn } from '../index';
 import { isVisible } from 'element-is-visible';
 
+const selector = 'input' + [
+  'button', 'checkbox', 'color', 'date', 'datetime-local', 'file', 'hidden',
+  'image', 'month', 'radio', 'range', 'reset', 'submit', 'time', 'datetime'
+].map((t) => `:not([type=${t}])`).join('');
+
 export const TextField = createInteractor<HTMLInputElement>('text field')({
-  selector: 'input:not([type]),input[type=text]',
+  selector,
   locator: (element) => element.labels ? (Array.from(element.labels)[0]?.textContent || '') : '',
   filters: {
     title: (element) => element.title,

--- a/packages/interactor/test/definitions/text-field.test.ts
+++ b/packages/interactor/test/definitions/text-field.test.ts
@@ -16,11 +16,28 @@ describe('@bigtest/interactor', () => {
 
     it('finds `input[type=text] tags by label', async () => {
       dom(`
-        <label type="text" for="name-field">Name</label><input id="name-field"/>
+        <label for="name-field">Name</label><input type="text" id="name-field"/>
       `);
 
       await expect(TextField('Name').exists()).resolves.toBeUndefined();
       await expect(TextField('Does not Exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    it('finds inputs with custom type', async () => {
+      dom(`
+        <label for="name-field">Name</label><input type="monkey" id="name-field"/>
+      `);
+
+      await expect(TextField('Name').exists()).resolves.toBeUndefined();
+      await expect(TextField('Does not Exist').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
+    });
+
+    it('does not find non text field inputs', async () => {
+      dom(`
+        <label for="name-field">Name</label><input type="range" id="name-field"/>
+      `);
+
+      await expect(TextField('Name').exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
     });
 
     it('does not yet support multiple label tags per `input`, only picks the first one', async () => {


### PR DESCRIPTION
Currently out TextField interactor is pretty strict, it only matches `[type=text]` inputs, and those that do not have a type attribute at all. With this change it will also match all of the text-like fields, like `[type=email]` or `[type=password]`, it will also match an input with a completely made up type. This behaviour is more inline with how browsers display these fields.

Note that we do *not* match any of the date related fields, this is because those fields differ in their functioning across browsers, and simply entering text into them is unlikely to have the desired result. This is actually a major pain point when using Selenium, so we should avoid this problem.