### PR TITLE
Modify post function to include content-type to satisfy geckodriver

### DIFF
--- a/.changeset/eight-llamas-develop.md
+++ b/.changeset/eight-llamas-develop.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/webdriver": patch
+---
+
+Modify post function to include content-type to satisfy geckodriver

--- a/.changeset/pink-parents-help.md
+++ b/.changeset/pink-parents-help.md
@@ -1,0 +1,5 @@
+---
+"bigtest": patch
+---
+
+Modify post function in webdriver for firefox

--- a/packages/webdriver/src/web-driver.ts
+++ b/packages/webdriver/src/web-driver.ts
@@ -19,9 +19,12 @@ export class WebDriver implements Driver<WDSession> {
   }
 
   *navigateTo(url: string): Operation<void> {
-    yield request(`${this.serverURL}/session/${this.session.sessionId}/url`, {
+    yield post(`${this.serverURL}/session/${this.session.sessionId}/url`, {
       method: 'post',
-      body: JSON.stringify({ url })
+      body: JSON.stringify({ url }),
+      headers: {
+        "Content-Type": 'application/json'
+      }
     });
   }
 }
@@ -42,15 +45,18 @@ export function* connect(driver: WebDriver, options: Options): Operation<void> {
       .over(args => args.concat(['--headless']))
   }
 
-  driver.session = yield request(`${driver.serverURL}/session`, {
+  driver.session = yield post(`${driver.serverURL}/session`, {
     method: 'post',
     body: JSON.stringify({
       capabilities: capabilities.get()
-    })
+    }),
+    headers: {
+      "Content-Type": 'application/json'
+    }
   });
 }
 
-function* request(url: string, init: RequestInit): Operation<WDResponse> {
+function* post(url: string, init: RequestInit): Operation<WDResponse> {
   let response: Response = yield fetch(url, init);
 
   if (!response.ok) {

--- a/packages/webdriver/src/web-driver.ts
+++ b/packages/webdriver/src/web-driver.ts
@@ -20,11 +20,7 @@ export class WebDriver implements Driver<WDSession> {
 
   *navigateTo(url: string): Operation<void> {
     yield post(`${this.serverURL}/session/${this.session.sessionId}/url`, {
-      method: 'post',
-      body: JSON.stringify({ url }),
-      headers: {
-        "Content-Type": 'application/json'
-      }
+      url,
     });
   }
 }
@@ -46,18 +42,18 @@ export function* connect(driver: WebDriver, options: Options): Operation<void> {
   }
 
   driver.session = yield post(`${driver.serverURL}/session`, {
+    capabilities: capabilities.get()
+  });
+}
+
+function* post(url: string, body: Record<string, unknown>): Operation<WDResponse> {
+  let response: Response = yield fetch(url, {
     method: 'post',
-    body: JSON.stringify({
-      capabilities: capabilities.get()
-    }),
+    body: JSON.stringify(body),
     headers: {
       "Content-Type": 'application/json'
     }
   });
-}
-
-function* post(url: string, init: RequestInit): Operation<WDResponse> {
-  let response: Response = yield fetch(url, init);
 
   if (!response.ok) {
     let details: WDResponse;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,12 +2132,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -9604,7 +9599,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -15303,41 +15298,10 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.1:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## Motivation
Trying to launch Firefox would result in Geckodriver returning an `Invalid content-type` error.

## Approach
- Added `headers` property to set content-type as `application/json`.