### PR TITLE
simplify the passing of options and status into a service

### DIFF
--- a/.changeset/grumpy-planets-hunt.md
+++ b/.changeset/grumpy-planets-hunt.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": minor
+"@bigtest/server": minor
+---
+
+pass the whole service slice of options and status into the service

--- a/packages/cli/src/start-server.ts
+++ b/packages/cli/src/start-server.ts
@@ -14,7 +14,7 @@ interface Options {
 export function* startServer(project: ProjectOptions, options: Options) {
   return yield readyResource({}, function*(ready) {
     let delegate = new Mailbox();
-    let atom = createOrchestratorAtom({ app: project.app });
+    let atom = createOrchestratorAtom(project);
     yield spawn(createOrchestrator({ atom, delegate, project }));
 
     yield function*() {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -35,6 +35,7 @@
     "@types/rimraf": "3.0.0",
     "@types/websocket": "^1.0.0",
     "abort-controller": "^3.0.0",
+    "deepmerge": "^4.2.2",
     "expect": "^24.9.0",
     "get-port": "^5.1.1",
     "mocha": "^6.2.2",

--- a/packages/server/src/app-server.ts
+++ b/packages/server/src/app-server.ts
@@ -16,7 +16,7 @@ export const appServer: Service<AppServiceStatus, AppOptions> = (serviceSlice) =
 const startApp = (serviceSlice: Slice<ServiceState<AppServiceStatus, AppOptions>, OrchestratorState>) => function* (options: AppOptions) {
   assert(!!options.url, 'no app url given');
 
-  let AppServiceStatus = serviceSlice.slice('status')
+  let appServiceStatus = serviceSlice.slice('status')
   
   if (options.command) {
     let child: Process = yield exec(options.command as string, {
@@ -27,17 +27,17 @@ const startApp = (serviceSlice: Slice<ServiceState<AppServiceStatus, AppOptions>
     yield spawn(function* () {
       let exitStatus = yield child.join();
 
-      AppServiceStatus.set({ type: 'exited', exitStatus });
+      appServiceStatus.set({ type: 'exited', exitStatus });
     });
   }
 
-  AppServiceStatus.set({ type: 'started' });
+  appServiceStatus.set({ type: 'started' });
 
   while(!(yield isReachable(options.url))) {
     yield timeout(100);
   }
 
-  AppServiceStatus.set({ type: 'ready' });
+  appServiceStatus.set({ type: 'ready' });
 
   yield;
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,6 @@ import { createOrchestratorAtom } from './orchestrator/atom';
 import { ProjectOptions } from '@bigtest/project';
 
 export function* createServer(project: ProjectOptions): Operation {
-  let atom = createOrchestratorAtom({ app: project.app });
+  let atom = createOrchestratorAtom(project);
   yield createOrchestrator({ atom, project });
 }

--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -42,7 +42,10 @@ module.exports = {
   yield writeFile(destinationPath, manifest);
 }
 
-export const manifestGenerator: Service<ManifestGeneratorStatus, ManifestGeneratorOptions> = function *(serviceStatus, options) {
+export const manifestGenerator: Service<ManifestGeneratorStatus, ManifestGeneratorOptions> = function *(serviceSlice) {
+  let options = serviceSlice.slice('options').get();
+  let serviceStatus = serviceSlice.slice('status');
+
   assert(!!options.files, 'no files options in ManifestGeneratorOptions');
   assert(!!options.destinationPath, 'no destinationApth in ManifestGeneratorOptions');
 

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -43,7 +43,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
 
   let connectTo = `ws://localhost:${options.project.connection.port}`;
 
-  yield spawn(createLogger({ atom: options.atom,  out: console.error }));
+  yield spawn(createLogger({ atom: options.atom, out: console.error }));
 
   let browserManager: BrowserManager = yield createBrowserManager({
     atom: options.atom,
@@ -73,9 +73,9 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     manifestPort: options.project.manifest.port,
   }));
 
-  let appServerStatus = options.atom.slice('appService', 'status');
+  let appServerState = options.atom.slice('appService');
 
-  yield fork(appServer(appServerStatus, { atom: options.atom }));
+  yield fork(appServer(appServerState));
 
   yield fork(createManifestServer({
     delegate: manifestServerDelegate,
@@ -84,14 +84,9 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     proxyPort: options.project.proxy.port,
   }));
 
-  let manifestServiceStatus = options.atom.slice('manifestGenerator', 'status');
+  let manifestGeneratorState = options.atom.slice('manifestGenerator');
 
-  yield fork(manifestGenerator(manifestServiceStatus, {
-    destinationPath: manifestSrcPath,
-    atom: options.atom,
-    mode: options.project.watchTestFiles ? 'watch' : 'build',
-    files: options.project.testFiles
-  }));
+  yield fork(manifestGenerator(manifestGeneratorState));
 
   console.debug('[orchestrator] wait for manifest generator');
   yield options.atom.slice('manifestGenerator', 'status').once(({ type }) => type === 'ready');

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -1,16 +1,24 @@
 import { Atom } from "@bigtest/atom";
-import { AppOptions, OrchestratorState } from "./state";
+import { OrchestratorState } from "./state";
+import { ProjectOptions } from '@bigtest/project/dist';
+import path = require('path');
 
-interface OrchestratorAtomOptions {
-  app?: AppOptions;
-}
+// TODO: eventually we can remove this type and just use ProjectOptions.
+// But until then we can just pick the bits we need.
+export type OrchestratorAtomOptions = Pick<ProjectOptions, 'app' |'watchTestFiles' | 'cacheDir' | 'testFiles'>
 
-export const createOrchestratorAtom = (options?: OrchestratorAtomOptions) => {
+export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
+  let manifestSrcDir = path.resolve(project.cacheDir, 'manifest/src');
+  let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');
+
   let atom = new Atom<OrchestratorState>({
     manifestGenerator: {
       status: { type: 'pending' },
+      
       options: {
-        mode: 'idle'
+        destinationPath: manifestSrcPath,
+        mode: project.watchTestFiles ? 'watch' : 'build',
+        files: project.testFiles
       }
     },
     manifest: {
@@ -25,7 +33,7 @@ export const createOrchestratorAtom = (options?: OrchestratorAtomOptions) => {
     },
     appService: {
       status: { type: 'pending' },
-      options: options?.app || {},
+      options: project.app,
     },
     proxyService: {
       proxyStatus: 'unstarted'

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -1,6 +1,6 @@
 import type { Test, TestResult, ResultStatus, ErrorDetails } from '@bigtest/suite';
 import type { BundlerError, BundlerWarning } from '@bigtest/bundler';
-import type { Atom, Slice } from '@bigtest/atom';
+import type { Slice } from '@bigtest/atom';
 import { Operation } from 'effection';
 
 export type AgentState = {
@@ -59,7 +59,7 @@ export type ServiceState<S extends ServiceStatus, O> = {
 };
 
 export type Service<S extends ServiceStatus, O> = {
-  (status: Slice<S, OrchestratorState>, options: O & { atom: Atom<OrchestratorState> }): Operation<void>;
+  (state: Slice<ServiceState<S, O>, OrchestratorState>): Operation<void>;
 };  
 
 export interface Manifest extends Test  {

--- a/packages/server/test/app-server.test.ts
+++ b/packages/server/test/app-server.test.ts
@@ -1,29 +1,25 @@
 import { describe, beforeEach, it } from 'mocha';
 import * as expect from 'expect';
-import type { AppServiceStatus, OrchestratorState } from '../src/orchestrator/state';
+import type { AppServiceStatus, OrchestratorState, ServiceState, AppOptions } from '../src/orchestrator/state';
 import type { Atom, Slice } from '@bigtest/atom';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { assertStatus } from '../src/assertions/status-assertions';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { appServer } from '../src/app-server';
 
 describe('app service', () => {
   let atom: Atom<OrchestratorState>;
-  let appStatus: Slice<AppServiceStatus, OrchestratorState>;
+  let appStatus: Slice<ServiceState<AppServiceStatus, AppOptions>, OrchestratorState>;
 
   describe('ready', () => {
     beforeEach(() => {
-      atom = createOrchestratorAtom({ app: {
-        url: "http://localhost:24000",
-        command: "yarn test:app:start 24000",
-      }
-    });
+      atom = createOrchestratorAtom(getTestProjectOptions());
 
-      appStatus = atom.slice('appService', 'status');
+      appStatus = atom.slice('appService');
 
       actions.fork(function * () {
-        yield appServer(appStatus, { atom });
+        yield appServer(appStatus);
       });
     });
 
@@ -42,16 +38,16 @@ describe('app service', () => {
 
   describe('exited', () => {
     beforeEach(() => {
-      atom = createOrchestratorAtom({ app: {
-          url: "http://localhost:24000",
+      atom = createOrchestratorAtom(getTestProjectOptions({
+        app: {
           command: "yarn no:such:command",
         }
-      });
+      }));
 
-      appStatus = atom.slice('appService', 'status');
+      appStatus = atom.slice('appService');
 
       actions.fork(function * () {
-        yield appServer(appStatus, { atom })
+        yield appServer(appStatus)
       });
     });
 

--- a/packages/server/test/command-processor.test.ts
+++ b/packages/server/test/command-processor.test.ts
@@ -6,7 +6,7 @@ import { Atom } from '@bigtest/atom';
 
 import { AgentEvent, Command as AgentCommand } from '@bigtest/agent';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { createCommandProcessor } from '../src/command-processor';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { CommandMessage } from '../src/command-server';
@@ -23,7 +23,7 @@ describe('command processor', () => {
     delegate = new Mailbox();
     events = new Mailbox();
     commands = new Mailbox();
-    atom = createOrchestratorAtom();
+    atom = createOrchestratorAtom(getTestProjectOptions());
     atom.slice('agents', 'agent-1').set({
       agentId: 'agent-1',
       browser: { name: "Safari", version: "13.0.4" },

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -8,7 +8,7 @@ import { Client } from '@bigtest/client';
 
 import { ChainableSubscription } from '@effection/subscription';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { createCommandServer } from '../src/command-server';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 
@@ -23,7 +23,7 @@ describe('command server', () => {
 
   beforeEach(async () => {
     delegate = new Mailbox();
-    let atom = createOrchestratorAtom();
+    let atom = createOrchestratorAtom(getTestProjectOptions());
     agents = atom.slice('agents');
     manifest = atom.slice('manifest');
     actions.fork(createCommandServer({

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -8,21 +8,32 @@ import { Agent } from '@bigtest/agent';
 import { World } from './helpers/world';
 
 import { createOrchestrator } from '../src/index';
-import { createOrchestratorAtom } from '../src/orchestrator/atom';
+import { createOrchestratorAtom, OrchestratorAtomOptions } from '../src/orchestrator/atom';
 import { AppOptions } from '../src/orchestrator/state';
 import { Manifest, BundlerState } from '../src/orchestrator/state';
+import * as merge from 'deepmerge';
+
+export type DeepPartial<T> = { [P in keyof T]?: DeepPartial<T[P]> };
 
 let orchestratorPromise: Context;
 let manifest: Manifest;
 let bundler: BundlerState = { type: 'UNBUNDLED' };
 
+const TestProjectOptions: OrchestratorAtomOptions = {
+  app: {
+    url: "http://localhost:24100",
+    command: "yarn test:app:start 24100",
+  },
+  testFiles: ["test/fixtures/*.t.js"],
+  cacheDir: "./tmp/test/orchestrator",
+  watchTestFiles: true
+}
+
+export const getTestProjectOptions = (overrides: DeepPartial<OrchestratorAtomOptions> = {}) =>
+  merge(TestProjectOptions, overrides) as OrchestratorAtomOptions;
+
 export const actions = {
-  atom: createOrchestratorAtom({
-    app: {
-      url: "http://localhost:24100",
-      command: "yarn test:app:start 24100",
-    },
-  }),
+  atom: createOrchestratorAtom(getTestProjectOptions()),
 
   fork<T>(operation: Operation<T>): Context<T> {
     return currentWorld.fork(operation);

--- a/packages/server/test/logger.test.ts
+++ b/packages/server/test/logger.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { createLogger } from '../src/logger';
 import { createOrchestratorAtom } from '../src';
 import { OrchestratorState } from '../src/orchestrator/state';
@@ -14,7 +14,7 @@ describe('logger', () => {
       expect(args).toEqual(["[manifest builder] build error:", "blah"]);
     };
 
-    atom = createOrchestratorAtom();
+    atom = createOrchestratorAtom(getTestProjectOptions());
     
     actions.fork(createLogger({ atom, out: logger }));
     

--- a/packages/server/test/manifest-builder.test.ts
+++ b/packages/server/test/manifest-builder.test.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs';
 
 import { Atom } from '@bigtest/atom';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { createManifestBuilder, updateSourceMapURL } from '../src/manifest-builder';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { OrchestratorState } from '../src/orchestrator/state';
@@ -31,7 +31,7 @@ describe('manifest builder', () => {
     await mkdir(SRC_DIR, { recursive: true });
     await copyFile(path.join(FIXTURES_DIR, 'raw-tree-format.t.js'), MANIFEST_PATH);
 
-    atom = createOrchestratorAtom();
+    atom = createOrchestratorAtom(getTestProjectOptions());
 
     actions.fork(function*() {
       yield createManifestBuilder({

--- a/packages/server/test/proxy.test.ts
+++ b/packages/server/test/proxy.test.ts
@@ -8,7 +8,7 @@ import { Atom } from '@bigtest/atom';
 import { AgentServerConfig } from '@bigtest/agent';
 import { fetch } from '@effection/fetch';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 import { createProxyServer } from '../src/proxy';
 import { OrchestratorState } from '../src/orchestrator/state';
 import { createOrchestratorAtom } from '../src/orchestrator/atom';
@@ -53,11 +53,12 @@ describe('proxy', () => {
     beforeEach(async () => {
       actions.fork(startAppServer);
 
-      atom = createOrchestratorAtom({
+      atom = createOrchestratorAtom(getTestProjectOptions({
         app: {
           url: `http://localhost:${APP_PORT}`
         }
-      });
+      }));
+
       actions.fork(createProxyServer({ atom, agentServerConfig, port: PROXY_PORT }));
 
       await actions.fork(atom.once((s) => s.proxyService.proxyStatus === 'started'));
@@ -131,7 +132,7 @@ describe('proxy', () => {
     let body: string;
 
     beforeEach(async () => {
-      atom = createOrchestratorAtom();
+      atom = createOrchestratorAtom(getTestProjectOptions());
       actions.fork(createProxyServer({ atom, agentServerConfig, port: PROXY_PORT }));
 
       await actions.fork(atom.once((s) => s.proxyService.proxyStatus === 'started'));

--- a/packages/server/test/result-stream.test.ts
+++ b/packages/server/test/result-stream.test.ts
@@ -10,7 +10,7 @@ import { createOrchestratorAtom } from '../src/orchestrator/atom';
 import { OrchestratorState, TestRunState } from '../src/orchestrator/state';
 import { TestEvent } from '../src/schema/test-event';
 
-import { actions } from './helpers';
+import { actions, getTestProjectOptions } from './helpers';
 
 describe('result stream', () => {
   let atom: Atom<OrchestratorState>;
@@ -18,7 +18,7 @@ describe('result stream', () => {
   let subscription: ChainableSubscription<TestEvent, void>;
 
   beforeEach(async () => {
-    atom = createOrchestratorAtom();
+    atom = createOrchestratorAtom(getTestProjectOptions());
     slice = atom.slice('testRuns', 'test-run-1');
     slice.set({
       testRunId: 'test-run-1',


### PR DESCRIPTION
I was experiencing a lot of friction between passing config into the 2 services we have so far and this PR is to simplify this before refactoring any more code.

For example, the `manifestGenerator` currently shares the same properties when `createOrchestratorAtom` is called and when the service is created in `orchestrator`:

```ts
    manifestGenerator: {
      status: { type: 'pending' },
      options: {
        mode: 'idle'
      }
    },
```

and in orchestrator:

```ts
  yield fork(manifestGenerator(manifestServiceStatus, {
    destinationPath: manifestSrcPath,
    atom: options.atom,
    mode: options.project.watchTestFiles ? 'watch' : 'build',
    files: options.project.testFiles
  }));
```

This is further complicated with `strictNullChecks` in tsconfig.json.   It is also annoying to have to pass the `atom` in when creating the service.

After the refactoring in this PR, the above looks like this:

```ts
  let appServerState = options.atom.slice('appService');

  yield fork(appServer(appServerState));

  let manifestGeneratorState = options.atom.slice('manifestGenerator');

  yield fork(manifestGenerator(manifestGeneratorState));
```

The whole slice is passed into the service which should make the `orchestrator` much clearer as we create more services.

The adding of the configuration has been pushed into `createOrchestratorAtom`:

```ts
export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
  let manifestSrcDir = path.resolve(project.cacheDir, 'manifest/src');
  let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');

  let atom = new Atom<OrchestratorState>({
    manifestGenerator: {
      status: { type: 'pending' },
      
      options: {
        destinationPath: manifestSrcPath,
        mode: project.watchTestFiles ? 'watch' : 'build',
        files: project.testFiles
      }
    },
    appService: {
      status: { type: 'pending' },
      options: project.app,
    },
```

