### PR TITLE
Add `focused` filter for asserting on focus state

### DIFF
--- a/.changeset/focused-filter.md
+++ b/.changeset/focused-filter.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/interactor": minor
+"bigtest": patch
+---
+
+Add `focused` filter to `Button`, `RadioButton`, `CheckBox`, `Link`,
+and `TextField` interactors

--- a/packages/interactor/src/definitions/button.ts
+++ b/packages/interactor/src/definitions/button.ts
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '../index';
+import { createInteractor, perform, focused } from '../index';
 import { isVisible } from 'element-is-visible';
 
 function isButtonElement(element: HTMLInputElement | HTMLButtonElement): element is HTMLButtonElement {
@@ -23,7 +23,8 @@ export const Button = createInteractor<HTMLInputElement | HTMLButtonElement>('bu
     disabled: {
       apply: (element) => element.disabled,
       default: false
-    }
+    },
+    focused
   },
   actions: {
     click: perform((element) => { element.click(); }),

--- a/packages/interactor/src/definitions/check-box.ts
+++ b/packages/interactor/src/definitions/check-box.ts
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '../index';
+import { createInteractor, perform, focused } from '../index';
 import { isVisible } from 'element-is-visible';
 
 export const CheckBox = createInteractor<HTMLInputElement>('check box')({
@@ -16,7 +16,8 @@ export const CheckBox = createInteractor<HTMLInputElement>('check box')({
     disabled: {
       apply: (element) => element.disabled,
       default: false
-    }
+    },
+    focused
   },
   actions: {
     click: perform((element) => { element.click(); }),

--- a/packages/interactor/src/definitions/link.ts
+++ b/packages/interactor/src/definitions/link.ts
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '../index';
+import { createInteractor, perform, focused } from '../index';
 import { isVisible } from 'element-is-visible';
 
 export const Link = createInteractor<HTMLLinkElement>('link')({
@@ -8,6 +8,7 @@ export const Link = createInteractor<HTMLLinkElement>('link')({
     href: (element) => element.href,
     id: (element) => element.id,
     visible: { apply: isVisible, default: true },
+    focused
   },
   actions: {
     click: perform((element) => { element.click(); })

--- a/packages/interactor/src/definitions/radio-button.ts
+++ b/packages/interactor/src/definitions/radio-button.ts
@@ -1,4 +1,4 @@
-import { createInteractor, perform } from '../index';
+import { createInteractor, perform, focused } from '../index';
 import { isVisible } from 'element-is-visible';
 
 export const RadioButton = createInteractor<HTMLInputElement>('radio button')({
@@ -16,7 +16,8 @@ export const RadioButton = createInteractor<HTMLInputElement>('radio button')({
     disabled: {
       apply: (element) => element.disabled,
       default: false
-    }
+    },
+    focused
   },
   actions: {
     click: perform((element) => { element.click(); }),

--- a/packages/interactor/src/definitions/text-field.ts
+++ b/packages/interactor/src/definitions/text-field.ts
@@ -1,4 +1,4 @@
-import { createInteractor, perform, fillIn } from '../index';
+import { createInteractor, perform, fillIn, focused } from '../index';
 import { isVisible } from 'element-is-visible';
 
 const selector = 'textarea, input' + [
@@ -19,7 +19,8 @@ export const TextField = createInteractor<HTMLInputElement | HTMLTextAreaElement
     disabled: {
       apply: (element) => element.disabled,
       default: false
-    }
+    },
+    focused
   },
   actions: {
     click: perform((element) => { element.click(); }),

--- a/packages/interactor/src/focused.ts
+++ b/packages/interactor/src/focused.ts
@@ -1,0 +1,3 @@
+export function focused(element: Element): boolean {
+  return element.ownerDocument.activeElement === element;
+}

--- a/packages/interactor/src/index.ts
+++ b/packages/interactor/src/index.ts
@@ -4,6 +4,7 @@ export { Page } from './page';
 export { App } from './app';
 export { perform } from './perform';
 export { fillIn } from './fill-in';
+export { focused } from './focused';
 
 export { Link } from './definitions/link';
 export { Heading } from './definitions/heading';

--- a/packages/interactor/test/definitions/button.test.ts
+++ b/packages/interactor/test/definitions/button.test.ts
@@ -89,6 +89,7 @@ describe('@bigtest/interactor', () => {
         `);
 
         await Button('Foo').focus();
+        await Button('Foo').is({ focused: true });
         await Heading('Success').exists();
       });
     });
@@ -110,6 +111,7 @@ describe('@bigtest/interactor', () => {
         await Button('Foo').focus();
         await Button('Foo').blur();
         await Heading('Success').exists();
+        await Button('Foo').is({ focused: false })
       });
     });
 

--- a/packages/interactor/test/definitions/check-box.test.ts
+++ b/packages/interactor/test/definitions/check-box.test.ts
@@ -236,5 +236,21 @@ describe('@bigtest/interactor', () => {
         await expect(CheckBox({ id: 'accept-field' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
+
+    describe('filter `focused`', () => {
+      it('filters checkboxes by whether they have focus', async () => {
+        dom(`
+          <p>
+            <input required type="checkbox" id="focused"/>
+            <input required type="checkbox" id="not-focused"/>
+            <script type="text/javascript">document.getElementById('focused').focus()</script>
+          </p>
+`);
+
+        await CheckBox({id: 'focused'}).is({ focused: true });
+        await CheckBox({id: 'not-focused', focused: true }).absent();
+      });
+    });
+
   });
 });

--- a/packages/interactor/test/definitions/link.test.ts
+++ b/packages/interactor/test/definitions/link.test.ts
@@ -99,5 +99,18 @@ describe('@bigtest/interactor', () => {
         await expect(Link('Foo', { id: 'does-not-exist' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
+
+    describe('filter `focused`', () => {
+      it.only('filters `a` tags by if they are focused', async () => {
+        dom(`
+          <p><a href="/has-focus" id="with">With Focus</a></p>
+          <p><a href="/does-not-have-focus" id="without">Without Focus</a></p>
+          <script type="text/javascript">document.links.with.focus()</script>
+        `);
+
+        await expect(Link('With Focus').is({ focused: true })).resolves.toBeUndefined();
+        await expect(Link('Without Focus', { focused: true }).absent()).resolves.toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/interactor/test/definitions/radio-button.test.ts
+++ b/packages/interactor/test/definitions/radio-button.test.ts
@@ -176,5 +176,20 @@ describe('@bigtest/interactor', () => {
         await expect(RadioButton({ id: 'accept-field' }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError');
       });
     });
+
+    describe('filter `focused`', () => {
+      it.only('filters radio buttons by whether they have focus', async () => {
+        dom(`
+          <p>
+            <input required type="radio" id="focused"/>
+            <input required type="radio" id="not-focused"/>
+            <script type="text/javascript">document.getElementById('focused').focus()</script>
+          </p>
+`);
+
+        await RadioButton({id: 'focused'}).is({ focused: true });
+        await RadioButton({id: 'not-focused', focused: true }).absent();
+      });
+    });
   });
 });

--- a/packages/interactor/test/definitions/text-field.test.ts
+++ b/packages/interactor/test/definitions/text-field.test.ts
@@ -93,6 +93,7 @@ describe('@bigtest/interactor', () => {
         `);
 
         await TextField('Name').focus();
+        await TextField('Name').is({ focused: true });
         await Heading('Success').exists();
       });
     });
@@ -112,6 +113,7 @@ describe('@bigtest/interactor', () => {
 
         await TextField('Name').focus();
         await TextField('Name').blur();
+        await TextField('Name').is({ focused: false });
         await Heading('Success').exists();
       });
     });


### PR DESCRIPTION
Motivation
-----------

When trying to implement the [todomvc test suite][1] using bigtest, the very first assertion is that the todo input field has focus, which made it immediately apparent that where focus is depending on various actions is quite important for usability and accessibility. Questions like "where is the focus when I open an aplication url?" or "where does the focus go when I navigate to a particular route?" are critical to be able to ask.

Approach
----------
This adds a `focused` filter to all of the focusable elements (link, button, checkbox, radio, textfield)

Open Questions
----------------

- [x] I named this `focused` to follow the convention of `disabled` and it reads better with an `is()` clause rather than a `has()` clause, but I could see an argument to name the filter `focus` since a document can only have but one focus and `has({ focus: true })` would work as well as `is({ focus: true })` if you read `focus` as **the** focus. in other words:
  - `is({ focus: true })`: "element is _the_ focus"
  - `has({ focus: true })`: "element has _the_ focus"

[1]: https://github.com/tastejs/todomvc/blob/master/tests/test.js