### PR TITLE
Validate manifest

### DIFF
--- a/.changeset/tasty-frogs-wash.md
+++ b/.changeset/tasty-frogs-wash.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/suite": minor
+"bigtest": minor
+"@bigtest/server": patch
+---
+
+Validate manifest, check duplicate tests and nesting depth

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -213,6 +213,42 @@ describe('@bigtest/cli', function() {
         expect(child.stdout?.output).toContain('⨯ FAILURE')
       });
     });
+
+    describe('running the suite with duplicate tests', () => {
+      let child: TestProcess;
+      let status: ExitStatus;
+
+      beforeEach(async () => {
+        child = await run('ci', '--test-files', './test/fixtures/duplicate.broken.ts');
+        status = await child.join();
+      });
+
+      it('exits with error code', async () => {
+        expect(status.code).toEqual(1);
+        expect(child.stdout?.output).toContain('Cannot run tests due to build errors in the test suite')
+        expect(child.stdout?.output).toContain('Invalid Test: contains duplicate test: "duplicate child"')
+        expect(child.stdout?.output).toContain('test/fixtures/duplicate.broken.ts')
+        expect(child.stdout?.output).toContain('⨯ FAILURE')
+      });
+    });
+
+    describe('running the suite with nesting depth exceeded', () => {
+      let child: TestProcess;
+      let status: ExitStatus;
+
+      beforeEach(async () => {
+        child = await run('ci', '--test-files', './test/fixtures/too-deep.broken.ts');
+        status = await child.join();
+      });
+
+      it('exits with error code', async () => {
+        expect(status.code).toEqual(1);
+        expect(child.stdout?.output).toContain('Cannot run tests due to build errors in the test suite')
+        expect(child.stdout?.output).toContain('Invalid Test: is too deeply nested, maximum allowed depth of nesting is 10')
+        expect(child.stdout?.output).toContain('test/fixtures/too-deep.broken.ts')
+        expect(child.stdout?.output).toContain('⨯ FAILURE')
+      });
+    });
   });
 
   describe('coverage', () => {

--- a/packages/cli/test/fixtures/duplicate.broken.ts
+++ b/packages/cli/test/fixtures/duplicate.broken.ts
@@ -1,0 +1,5 @@
+import { test } from '@bigtest/suite';
+
+export default test('Passing Test')
+  .child("duplicate child", test => test)
+  .child("duplicate child", test => test);

--- a/packages/cli/test/fixtures/too-deep.broken.ts
+++ b/packages/cli/test/fixtures/too-deep.broken.ts
@@ -1,0 +1,14 @@
+import { test } from '@bigtest/suite';
+
+export default test('Passing Test')
+  .child("child", test => test
+    .child("child", test => test
+      .child("child", test => test
+        .child("child", test => test
+          .child("child", test => test
+            .child("child", test => test
+              .child("child", test => test
+                .child("child", test => test
+                  .child("child", test => test
+                    .child("child", test => test
+                      .child("child", test => test)))))))))))

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -2,6 +2,7 @@ import { bigtestGlobals } from '@bigtest/globals';
 import { Operation } from 'effection';
 import { subscribe } from '@effection/subscription';
 import { once } from '@effection/events';
+import { validateTest } from '@bigtest/suite';
 import { Deferred } from '@bigtest/effection';
 import { Bundler } from '@bigtest/bundler';
 import { Atom } from '@bigtest/atom';
@@ -78,6 +79,8 @@ function* processManifest(options: ManifestBuilderOptions): Operation {
 
   manifest = manifest.default || manifest;
   manifest.fileName = fileName;
+
+  validateTest(manifest);
 
   let slice = options.atom.slice('manifest');
 

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint \"{src,test}/**/*.ts\"",
+    "mocha": "mocha -r ts-node/register",
     "test:unit": "mocha -r ts-node/register test/**/*.test.ts",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test": "yarn test:unit && yarn test:types",

--- a/packages/suite/src/index.ts
+++ b/packages/suite/src/index.ts
@@ -1,2 +1,3 @@
 export * from './interfaces';
 export { test, TestBuilder } from './dsl';
+export { validateTest, MAXIMUM_DEPTH } from './validate-test';

--- a/packages/suite/src/validate-test.ts
+++ b/packages/suite/src/validate-test.ts
@@ -1,0 +1,53 @@
+import { Test } from './interfaces';
+
+type Loc = {
+  file: string;
+}
+
+class TestValidationError extends Error {
+  name = 'TestValidationError'
+
+  public loc?: Loc;
+
+  constructor(message: string, file?: string) {
+    super(message);
+    if(file) {
+      this.loc = { file }
+    }
+  }
+}
+
+function findDuplicates<T>(array: T[], callback: (value: T) => void) {
+  let ledger = new Set();
+  for(let element of array) {
+    if(ledger.has(element)) {
+      callback(element);
+    }
+    ledger.add(element);
+  }
+}
+
+export const MAXIMUM_DEPTH = 10;
+
+export function validateTest(test: Test): true {
+  function validateTestInner(test: Test, path: string[] = [], file?: string, depth = 0): true {
+    if(depth > MAXIMUM_DEPTH) {
+      throw new TestValidationError(`Invalid Test: is too deeply nested, maximum allowed depth of nesting is ${MAXIMUM_DEPTH}\n\nTest: ${path.join(' → ')}`, file)
+    }
+
+    findDuplicates(test.assertions.map((a) => a.description), (duplicate) => {
+      throw new TestValidationError(`Invalid Test: contains duplicate assertion: ${JSON.stringify(duplicate)}\n\nTest: ${path.join(' → ')}`, file)
+    });
+
+    findDuplicates(test.children.map((c) => c.description), (duplicate) => {
+      throw new TestValidationError(`Invalid Test: contains duplicate test: ${JSON.stringify(duplicate)}\n\nTest: ${path.join(' → ')}`, file)
+    });
+
+    for(let child of test.children) {
+      validateTestInner(child, path.concat(child.description), child.path || file, depth + 1);
+    }
+
+    return true;
+  }
+  return validateTestInner(test, [test.description], test.path);
+}

--- a/packages/suite/test/validate-test.test.ts
+++ b/packages/suite/test/validate-test.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect'
+
+import { test, validateTest } from '../src/index';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+let noop = async () => {};
+
+describe('validateTest', () => {
+  it('returns true for a valid test', async () => {
+    let example = test('foo');
+
+    expect(validateTest(example)).toEqual(true);
+  });
+
+  it('returns true for a valid test with steps, assertions and children', async () => {
+    let example =
+      test('foo')
+        .step('step one', noop)
+        .step('step two', noop)
+        .assertion('assertion one', noop)
+        .assertion('assertion two', noop)
+        .child('child one', test => test
+          .step('child step one', noop)
+          .step('child step two', noop)
+          .assertion('child assertion one', noop)
+          .assertion('child assertion two', noop)
+        )
+        .child('child two', test => test
+          .step('child step one', noop)
+          .step('child step two', noop)
+          .assertion('child assertion one', noop)
+          .assertion('child assertion two', noop)
+        )
+
+    expect(validateTest(example)).toEqual(true);
+  });
+
+  it('returns true for a valid test with multiple steps with the same description', async () => {
+    let example =
+      test('foo')
+        .step('step', noop)
+        .step('step', noop)
+        .step('step', noop)
+        .assertion('assertion one', noop)
+
+    expect(validateTest(example)).toEqual(true);
+  });
+
+  it('is invalid with multiple assertions with same description', async () => {
+    let example =
+      test('foo')
+        .assertion('assertion', noop)
+        .assertion('assertion', noop)
+
+    expect(() => { validateTest(example) }).toThrowError('Invalid Test')
+  });
+
+  it('is invalid with multiple children with same description', async () => {
+    let example =
+      test('foo')
+        .child('child', test => test)
+        .child('child', test => test)
+
+    expect(() => { validateTest(example) }).toThrowError('Invalid Test')
+  });
+
+  it('is invalid with an invalid child', async () => {
+    let example =
+      test('foo')
+        .child('child two', test => test
+          .assertion('assertion', noop)
+          .assertion('assertion', noop)
+        )
+
+    expect(() => { validateTest(example) }).toThrowError('Invalid Test')
+  });
+
+  it('is invalid if it exceeds maximum depth', async () => {
+    let example =
+      test('foo')
+        .child('child', test => test
+          .child('child', test => test
+            .child('child', test => test
+              .child('child', test => test
+                .child('child', test => test
+                  .child('child', test => test
+                    .child('child', test => test
+                      .child('child', test => test
+                        .child('child', test => test
+                          .child('child', test => test
+                            .child('child', test => test)))))))))))
+
+    expect(() => { validateTest(example) }).toThrowError('Invalid Test')
+  });
+})


### PR DESCRIPTION
Checks that test manifest meets the required preconditions. Currently it checks:

- Assertion paths must be unique
- Test paths must be unique, closes #506
- Maximum depth is not exceeded, closes #294