### PR TITLE
Interactor children

### DIFF
--- a/.changeset/selfish-cows-burn.md
+++ b/.changeset/selfish-cows-burn.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Interactors can specify children, which are related interactors

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,5 +1,5 @@
 import { bigtestGlobals } from '@bigtest/globals';
-import { InteractorSpecification, FilterParams, Filters, Actions, InteractorInstance, LocatorFn } from './specification';
+import { InteractorSpecification, FilterParams, Filters, Actions, Children, InteractorConstructor, InteractorInstance, LocatorFn } from './specification';
 import { Locator } from './locator';
 import { Filter } from './filter';
 import { Interactor } from './interactor';
@@ -9,8 +9,8 @@ import { converge } from './converge';
 const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
 
 export function createInteractor<E extends Element>(interactorName: string) {
-  return function<F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>) {
-    let InteractorClass = class extends Interactor<E, F, A> {};
+  return function<F extends Filters<E> = {}, A extends Actions<E> = {}, C extends Children = {}>(specification: InteractorSpecification<E, F, A, C>): InteractorConstructor<E, F, A, C> {
+    let InteractorClass = class extends Interactor<E, F, A, C> {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {
       Object.defineProperty(InteractorClass.prototype, actionName, {
@@ -34,8 +34,20 @@ export function createInteractor<E extends Element>(interactorName: string) {
       });
     }
 
-    function initInteractor(filters?: FilterParams<E, F>): InteractorInstance<E, F, A>;
-    function initInteractor(value: string, filters?: FilterParams<E, F>): InteractorInstance<E, F, A>;
+    for(let [childName, child] of Object.entries(specification.children || {})) {
+      Object.defineProperty(InteractorClass.prototype, childName, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value: function(...args: any[]) {
+          return this.find(child(...args));
+        },
+        configurable: true,
+        writable: true,
+        enumerable: false,
+      });
+    }
+
+    function initInteractor(filters?: FilterParams<E, F>): InteractorInstance<E, F, A, C>;
+    function initInteractor(value: string, filters?: FilterParams<E, F>): InteractorInstance<E, F, A, C>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function initInteractor(...args: any[]) {
       let locator, filter;
@@ -45,7 +57,7 @@ export function createInteractor<E extends Element>(interactorName: string) {
       } else {
         filter = new Filter(specification, args[0] || {});
       }
-      return new InteractorClass(interactorName, specification, filter, locator) as InteractorInstance<E, F, A>;
+      return new InteractorClass(interactorName, specification, filter, locator) as InteractorInstance<E, F, A, C>;
     }
 
     return initInteractor;

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -38,7 +38,12 @@ export function createInteractor<E extends Element>(interactorName: string) {
       Object.defineProperty(InteractorClass.prototype, childName, {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         value: function(...args: any[]) {
-          return this.find(child(...args));
+          if(typeof(child) === 'object') {
+            return child.find(this, ...args);
+
+          } else {
+            return this.find(child(...args));
+          }
         },
         configurable: true,
         writable: true,

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -5,7 +5,7 @@ import { noCase } from 'change-case';
 export class Filter<E extends Element, F extends Filters<E>> {
   constructor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public specification: InteractorSpecification<E, F, any>,
+    public specification: InteractorSpecification<E, F, any, any>,
     public filters: FilterParams<E, F>,
   ) {};
 

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -1,6 +1,6 @@
 import { bigtestGlobals } from '@bigtest/globals';
 import { converge } from './converge';
-import { Filters, Actions, FilterParams, InteractorSpecification } from './specification';
+import { Filters, Actions, Children, FilterParams, InteractorSpecification } from './specification';
 import { Filter } from './filter';
 import { Locator } from './locator';
 import { MatchFilter } from './match';
@@ -9,24 +9,24 @@ import { formatTable } from './format-table';
 import { FilterNotMatchingError } from './errors';
 import { interaction, check, Interaction, ReadonlyInteraction } from './interaction';
 
-export class Interactor<E extends Element, F extends Filters<E>, A extends Actions<E>> {
+export class Interactor<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private ancestors: Array<Interactor<any, any, any>> = [];
+  private ancestors: Array<Interactor<any, any, any, any>> = [];
 
   constructor(
     public name: string,
-    public specification: InteractorSpecification<E, F, A>,
+    public specification: InteractorSpecification<E, F, A, C>,
     public filter: Filter<E, F>,
     public locator?: Locator<E>,
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private get ancestorsAndSelf(): Array<Interactor<any, any, any>> {
+  private get ancestorsAndSelf(): Array<Interactor<any, any, any, any>> {
     return [...this.ancestors, this];
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  find<T extends Interactor<any, any, any>>(interactor: T): T {
+  find<T extends Interactor<any, any, any, any>>(interactor: T): T {
     return Object.create(interactor, {
       ancestors: {
         value: [...this.ancestors, this, ...interactor.ancestors]

--- a/packages/interactor/src/perform.ts
+++ b/packages/interactor/src/perform.ts
@@ -1,10 +1,10 @@
 import { Interactor } from "./interactor";
-import { Filters, Actions } from "./specification";
+import { Filters, Actions, Children } from "./specification";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends any[]>(fn: (element: E, ...args: T) => void) {
+export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children, T extends any[]>(fn: (element: E, ...args: T) => void) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (interactor: Interactor<E, F, A>, ...args: T) => interactor.perform(element => {
+  return (interactor: Interactor<E, F, A, C>, ...args: T) => interactor.perform(element => {
     fn(element, ...args);
   });
 }

--- a/packages/interactor/src/resolve.ts
+++ b/packages/interactor/src/resolve.ts
@@ -6,18 +6,18 @@ import { formatTable } from './format-table';
 const defaultSelector = 'div';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findMatches(parentElement: Element, interactor: Interactor<any, any, any>): Match<Element, any>[] {
+function findMatches(parentElement: Element, interactor: Interactor<any, any, any, any>): Match<Element, any>[] {
   let elements = Array.from(parentElement.querySelectorAll(interactor.specification.selector || defaultSelector));
   return elements.map((e) => new Match(e, interactor.filter, interactor.locator));
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findMatchesMatching(parentElement: Element, interactor: Interactor<any, any, any>): Match<Element, any>[] {
+function findMatchesMatching(parentElement: Element, interactor: Interactor<any, any, any, any>): Match<Element, any>[] {
   return findMatches(parentElement, interactor).filter((m) => m.matches);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findMatchesNonEmpty(parentElement: Element, interactor: Interactor<any, any, any>): Match<Element, any>[] {
+function findMatchesNonEmpty(parentElement: Element, interactor: Interactor<any, any, any, any>): Match<Element, any>[] {
   let matches = findMatches(parentElement, interactor);
   let matching = matches.filter((m) => m.matches);
   if(matching.length > 0) {
@@ -37,7 +37,7 @@ function findMatchesNonEmpty(parentElement: Element, interactor: Interactor<any,
 // and return it. If no elements match, raise an error. If more than one
 // element matches, raise an error.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function resolveUnique(parentElement: Element, interactor: Interactor<any, any, any>): Element {
+export function resolveUnique(parentElement: Element, interactor: Interactor<any, any, any, any>): Element {
   let matching = findMatchesNonEmpty(parentElement, interactor);
 
   if(matching.length === 1) {
@@ -51,14 +51,14 @@ export function resolveUnique(parentElement: Element, interactor: Interactor<any
 // Given a parent element, and an interactor, find all matching elements and
 // return them. If no elements match, raise an error.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function resolveNonEmpty(parentElement: Element, interactor: Interactor<any, any, any>): Element[] {
+export function resolveNonEmpty(parentElement: Element, interactor: Interactor<any, any, any, any>): Element[] {
   return findMatchesNonEmpty(parentElement, interactor).map(m => m.element);
 }
 
 // Given a parent element, and an interactor, check if there are any matching
 // elements, and throw an error if there are. Otherwise return undefined.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function resolveEmpty(parentElement: Element, interactor: Interactor<any, any, any>): void {
+export function resolveEmpty(parentElement: Element, interactor: Interactor<any, any, any, any>): void {
   let matching = findMatchesMatching(parentElement, interactor);
 
   if(matching.length !== 0) {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -13,11 +13,15 @@ export type FilterObject<T, E extends Element> = {
   default?: T;
 }
 
+export type ChildObject<T extends Array<any>, E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> = {
+  find: (interactor: Interactor<Element, {}, {}, {}>, ...args: T) => InteractorInstance<E, F, A, C>;
+}
+
 export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>
 
 export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 
-export type Children = Record<string, InteractorConstructor<any, any, any, any>>;
+export type Children = Record<string, InteractorConstructor<any, any, any, any> | ChildObject<any, any, any, any, any>>;
 
 export type InteractorSpecification<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> = {
   selector?: string;
@@ -34,7 +38,10 @@ export type ActionMethods<E extends Element, A extends Actions<E>> = {
 }
 
 export type ChildrenMethods<C extends Children> = {
-  [P in keyof C]: C[P];
+  [P in keyof C]:
+    C[P] extends ChildObject<infer TArgs, infer TElement, infer TFilters, infer TActions, infer TChildren> ?
+    ((...args: TArgs) => InteractorInstance<TElement, TFilters, TActions, TChildren>) :
+    C[P]
 }
 
 export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -2,7 +2,7 @@
 
 import { Interactor } from './interactor';
 
-export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}>, ...args: any[]) => unknown;
+export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}, {}>, ...args: any[]) => unknown;
 
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
@@ -17,17 +17,24 @@ export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | F
 
 export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 
-export type InteractorSpecification<E extends Element, F extends Filters<E>, A extends Actions<E>> = {
+export type Children = Record<string, InteractorConstructor<any, any, any, any>>;
+
+export type InteractorSpecification<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> = {
   selector?: string;
   actions?: A;
   filters?: F;
+  children?: C;
   locator?: LocatorFn<E>;
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
-  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}>, ...args: infer TArgs) => infer TReturn)
+  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}, {}>, ...args: infer TArgs) => infer TReturn)
     ? ((...args: TArgs) => TReturn)
     : never;
+}
+
+export type ChildrenMethods<C extends Children> = {
+  [P in keyof C]: C[P];
 }
 
 export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {
@@ -39,4 +46,9 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
     never;
 }
 
-export type InteractorInstance<E extends Element, F extends Filters<E>, A extends Actions<E>> = Interactor<E, F, A> & ActionMethods<E, A>;
+export interface InteractorConstructor<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> {
+  (value: string, filters?: FilterParams<E, F>): InteractorInstance<E, F, A, C>;
+  (filters?: FilterParams<E, F>): InteractorInstance<E, F, A, C>;
+}
+
+export type InteractorInstance<E extends Element, F extends Filters<E>, A extends Actions<E>, C extends Children> = Interactor<E, F, A, C> & ActionMethods<E, A> & ChildrenMethods<C>;

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -62,7 +62,10 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")({
 });
 
 const MainNav = createInteractor('main nav')({
-  selector: 'nav'
+  selector: 'nav',
+  children: {
+    textField: TextField,
+  }
 });
 
 describe('@bigtest/interactor', () => {
@@ -513,6 +516,25 @@ describe('@bigtest/interactor', () => {
         '┃ ⨯ "Email"    ┃ ✓ true        ┃ ⨯ "jonas@example.com" ┃',
       ].join('\n'))
       await expect(TextField('Password', { enabled: false, value: 'test1234' }).exists()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('children', () => {
+    it('can find child interactors', async () => {
+      dom(`
+        <nav>
+          <input id="Email" value='jonas@example.com'/>
+        </nav>
+      `);
+
+      await expect(MainNav().textField('Email').exists()).resolves.toBeUndefined();
+      await expect(MainNav().textField({ value: 'jonas@example.com' }).exists()).resolves.toBeUndefined();
+      await expect(MainNav().textField('Does not exist').exists()).rejects.toHaveProperty('message', [
+        'did not find text field "Does not exist" within main nav, did you mean one of:', '',
+        '┃ text field ┃ enabled: true ┃',
+        '┣━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "Email"  ┃ ✓ true        ┃',
+      ].join('\n'))
     });
   });
 });

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -65,6 +65,11 @@ const MainNav = createInteractor('main nav')({
   selector: 'nav',
   children: {
     textField: TextField,
+    itemLink: {
+      find(interactor, item: number) {
+        return interactor.find(Link(`Item ${item}`))
+      }
+    }
   }
 });
 
@@ -534,6 +539,22 @@ describe('@bigtest/interactor', () => {
         '┃ text field ┃ enabled: true ┃',
         '┣━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
         '┃ ⨯ "Email"  ┃ ✓ true        ┃',
+      ].join('\n'))
+    });
+
+    it('can find child interactors with custom definition', async () => {
+      dom(`
+        <nav>
+          <a href="/moo">Item 4</a>
+        </nav>
+      `);
+
+      await expect(MainNav().itemLink(4).exists()).resolves.toBeUndefined();
+      await expect(MainNav().itemLink(1337).exists()).rejects.toHaveProperty('message', [
+        'did not find link "Item 1337" within main nav, did you mean one of:', '',
+        '┃ link       ┃',
+        '┣━━━━━━━━━━━━┫',
+        '┃ ⨯ "Item 4" ┃',
       ].join('\n'))
     });
   });

--- a/packages/interactor/types/children.ts
+++ b/packages/interactor/types/children.ts
@@ -1,0 +1,52 @@
+import { createInteractor, perform } from '../src/index';
+
+const Link = createInteractor<HTMLLinkElement>('link')({
+  selector: 'a',
+  filters: {
+    href: (element) => element.href,
+  },
+  actions: {
+    click: perform(element => { element.click() }),
+  }
+});
+
+const MainNav = createInteractor('main nav')({
+  selector: 'nav',
+  children: {
+    link: Link,
+    itemLink: {
+      find(interactor, item: number) {
+        return interactor.find(Link(`Item ${item}`))
+      }
+    }
+  }
+});
+
+// valid simple child
+MainNav().link()
+MainNav().link('Foo')
+MainNav().link({ href: 'http' })
+MainNav().link('Foo', { href: 'http' })
+
+// valid custom child
+MainNav().itemLink(3)
+
+// using actions through child
+MainNav().link('Foo').click()
+MainNav().itemLink(3).click()
+
+// simple child filter does not exist
+// $ExpectError
+MainNav().link({ doesNotExist: 'http' })
+
+// simple child filter has wrong type
+// $ExpectError
+MainNav().link({ href: 4 })
+
+// custom child no argument
+// $ExpectError
+MainNav().itemLink()
+
+// custom child incorrectly typed argument
+// $ExpectError
+MainNav().itemLink('foo')


### PR DESCRIPTION
Allows interactors to have children, defined like this:

``` typescript
const MainNav = createInteractor('main nav')({
  selector: 'nav',
  children: {
    link: Link,
    itemLink: {
      find(interactor, item: number) {
        return interactor.find(Link(`Item ${item}`))
      }
    }
  }
});
```

And used like this:

``` typescript
MainNav().link()
MainNav().link('Foo')
MainNav().link({ href: 'http' })
MainNav().link('Foo', { href: 'http' })
MainNav().itemLink(3)
```

This enables interactors to have a relation to other interactors.

Questions:

1. Is this even a good idea at all? I personally wanted this for the `Select` interactor, so we can do stuff like `Select('Animal').option('Dog', { disabled: true }).exists()`. While this is totally possible today with `Select('Animal').find(Option('Dog', { disabled: true })).exists()`, I find that to be a bit clunky, and it would be neat if we had a cleaner API for it.
1. Is `children` an appropriate name? I could see having for example a `fieldset` interactor on a form element, which would actually fetch a parent element. What could we call it instead?
1. Is it necessary to take an interactor as an argument, or should we just assume that whatever is returned will always be passed to `find`?