### PR TITLE
Change default suggested app port to 3000

### DIFF
--- a/.changeset/late-starfishes-return.md
+++ b/.changeset/late-starfishes-return.md
@@ -1,0 +1,5 @@
+---
+"bigtest": patch
+---
+
+Change default suggested app port to 3000

--- a/.changeset/sharp-rocks-compete.md
+++ b/.changeset/sharp-rocks-compete.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/cli": patch
+---
+
+Change the default suggested app port to 3000 in bigtest init

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -23,7 +23,7 @@ export function* init(configFile: string): Operation<void> {
     options = JSON.parse(yield fs.readFile(path.resolve(configFile)));
   } catch {
     options = {
-      port: 24000,
+      port: 28000,
       launch: ['chrome.headless']
     };
   }
@@ -50,7 +50,7 @@ export function* init(configFile: string): Operation<void> {
     options.app.env = {
       PORT: yield prompt.number('Which port would you like to run your application on?', {
         name: 'app.env.PORT',
-        defaultValue: Number(options.app.env?.PORT) || 3000,
+        defaultValue: Number(options.app.env?.PORT) || ((options.port || 0) + 1),
         min: 0,
         max: 65535,
       })

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -50,7 +50,7 @@ export function* init(configFile: string): Operation<void> {
     options.app.env = {
       PORT: yield prompt.number('Which port would you like to run your application on?', {
         name: 'app.env.PORT',
-        defaultValue: Number(options.app.env?.PORT) || ((options.port || 0) + 1),
+        defaultValue: Number(options.app.env?.PORT) || 3000,
         min: 0,
         max: 65535,
       })


### PR DESCRIPTION
## Motivation
Sort of related to #584.

When running `yarn bigtest init`, the default suggested port for the application is [calculated by adding 1](https://github.com/thefrontside/bigtest/blob/v0/packages/cli/src/init.ts#L53) to the server port for which will [often be 24000](https://github.com/thefrontside/bigtest/blob/v0/packages/cli/src/init.ts#L25-L35). This means the application will be set up to run on 24001 but that is reserved for the proxy server.

## Approach
If `options.app.env.port` already exists, `yarn bigtest init` will use that variable as the port to suggest for running the application, if not, I've modified the default suggestion to `3000`.

I don't know if we should prevent users from setting `24001`, `24002`, `24003`, and `24005` from within `yarn bigtest init` but we need to stray away from `PORT + 1` for now in order to release beta.