### PR TITLE
Catch unexpected exceptions and offer to report them as bugs

### DIFF
--- a/.changeset/no-naked-errors.md
+++ b/.changeset/no-naked-errors.md
@@ -1,0 +1,8 @@
+---
+"@bigtest/cli": patch
+"bigtest": patch
+---
+
+When an unexpected error happens in the CLI, catch it, let the user
+know it is our fault, and generate a link to a github issue containing
+diagnostic information

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,8 @@
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-reports": "^3.0.2",
-    "json5": "^2.1.3"
+    "json5": "^2.1.3",
+    "terminal-link": "^2.1.1"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^2.3.2",
     "eslint-plugin-prefer-let": "^1.0.1",
     "expect": "^24.9.0",
+    "jest-mock": "^26.6.0",
     "mocha": "^6.2.2",
     "ts-node": "*"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,6 @@
 import { CLI } from './cli';
 import { main } from '@effection/node';
 
-main(CLI(process.argv.slice(2)));
+import { warnUnexpectedExceptions } from './warn-unexpected-exceptions';
+
+main(warnUnexpectedExceptions(CLI)(process.argv.slice(2)));

--- a/packages/cli/src/warn-unexpected-exceptions.ts
+++ b/packages/cli/src/warn-unexpected-exceptions.ts
@@ -1,0 +1,54 @@
+import { Operation } from 'effection';
+
+export function warnUnexpectedExceptions<T>(operation: (argv: string[]) => Operation<T>): (argv: string[]) => Operation<T> {
+  return function*(argv: string[]) {
+    try {
+      return yield operation(argv);
+    } catch (error) {
+      if (error.name !== 'EffectionMainError') {
+        console.warn(unexpectedErrorMessage(error, argv));
+      }
+      throw error;
+    }
+  }
+}
+
+const unexpectedErrorMessage = (error: any, argv: string[]) =>
+  `😱😱😱 OH NO! UNEXPECTED ERROR! 😱😱😱
+It looks like you've encountered a bug in BigTest that triggered an unexpected
+shutdown. And yes, in case you're wondering, this is definitely on us. It would
+help us a lot to improve BigTest if you'd take the time to report the problem at
+the following url:
+
+${newIssueLink(error, argv)}`;
+
+
+function newIssueLink(error: any, argv: string[]) {
+  let message = error && error.message != null ? error.message : 'unknown error';
+  let title = `CRASH: ${message}`;
+  let labels = `🐛bug,@bigtest/cli`;
+  let body = getIssueBody(error, argv);
+  return uriEncode`https://github.com/thefrontside/bigtest/issues/new?title=${title}&labels=${labels}&body=${body}`;
+}
+
+const getIssueBody = (error: any, argv: string[]) =>
+  `
+<!--
+Thanks for taking the time to submit a bug report. In addition to the information below, please include anything else that you think might be relevant in helping us diagnose the problem. Also, be sure to double check this issue report before submitting it to make sure it doesn't contain any non-public information.
+
+Again, thank you so much for taking the time to improve BigTest
+-->
+
+Args
+----
+${argv.join(',')}
+
+Stack
+-----
+${error && error.stack ? error.stack : 'none'}
+`
+
+function uriEncode(strings: TemplateStringsArray, ...values: string[]) {
+  let encoded = values.map(encodeURIComponent);
+  return strings.map((str, idx) => idx < values.length ? `${str}${encoded[idx]}` : str).join('');
+}

--- a/packages/cli/src/warn-unexpected-exceptions.ts
+++ b/packages/cli/src/warn-unexpected-exceptions.ts
@@ -1,4 +1,5 @@
 import { Operation } from 'effection';
+import * as terminalLink from 'terminal-link';
 
 export function warnUnexpectedExceptions<T>(operation: (argv: string[]) => Operation<T>): (argv: string[]) => Operation<T> {
   return function*(argv: string[]) {
@@ -13,16 +14,17 @@ export function warnUnexpectedExceptions<T>(operation: (argv: string[]) => Opera
   }
 }
 
+//eslint-disable-next-line @typescript-eslint/no-explicit-any
 const unexpectedErrorMessage = (error: any, argv: string[]) =>
   `😱😱😱 OH NO! UNEXPECTED ERROR! 😱😱😱
 It looks like you've encountered a bug in BigTest that triggered an unexpected
 shutdown. And yes, in case you're wondering, this is definitely on us. It would
-help us a lot to improve BigTest if you'd take the time to report the problem at
-the following url:
+help us a lot to improve BigTest if you'd take the time to report the problem.
 
-${newIssueLink(error, argv)}`;
+${terminalLink.stderr('Submit an issue to the BigTest repository', newIssueLink(error, argv))}
+`
 
-
+//eslint-disable-next-line @typescript-eslint/no-explicit-any
 function newIssueLink(error: any, argv: string[]) {
   let message = error && error.message != null ? error.message : 'unknown error';
   let title = `CRASH: ${message}`;
@@ -31,21 +33,26 @@ function newIssueLink(error: any, argv: string[]) {
   return uriEncode`https://github.com/thefrontside/bigtest/issues/new?title=${title}&labels=${labels}&body=${body}`;
 }
 
+//eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getIssueBody = (error: any, argv: string[]) =>
-  `
-<!--
-Thanks for taking the time to submit a bug report. In addition to the information below, please include anything else that you think might be relevant in helping us diagnose the problem. Also, be sure to double check this issue report before submitting it to make sure it doesn't contain any non-public information.
+`
+# Error Report
 
