### PR TITLE
Graceful agent shutdown

### DIFF
--- a/.changeset/socket-handling.md
+++ b/.changeset/socket-handling.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/effection-express": minor
+"bigtest": patch
+---
+server websocket handlers can now explicitly handle socket exit codes

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -1,6 +1,6 @@
 import { Local, WebDriver } from '@bigtest/webdriver';
 import { readyResource } from '@bigtest/effection';
-import { express } from '@bigtest/effection-express';
+import { express, CloseEvent } from '@bigtest/effection-express';
 
 import { ChainableSubscription, subscribe } from '@effection/subscription';
 import { static as staticMiddleware } from 'express';
@@ -69,14 +69,13 @@ describe("@bigtest/agent", function() {
     describe('connecting a browser to the agent URL', () => {
       let browser: WebDriver;
       let connection: AgentConnection;
-      let events: ChainableSubscription<TestEvent, undefined>;
+      let events: ChainableSubscription<TestEvent, CloseEvent>;
 
       beforeEach(async function() {
         browser = await run(Local({ browserName: 'chrome', headless: true }));
         await run(browser.navigateTo(config.agentUrl(`ws://localhost:8001`)));
         connection = await run(connections.expect());
         events = await run(subscribe(connection.events));
-
       });
 
       it('sends a connection message with an agent id', () => {

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -6,7 +6,7 @@ import * as util from 'util';
 import { Server } from 'http';
 
 import { throwOnErrorEvent, once, on } from '@effection/events';
-import { Subscribable, SymbolSubscribable, Subscription, subscribe } from '@effection/subscription';
+import { Subscribable, SymbolSubscribable, Subscription, subscribe, createSubscription } from '@effection/subscription';
 import { ensure } from '@bigtest/effection';
 
 type OperationRequestHandler = (req: actualExpress.Request, res: actualExpress.Response) => Operation<void>;
@@ -15,10 +15,15 @@ type WsOperationRequestHandler = (socket: Socket, req: actualExpress.Request) =>
 export type Response = actualExpress.Response;
 export type Request = actualExpress.Request;
 
+export interface CloseEvent {
+  readonly code: number;
+  readonly reason: string;
+}
+
 // JSON.parse return type is `any`, so that's the type
 // of the subscription
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class Socket implements Subscribable<any, void> {
+export class Socket implements Subscribable<any, CloseEvent> {
   constructor(public raw: WebSocket) {}
 
   *send(data: unknown): Operation<void> {
@@ -30,8 +35,18 @@ export class Socket implements Subscribable<any, void> {
   // JSON.parse return type is `any`, so that's the type
   // of the subscription
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  *[SymbolSubscribable](): Operation<Subscription<any, void>> {
-    return yield subscribe(on<MessageEvent[]>(this.raw, 'message').map(([event]) => JSON.parse(event.data)));
+  *[SymbolSubscribable](): Operation<Subscription<any, CloseEvent>> {
+    let { raw } = this;
+    return yield createSubscription(function*(publish) {
+      yield spawn(subscribe(on<MessageEvent[]>(raw, 'message')
+                            .map(([event]) => JSON.parse(event.data)))
+                  .forEach(function*(message) {
+                    publish(message);
+                  }));
+
+      let [close]: [CloseEvent] = yield once(raw, 'close');
+      return close;
+    });
   }
 }
 
@@ -68,10 +83,7 @@ export class Express {
           yield ensure(() => req.destroy());
           yield spawn(handler(new Socket(socket), req));
 
-          let [{ reason, code }] = yield once(socket, 'close');
-          if(code !== 1000 && code !== 1001) {
-            throw new Error(`websocket client closed connection unexpectedly: [${code}] ${reason}`);
-          }
+          yield once(socket, 'close');
         });
       })
     })

--- a/packages/effection-express/test/websocket.test.ts
+++ b/packages/effection-express/test/websocket.test.ts
@@ -20,6 +20,7 @@ describe('websocket server', () => {
     let app = express();
     await run(app.ws('*', function*(socket) {
       incoming.send(socket);
+      yield;
     }));
     await run(app.listen(3400));
 

--- a/packages/effection-express/test/websocket.test.ts
+++ b/packages/effection-express/test/websocket.test.ts
@@ -61,7 +61,7 @@ describe('websocket server', () => {
       let close: CloseEvent;
       beforeEach(async () => {
         client.close(4000, 'an application defined status code');
-        close = await run(messages.forEach(function*() {}));
+        close = await run(messages.forEach(function*() { return; }));
       });
 
       it('finishes the subscription with the close event', async () => {

--- a/packages/effection-express/test/websocket.test.ts
+++ b/packages/effection-express/test/websocket.test.ts
@@ -7,7 +7,7 @@ import { subscribe, ChainableSubscription } from '@effection/subscription';
 import * as WebSocket from 'ws';
 
 import { run } from './helpers';
-import { Socket, express } from '../src';
+import { Socket, express, CloseEvent } from '../src';
 
 describe('websocket server', () => {
   let client: WebSocket;
@@ -34,7 +34,7 @@ describe('websocket server', () => {
   });
 
   describe('when receiving messages via subscription', () => {
-    let messages: ChainableSubscription<unknown, void>;
+    let messages: ChainableSubscription<unknown, CloseEvent>;
 
     beforeEach(async () => {
       messages = await run(subscribe(connection));
@@ -55,5 +55,20 @@ describe('websocket server', () => {
       expect(await run(messages.expect())).toEqual({ message: "Hello World!" });
       expect(await run(messages.expect())).toEqual({ message: "Goodbye World!" });
     });
+
+    describe('when the client closes', () => {
+      let close: CloseEvent;
+      beforeEach(async () => {
+        client.close(4000, 'an application defined status code');
+        close = await run(messages.forEach(function*() {}));
+      });
+
+      it('finishes the subscription with the close event', async () => {
+        expect(close.code).toEqual(4000);
+        expect(close.reason).toEqual('an application defined status code')
+      });
+    });
   });
+
+
 })

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -35,12 +35,11 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
         }
       });
 
-      let close: CloseEvent = yield subscribe(connection.events).forEach(function*(message: TestEvent) {
+      let { code, reason }: CloseEvent = yield subscribe(connection.events).forEach(function*(message: TestEvent) {
         console.debug('[connection] got message from agent', connection.agentId, message);
         options.delegate.send({ ...message, agentId: connection.agentId });
       });
 
-      let { code, reason } = close;
       console.debug(`[connection] disconnected ${connection.agentId} [${code}${reason ? `: ${reason}` : ''}]`);
 
       agent.remove();

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -35,10 +35,13 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
         }
       });
 
-      yield subscribe(connection.events).forEach(function*(message: TestEvent) {
+      let close: CloseEvent = yield subscribe(connection.events).forEach(function*(message: TestEvent) {
         console.debug('[connection] got message from agent', connection.agentId, message);
         options.delegate.send({ ...message, agentId: connection.agentId });
       });
+
+      let { code, reason } = close;
+      console.debug(`[connection] disconnected ${connection.agentId} [${code}${reason ? `: ${reason}` : ''}]`);
 
       agent.remove();
     });


### PR DESCRIPTION
> fixes #453 

Motivation
-----------
As mentioned in #632, The effection-express hard fails on any socket close that isn't 1000 or 1001, but this makes it impossible to handle several valid shutdown scenarios (like when an agent closes because the browser tab was closed)

Approach
----------
This makes the effection-express websocket subscription actually return the close event rather than fail if it's not a "clean close" so that socket handlers can do what they please.

The other key change is that the websocket server _no longer_ waits until the socket is closed before shutting down the operation. This allows the handler to have its own handling of the close event (since before, the context was being shutdown before the child was actually seeing the close event) If you think about it, this makes sense. If you have a handler that wants to return _before_ the socket is closed by the other end, then it can now do so. It's now up to the handle itself to wait until the appropriate time to exit.

Eventually, it will probably be worth it to have a low-level socket abstraction in effection proper that encodes these ideas as well as makes it possible to work with binary data.