### PR TITLE
Allow steps to have duplicate descriptions

### DIFF
--- a/.changeset/proud-plums-retire.md
+++ b/.changeset/proud-plums-retire.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/agent": minor
+"@bigtest/server": minor
+"bigtest": minor
+---
+
+Handle duplicates in step descriptions

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -64,8 +64,8 @@ export function* runLane(config: LaneConfig) {
       originalConsole.warn(`[agent] the interactor timeout should be less than, but is greater than or equal to, the step timeout of ${stepTimeout}`);
     }
 
-    for(let step of test.steps) {
-      let stepPath = currentPath.concat(step.description);
+    for(let [index, step] of test.steps.entries()) {
+      let stepPath = currentPath.concat(`${index}:${step.description}`);
       try {
         originalConsole.debug('[agent] running step', step);
         events.send({ testRunId, type: 'step:running', path: stepPath });

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -155,7 +155,7 @@ describe("@bigtest/agent", function() {
           beforeEach(async () => {
             longStep = await run(events.match({
               type: 'step:result',
-              path: ['tests', 'test step timeouts', 'this takes literally forever']
+              path: ['tests', 'test step timeouts', '0:this takes literally forever']
             }).first()) as unknown as StepResult;
           });
 
@@ -172,7 +172,7 @@ describe("@bigtest/agent", function() {
           beforeEach(async () => {
             step = await run(events.match({
               type: 'step:result',
-              path: ['tests', 'test fetch', 'fetch is mocked']
+              path: ['tests', 'test fetch', '0:fetch is mocked']
             }).first()) as unknown as StepResult;
           });
 

--- a/packages/server/src/result-aggregator/test.ts
+++ b/packages/server/src/result-aggregator/test.ts
@@ -13,7 +13,7 @@ export class TestAggregator extends Aggregator<TestResult, AggregatorTestOptions
       let slice = this.slice.slice('steps', index);
       return new StepAggregator(slice, {
         ...this.options,
-        path: this.options.path.concat(step.description),
+        path: this.options.path.concat(`${index}:${step.description}`),
       }).run();
     }).concat([...this.slice.get().assertions.entries()].map(([index, assertion]) => {
       let slice = this.slice.slice('assertions', index);

--- a/packages/server/src/result-stream.ts
+++ b/packages/server/src/result-stream.ts
@@ -81,7 +81,7 @@ function* streamTest(slice: Slice<TestResult, OrchestratorState>, publish: Publi
     let stepSlice = slice.slice('steps', Number(index));
     yield fork(streamStep(stepSlice, publish, {
       ...options,
-      path: options.path.concat(step.description),
+      path: options.path.concat(`${index}:${step.description}`),
     }));
   }
   for(let [index, assertion] of Object.entries(slice.get().assertions)) {

--- a/packages/server/test/result-stream.test.ts
+++ b/packages/server/test/result-stream.test.ts
@@ -71,7 +71,7 @@ describe('result stream', () => {
           type: 'step:running',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
-          path: ['some test', 'step one'],
+          path: ['some test', '0:step one'],
         });
       });
     });
@@ -88,7 +88,7 @@ describe('result stream', () => {
           status: 'ok',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
-          path: ['some test', 'step one'],
+          path: ['some test', '0:step one'],
         });
       });
     });
@@ -110,7 +110,7 @@ describe('result stream', () => {
           status: 'failed',
           agentId: 'agent-1',
           testRunId: 'test-run-1',
-          path: ['some test', 'step one'],
+          path: ['some test', '0:step one'],
           error: { message: 'blah' },
           timeout: false,
         });
@@ -395,7 +395,7 @@ describe('result stream', () => {
         status: 'failed',
         agentId: 'agent-1',
         testRunId: 'test-run-1',
-        path: ['some test', 'step one'],
+        path: ['some test', '0:step one'],
       }).expect());
     });
   });

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -150,7 +150,7 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', "Signing In", "when I fill in the login form"]
+          path: ['All tests', "Signing In", "1:when I fill in the login form"]
         })
       });
 
@@ -169,7 +169,7 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'failed',
           testRunId: runCommand.testRunId,