-Again, thank you so much for taking the time to improve BigTest
--->
+> Please fill in your error report here with any details you think may be relevant to why
+> the crash happened. Make sure to double check the diagnostic information to make sure that
+> it doesn't contain anything that shouldn't be public.
 
-Args
+<details><summary>diagnostics</summary>
+
+Argv
 ----
 ${argv.join(',')}
 
 Stack
 -----
 ${error && error.stack ? error.stack : 'none'}
+
+</details>
 `
 
 function uriEncode(strings: TemplateStringsArray, ...values: string[]) {

--- a/packages/cli/test/helpers/index.ts
+++ b/packages/cli/test/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './world';
+export * from './stream';

--- a/packages/cli/test/unexpected-errors.test.ts
+++ b/packages/cli/test/unexpected-errors.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import * as jest from 'jest-mock';
+import { Context } from 'effection';
+import { MainError } from '@effection/node';
+import { Deferred } from '@bigtest/effection';
+import { World } from './helpers';
+
+import { warnUnexpectedExceptions } from '../src/warn-unexpected-exceptions';
+
+describe('unexpected errors', () => {
+  let suspense: Deferred<void>;
+  let context: Context;
+  let warn: jest.SpyInstance<void, string[]>;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+
+    suspense = Deferred();
+    context = World.spawn(function*() {
+      try {
+        return yield warnUnexpectedExceptions(function*(argv) {
+          yield suspense.promise;
+          return argv;
+        })(['hello', 'world']);
+      } catch (error) {}
+    });
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  describe('when the process exits normally', () => {
+    let result: string[];
+    beforeEach(async () => {
+      suspense.resolve();
+      result = await context;
+    });
+
+    it('returns the result as expected', () => {
+      expect(result).toEqual(['hello', 'world']);
+    });
+
+    it('does not warn anything', () => {
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the process completes with an expected error', () => {
+    beforeEach(async () => {
+      suspense.reject(new MainError({ exitCode: 30}));
+      return await context;
+    })
+
+    it('does not print any warnings', () => {
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the process completes with an unexpected error', () => {
+    beforeEach(async () => {
+      suspense.reject(new Error('boom!'));
+      await context;
+    });
+
+    it('warns a biggie warning', () => {
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("UNEXPECTED ERROR"));
+    });
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,6 +2462,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
+  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@manypkg/find-root@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.0.0.tgz#b8e96d7c24678b1b65c2057ae47df750669197d7"
@@ -8894,6 +8905,14 @@ jest-mock@^24.0.0, jest-mock@^24.9.0:
   integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
   dependencies:
     "@jest/types" "^24.9.0"
+
+jest-mock@^26.6.0:
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.0.tgz#5d13a41f3662a98a55c7742ac67c482e232ded13"
+  integrity sha512-HsNmL8vVIn1rL1GWA21Drpy9Cl+7GImwbWz/0fkWHrUXVzuaG7rP0vwLtE+/n70Mt0U8nPkz8fxioi3SC0wqhw==
+  dependencies:
+    "@jest/types" "^26.6.0"
+    "@types/node" "*"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,7 +2132,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9558,7 +9563,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -13795,6 +13800,14 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz#f663df252af5f37c5d49bbd7eeefa9e0b9e59e47"
+  integrity sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 svg-parser@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -13907,6 +13920,14 @@ term-size@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
   integrity sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
+
+terminal-link@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@2.3.5:
   version "2.3.5"
@@ -15241,10 +15262,41 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
+  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
> closes #618 

Motivation
----------
It's a tough look whenever something terrible happens and the server or the CLI halts without doing the thing that you were asking it to do. For example, we were having an issue with our proxy server crashing on canceled requests with:

```
Error: unexpected end of file
    at Zlib.zlibOnError [as onerror] (zlib.js:180:17) {
  errno: -5,
  code: 'Z_BUF_ERROR'
}
```

It's even worse when that happens, and it silently makes a terrible impression on our users and we never even have the notification that it happened.

Approach
----------
This change catches all top-level exceptions that are _not_ effetion `MainError`s and prints out an explanation and generates a link to a new github issue with several diagnostic  values pre-filled in.

Screeshots
-----------

![run bigtest command that crashes then open ticket](https://user-images.githubusercontent.com/4205/96160321-67617900-0edb-11eb-929d-68cfa60fa7a5.gif)

TODOS & Open Questions
--------------------------

- [x] I'm not sure the best way to test this. I could, of course unit test the `warnUnexpectedErrors()` middleware directly, but It's kind of a small test given something that is so over-arching in its effect. If there were some way to booby-trap the CLI so that by running the `bigtest throw` command, you could have it raise an arbitrary exception from the CLI. Ideally, we could use a plugin architecture inside the test case to exend the CLI with a `throw` command, but that seems like a lot of work. Still, having our thing that is there to give us a good look even when we look bad, makes us look even worse.... well that is really bad. So not having this really well tested feel dangerous
- [x] The way that this was implemented was to catch all non `MainError`s, but that felt not so great. It occurred to me that what might even be better would be to have the `Promise` returned from @effection/node` always resolve on both successful exits _and_ on `MainError` exits since these are still _expected_ outcomes. Only on an unexpected error would the promise actually reject. This would have the benefit of allowing custom error handling of unexpected exits, but baked in handling of all expected exits. In other words, we would have been able to write this as:
```ts
import { CLI } from './cli';
import { main } from '@effection/node';
import { unexpectedExit } from './unexpected-exit';

main(CLI(process.argv.slice(2)))
  .catch(unexpectedExit);
```

This just makes the unexpected exit code a lot easier to write since it is just a function, not an operation, and it doesn't need to know anything amout `MainError`