### PR TITLE
Show app errors on test run if application server exits prematurely

### DIFF
--- a/.changeset/cyan-pandas-think.md
+++ b/.changeset/cyan-pandas-think.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/server": minor
+"bigtest": minor
+---
+
+Show app errors on test run if application server exits prematurely

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -268,6 +268,23 @@ describe('@bigtest/cli', function() {
         expect(child.stdout?.output).toContain('⨯ FAILURE')
       });
     });
+
+    describe('running the suite with app errors', () => {
+      let child: TestProcess;
+      let status: ExitStatus;
+
+      beforeEach(async () => {
+        child = await run('ci', '--app-command', 'yarn node doesnotexist.js');
+        status = await child.join();
+      });
+
+      it('exits with error code', async () => {
+        expect(status.code).toEqual(1);
+        expect(child.stdout?.output).toContain('Application exited unexpectedly with exit code 1 with the following output:')
+        expect(child.stdout?.output).toContain('Cannot find module')
+        expect(child.stdout?.output).toContain('⨯ FAILURE')
+      });
+    });
   });
 
   describe('coverage', () => {

--- a/packages/server/src/app-server.ts
+++ b/packages/server/src/app-server.ts
@@ -33,21 +33,19 @@ const startApp = ({ atom }: AppServerOptions): Service<AppOptions> => function* 
     yield spawn(function* () {
       let exitStatus = yield child.join();
 
-      appStatus.set({ type: 'crashed', exitStatus });
+      appStatus.set({ type: 'exited', exitStatus });
     });
   }
 
   appStatus.set({ type: 'started' });
-  
-  while(true) {
+
+  while(!(yield isReachable(options.url))) {
     yield timeout(100);
-    
-    if (yield isReachable(options.url)) {
-      appStatus.set({ type: 'reachable' });
-    } else {
-      appStatus.set({ type: 'unreachable' });
-    }
   }
+
+  appStatus.set({ type: 'reachable' });
+
+  yield;
 }
 
 function* isReachable(url: string) {

--- a/packages/server/src/command-processor.ts
+++ b/packages/server/src/command-processor.ts
@@ -47,6 +47,21 @@ function* run({ id: testRunId, files }: RunMessage, options: CommandProcessorOpt
       return;
     }
 
+    let appStatus = options.atom.slice("appService", "status").get();
+
+    if(appStatus.type === 'exited') {
+      testRunSlice.set({
+        testRunId: testRunId,
+        status: 'failed',
+        error: {
+          name: 'AppError',
+          message: `Application exited unexpectedly with exit code ${appStatus.exitStatus.code} with the following output:\n\n${appStatus.exitStatus.tail}`
+        },
+        agents: {}
+      });
+      return;
+    }
+
     // todo: we should perform filtering of the agents here
     let agents: AgentState[] = Object.values(options.atom.get().agents);
 

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,3 +1,4 @@
+import { fork } from 'effection';
 import { OrchestratorState } from './orchestrator/state';
 import { Atom } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';
@@ -8,9 +9,7 @@ export interface LoggerOptions {
 }
 
 export function* createLogger({ atom, out }: LoggerOptions) {
-  let bundlerState = atom.slice('bundler');
-
-  yield subscribe(bundlerState).forEach(function* (event) {
+  yield fork(subscribe(atom.slice('bundler')).forEach(function* (event) {
     if(event.type === 'ERRORED'){
       out("[manifest builder] build error:");
       out(event.error.message);
@@ -18,5 +17,14 @@ export function* createLogger({ atom, out }: LoggerOptions) {
     if(event.type === 'GREEN'){
       out("[manifest builder] build successful!");
     }
-  })
+  }));
+
+  yield fork(subscribe(atom.slice('appService', 'status')).forEach(function* (status) {
+    if(status.type === 'reachable') {
+      out("[app] successfully connected to application!");
+    }
+    if(status.type === 'exited') {
+      out(`[app] application has exited with status code ${status.exitStatus.code}`)
+    }
+  }));
 }

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -119,10 +119,10 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
       console.debug('[orchestrator] connection server ready');
     });
     yield fork(function*() {
-      yield options.atom.slice('appService', 'status').once((status) => {
-        return status.type === 'reachable'
+      let status = yield options.atom.slice('appService', 'status').once((status) => {
+        return status.type === 'reachable' || status.type === 'exited';
       });
-      console.debug('[orchestrator] app server ready');
+      console.debug(`[orchestrator] app server ${status.type}`);
     });
     yield fork(function* () {
       yield options.atom.slice('bundler').once(({ type }) => type === 'GREEN' || type === 'ERRORED');

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -51,11 +51,10 @@ export type BundlerState =
 export type BundlerTypes = Pick<BundlerState, 'type'>['type'];
 
 export type ServiceStatus =
-  | { type: 'unstarted' } 
+  | { type: 'unstarted' }
   | { type: 'started' }
   | { type: 'reachable' }
-  | { type: 'unreachable' }
-  | { type: 'crashed'; exitStatus: ExitStatus };
+  | { type: 'exited'; exitStatus: ExitStatus };
 
 export type ServiceStatuses = ServiceStatus['type'];
 

--- a/packages/server/test/app-server.test.ts
+++ b/packages/server/test/app-server.test.ts
@@ -16,56 +16,50 @@ describe('app service', () => {
       atom = createOrchestratorAtom({ app: {
           url: "http://localhost:24000",
           command: "yarn test:app:start 24000",
-        } 
+        }
       });
-  
+
       actions.fork(function * () {
         yield createAppServer({ atom })
       });
     });
-  
-    it("should be transition from 'started' to 'unreachable' to 'reachable'", async () => {
+
+    it("should be transition from 'started' to 'reachable'", async () => {
       let appStatus = atom.slice('appService', 'status');
-  
+
       expect(appStatus.get().type).toBe('started');
-  
-      await actions.fork(
-        appStatus.once(status => status.type === 'unreachable')
-      );
-  
-      expect(appStatus.get().type).toBe('unreachable');
-  
+
       await actions.fork(
         appStatus.once(status => status.type === 'reachable')
       );
-  
+
       expect(appStatus.get().type).toBe('reachable');
     });
   });
 
-  describe('crashed', () => {
+  describe('exited', () => {
     beforeEach(() => {
       atom = createOrchestratorAtom({ app: {
           url: "http://localhost:24000",
           command: "yarn no:such:command",
-        } 
+        }
       });
-  
+
       actions.fork(function * () {
         yield createAppServer({ atom })
       });
     });
 
-    it('should transition to crashed', async () => {
+    it('should transition to exited', async () => {
       let appStatus = atom.slice('appService', 'status');
 
       await actions.fork(
-        appStatus.once(status => status.type === 'crashed')
+        appStatus.once(status => status.type === 'exited')
       );
 
       let current = appStatus.get();
 
-      assertAppServiceStatus(current.type, { is: 'crashed' });
+      assertAppServiceStatus(current.type, { is: 'exited' });
 
       expect(current.exitStatus.code).toBe(1);
     })


### PR DESCRIPTION
If the app server exits for any reason, we should show the output of it so it's easy to debug what went wrong.

There are many ways of implementing this. We decided on adding the check at the beginning of the test run and allowing the orchestrator to boot fully even if the app server has exited. This way we open up for a more advanced handling of the app server in the future. For example we could attempt to restart it on every test run if it has exited.

We could even lazy-load it and not attempt to start it until the first test run is initiated, this would make our orchestrator start significantly faster. We could also do the the same for the bundler.

I also adjusted the possible values for the state of the app server: crashes has been renamed with the more neutral exited, since we don't actually know why the server exited, it could have just exited with `0`, for example if the user forgot to add `--watch` or something. The unreachable state was removed entirely, since it interacted badly with the `exited` state, effectively overwriting its value, and therefore the `exitStatus` information not being available when we want to print the error.

Closes #321
Closes #642

<img width="975" alt="Screenshot 2020-10-22 at 09 52 25" src="https://user-images.githubusercontent.com/134/96841755-73ee5000-144c-11eb-9c04-eefb75155479.png">