-          path: ['All tests', "Signing In", "when I fill in the login form"],
+          path: ['All tests', "Signing In", "1:when I fill in the login form"],
           error: {
             message: "this step failed",
           }
@@ -255,7 +255,7 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I log out', 'when I click on the logout button']
+          path: ['All tests', 'Signing In', 'when I log out', '0:when I click on the logout button']
         })
         agent.send({
           type: 'assertion:result',
@@ -286,7 +286,7 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I log out', 'when I click on the logout button']
+          path: ['All tests', 'Signing In', 'when I log out', '0:when I click on the logout button']
         })
         agent.send({
           type: 'assertion:result',
@@ -317,19 +317,19 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'given a user']
+          path: ['All tests', 'Signing In', '0:given a user']
         })
         agent.send({
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I fill in the login form']
+          path: ['All tests', 'Signing In', '1:when I fill in the login form']
         })
         agent.send({
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I press the submit button']
+          path: ['All tests', 'Signing In', '2:when I press the submit button']
         })
         agent.send({
           type: 'assertion:result',
@@ -347,13 +347,13 @@ describe('running tests on an agent', () => {
           type: 'step:result',
           status: 'failed',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I log out', 'when I click on the logout button']
+          path: ['All tests', 'Signing In', 'when I log out', '0:when I click on the logout button']
         })
         agent.send({
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I go to the main navigation page', 'I click the hamburger button']
+          path: ['All tests', 'Signing In', 'when I go to the main navigation page', '0:I click the hamburger button']
         })
         agent.send({
           type: 'assertion:result',
@@ -407,14 +407,14 @@ describe('running tests on an agent', () => {
         type: 'step:result',
         status: 'ok',
         testRunId: runCommand.testRunId,
-        path: ['All tests', "Signing In", "when I fill in the login form"]
+        path: ['All tests', "Signing In", "1:when I fill in the login form"]
       });
 
       agent.send({
         type: 'step:result',
         status: 'failed',
         testRunId: runCommand.testRunId,
-        path: ['All tests', "Signing In", "when I fill in the login form"],
+        path: ['All tests', "Signing In", "1:when I fill in the login form"],
         error: { message: "this step failed" }
       });
     });

--- a/packages/server/test/subscription.test.ts
+++ b/packages/server/test/subscription.test.ts
@@ -78,7 +78,7 @@ describe('running tests with subscription on an agent', () => {
           type: 'step:result',
           status: 'ok',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I fill in the login form']
+          path: ['All tests', 'Signing In', '1:when I fill in the login form']
         })
       });
 
@@ -88,7 +88,7 @@ describe('running tests with subscription on an agent', () => {
           event: {
             type: 'step:result',
             status: 'ok',
-            path: ['All tests', 'Signing In', 'when I fill in the login form'],
+            path: ['All tests', 'Signing In', '1:when I fill in the login form'],
             agentId,
             testRunId
           }
@@ -102,7 +102,7 @@ describe('running tests with subscription on an agent', () => {
           type: 'step:result',
           status: 'failed',
           testRunId: runCommand.testRunId,
-          path: ['All tests', 'Signing In', 'when I fill in the login form'],
+          path: ['All tests', 'Signing In', '1:when I fill in the login form'],
           error: {
             message: 'this step failed',
           }
@@ -114,7 +114,7 @@ describe('running tests with subscription on an agent', () => {
           event: {
             type: 'step:result',
             status: 'failed',
-            path: ['All tests', 'Signing In', 'when I fill in the login form'],
+            path: ['All tests', 'Signing In', '1:when I fill in the login form'],
             error: {
               message: 'this step failed',
             }
@@ -137,7 +137,7 @@ describe('running tests with subscription on an agent', () => {
           event: {
             type: 'step:result',
             status: 'disregarded',
-            path: ['All tests', 'Signing In', 'when I press the submit button'],
+            path: ['All tests', 'Signing In', '2:when I press the submit button'],
           }
         }).first());
       });


### PR DESCRIPTION
Include the step index in its path, this way we can report results even if step descriptions are duplicates.

Closes #622