### PR TITLE
Don't raise gzip errors after the unzip stream is finished

### DIFF
--- a/packages/server/src/proxy.ts
+++ b/packages/server/src/proxy.ts
@@ -54,7 +54,11 @@ export const startProxyServer = (options: ProxyOptions) => function* ({ url: tar
       let unzip = zlib.createGunzip();
 
       yield throwOnErrorEvent(tr);
-      yield throwOnErrorEvent(unzip);
+
+      yield spawn(function*() {
+        yield throwOnErrorEvent(unzip);
+        yield once(unzip, 'finish');
+      });
 
       tr.select('head', (node) => {
         let rs = node.createReadStream();


### PR DESCRIPTION
> fixes #557 

Motivation
------------
We were seeing the orchestrator crash intermittently with a zlib crash:

```
Error: unexpected end of file
    at Zlib.zlibOnError [as onerror] (zlib.js:180:17) {
  errno: -5,
  code: 'Z_BUF_ERROR'
}
```
This appears to happen when the test finishes before the app html completes loading. Ironically, this means that we're more likely to see this in a brand new test suite where it's more feasible that an assertion passes or fails without actually needing the DOM to run.  In these instances, the browser may abort the request which means that the response stream is closes. This halts the flow of bytes, but it appears that either bytes are still being pulled or pushed from the unzip stream which causes it to error. We can compare the event order on the various streams...

- `proxyRes`: The response sent back to the client
- `tr`: the streaming html transformer that injects the harness
- `unzip`: the unzip stream
- `res`: the upstream response from the proxied resource
- `req`: the original client request

They are piped like `unzip` -> `tr` -> `proxyRes`

A normal request for the `/account/settings` looks like:

![successful request in chrome devtools](https://user-images.githubusercontent.com/4205/95938107-cff70b80-0d9e-11eb-977a-d7fb0ff96792.png)

```
GET /account/settings HTTP/1.1
   proxyRes#resume
   unzip#resume
   tr#resume
   proxyRes#close
   proxyRes#end
   unzip#finish
   unzip#end
   tr#finish
   tr#end
   req#close
   res#finish
   req#resume
   res#close
   unzip#close
   res.socket#finish
   res.socket#close
```

But whenever the request is canceled, an error is raised after the `unzip#finish` event. Here are some examples of some failure event sequences when the request is canceled by the client.

![lsettings failed to load](https://user-images.githubusercontent.com/4205/95938141-deddbe00-0d9e-11eb-9c42-0fc309a4b07e.png)


(1)
```
GET /account/settings HTTP/1.1
   unzip#finish
   unzip#resume
   tr#resume
   unzip#error
```

(2)
```
GET /account/settings HTTP/1.1
   proxyRes#resume
   unzip#resume
   tr#resume
   proxyRes#close
   proxyRes#end
   unzip#finish
   res.socket#error
   tr#pause
   req#close
   res#close
   res.socket#close
   proxyRes#resume
   unzip#end
   tr#finish
```

(3)
```
GET /account/settings HTTP/1.1
   unzip#finish
   unzip#resume
   tr#resume
   unzip#error
   res.socket#finish
   res#close
   res.socket#close
```

It's a bit alarming how unreliable the event failure sequence is, but one thing they all share in common is that something causes `unzip` to resume after it has already raised the `finished` event. This could be either a bug in trumpet, zlib, or http-proxy.

Approach
----------

This works around this by ignoring any error events that happen after the `unzip#finish` event since all bytes that will move through the stream already have moved through the stream, and so there's no point in raising errors after that.

TODOS & Open questions
--------------------------

- [ ] I was unsuccessful in reliably simulating a canceled request. `fetch()` almost always has the entire body before you can abort, and so testing this has been a challenge.
- [ ] We may want to investigate implementing our own proxy at some point, or migrating over to service workers instead. Who knows if we're leaking garbage when these errors occur.