### PR TITLE
Pc multi step context threading

### DIFF
--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -1,5 +1,5 @@
 import { TestImplementation, Context, Step, Assertion } from './interfaces';
-import { Stepable, ActionContext, StepDefinition, Action, ResolveContext, AssertionList, Check, TestBuilderImplementation } from './types';
+import { Stepable, ActionContext, StepDefinition, Action, ResolveContext, AssertionList, Check } from './types';
 
 
 export function test<C extends Context>(description: string): TestBuilder<C> {
@@ -11,7 +11,7 @@ export function test<C extends Context>(description: string): TestBuilder<C> {
   });
 }
 
-export class TestBuilder<C extends Context> implements TestBuilderImplementation<C> {
+export class TestBuilder<C extends Context> implements TestImplementation {
   public description: string;
   public steps: Step[];
   public assertions: Assertion[];

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -26,7 +26,7 @@ type AssertionList<C extends Context> = [AssertionDefinition<C>, ...AssertionDef
 
 type StepReturn = Context | void;
 
-type ResolveStepReturn<C extends Context, R extends StepReturn> = R extends void | undefined ? C : C & R;
+type ResolveStepReturn<C extends Context, R extends StepReturn> = R extends void | undefined | null ? C : C & R;
 
 export class TestBuilder<C extends Context> implements TestImplementation {
   public description: string;
@@ -53,7 +53,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     step1: StepDefinition<C, R1>,
     step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
     step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>
-  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>>;
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>>;
   step<
     R1 extends StepReturn,
     R2 extends StepReturn,
@@ -64,7 +64,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
     step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,
     step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>
-  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>;
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>>;
   step<
     R1 extends StepReturn,
     R2 extends StepReturn,
@@ -77,7 +77,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,
     step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,
     step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,R4>,R5>
-  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>>;
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>, R5>>;
   step<
     R1 extends StepReturn,
     R2 extends StepReturn,
@@ -92,7 +92,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,
     step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,R5>,
     step6: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>,R3>,R4>,R5>,R6>
-  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,R4>,R5>>;
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,R4>,R5>, R6>>;
   step<R extends StepReturn>(description: string, action: Action<C, R>): TestBuilder<ResolveStepReturn<C, R>>;
   step<R extends StepReturn>(...args: StepDefinition<C, R>[] | [string, Action<C, R>]): TestBuilder<ResolveStepReturn<C, R>> {
 

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -42,14 +42,59 @@ export class TestBuilder<C extends Context> implements TestImplementation {
   }
 
 
-  step<R extends StepReturn>(step: StepDefinition<C, R>): TestBuilder<ResolveStepReturn<C, R>>
-  step<R1 extends StepReturn, R2 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>
-  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>>
-  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>
-  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn, R5 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>>
-  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn, R5 extends StepReturn, R6 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>, step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>, R5>): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>>
-  step<R extends StepReturn>(description: string, action: Action<C,R>): TestBuilder<ResolveStepReturn<C, R>>;
-  step<R extends StepReturn>(...args: StepDefinition<C, R>[] | [string, Action<C,R>]): TestBuilder<ResolveStepReturn<C, R>> {
+  step<R extends StepReturn>(
+    step: StepDefinition<C, R>
+  ): TestBuilder<ResolveStepReturn<C, R>>;
+  step<R1 extends StepReturn, R2 extends StepReturn>(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveStepReturn<C, R1>, R2>
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>;
+  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn>(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
+    step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>>;
+  step<
+    R1 extends StepReturn,
+    R2 extends StepReturn,
+    R3 extends StepReturn,
+    R4 extends StepReturn
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
+    step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>;
+  step<
+    R1 extends StepReturn,
+    R2 extends StepReturn,
+    R3 extends StepReturn,
+    R4 extends StepReturn,
+    R5 extends StepReturn
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
+    step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,
+    step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,R4>,R5>
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>>;
+  step<
+    R1 extends StepReturn,
+    R2 extends StepReturn,
+    R3 extends StepReturn,
+    R4 extends StepReturn,
+    R5 extends StepReturn,
+    R6 extends StepReturn
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveStepReturn<C, R1>, R2>,
+    step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,
+    step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>,R5>,
+    step6: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>,R3>,R4>,R5>,R6>
+  ): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>,R4>,R5>>;
+  step<R extends StepReturn>(description: string, action: Action<C, R>): TestBuilder<ResolveStepReturn<C, R>>;
+  step<R extends StepReturn>(...args: StepDefinition<C, R>[] | [string, Action<C, R>]): TestBuilder<ResolveStepReturn<C, R>> {
 
     function getSteps(): Step[] {
       let [first, second] = args;

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -26,7 +26,7 @@ type AssertionList<C extends Context> = [AssertionDefinition<C>, ...AssertionDef
 
 type StepReturn = Context | void;
 
-type ResolveStepReturn<C extends Context, R extends StepReturn> = R extends void ? C : C & R;
+type ResolveStepReturn<C extends Context, R extends StepReturn> = R extends void | undefined ? C : C & R;
 
 export class TestBuilder<C extends Context> implements TestImplementation {
   public description: string;
@@ -41,15 +41,15 @@ export class TestBuilder<C extends Context> implements TestImplementation {
     this.children = test.children;
   }
 
-  
 
-  // step<R extends StepReturn>(...steps: StepList<C>): TestBuilder<C>;
-  // step<R extends StepReturn>(description: string, action: Action<C,R>): TestBuilder<ResolveStepReturn<C, R>>;
   step<R extends StepReturn>(step: StepDefinition<C, R>): TestBuilder<ResolveStepReturn<C, R>>
-  step<R extends StepReturn>(description: string, action: Action<C,R>): TestBuilder<ResolveStepReturn<C, R>>;
   step<R1 extends StepReturn, R2 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>
-  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>
-  step<R extends StepReturn>(...args: (string | Step)[]): TestBuilder<ResolveStepReturn<C, R>> {
+  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>>
+  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>): TestBuilder<ResolveStepReturn<ResolveStepReturn<C, R2>, R1>>
+  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn, R5 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>>
+  step<R1 extends StepReturn, R2 extends StepReturn, R3 extends StepReturn, R4 extends StepReturn, R5 extends StepReturn, R6 extends StepReturn>(step1: StepDefinition<C, R1>, step2: StepDefinition<ResolveStepReturn<C, R1>, R2>, step3: StepDefinition<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, step4: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>, step5: StepDefinition<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>, R5>): TestBuilder<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<ResolveStepReturn<C, R1>, R2>, R3>, R4>>
+  step<R extends StepReturn>(description: string, action: Action<C,R>): TestBuilder<ResolveStepReturn<C, R>>;
+  step<R extends StepReturn>(...args: StepDefinition<C, R>[] | [string, Action<C,R>]): TestBuilder<ResolveStepReturn<C, R>> {
 
     function getSteps(): Step[] {
       let [first, second] = args;

--- a/packages/suite/src/types.ts
+++ b/packages/suite/src/types.ts
@@ -1,0 +1,84 @@
+import { TestImplementation, Context } from './interfaces';
+
+export type Action<C extends Context, R extends Context | void> = (context: C) => Promise<R> | R;
+export type Check<C extends Context> = (context: C) => Promise<void> | void;
+
+export interface StepDefinition<C extends Context, R extends Context | void> {
+  description: string;
+  action: Action<C,R>;
+}
+
+export interface AssertionDefinition<C extends Context> {
+  description: string;
+  check: Check<C>;
+}
+
+export type AssertionList<C extends Context> = [AssertionDefinition<C>, ...AssertionDefinition<C>[]];
+
+export type ActionContext = Context | void;
+
+export type ResolveContext<C extends Context, R extends ActionContext> = R extends void | undefined | null ? C : C & R;
+
+export type Stepable<C extends Context> = {
+  <R extends ActionContext>(
+    step: StepDefinition<C, R>
+  ): TestBuilderImplementation<ResolveContext<C, R>>;
+  <R1 extends ActionContext, R2 extends ActionContext>(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveContext<C, R1>, R2>
+  ): TestBuilderImplementation<ResolveContext<ResolveContext<C, R2>, R1>>;
+  <R1 extends ActionContext, R2 extends ActionContext, R3 extends ActionContext>(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveContext<C, R1>, R2>,
+    step3: StepDefinition<ResolveContext<ResolveContext<C, R1>, R2>, R3>
+  ): TestBuilderImplementation<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>>;
+  <
+    R1 extends ActionContext,
+    R2 extends ActionContext,
+    R3 extends ActionContext,
+    R4 extends ActionContext
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveContext<C, R1>, R2>,
+    step3: StepDefinition<ResolveContext<ResolveContext<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>
+  ): TestBuilderImplementation<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>>;
+  <
+    R1 extends ActionContext,
+    R2 extends ActionContext,
+    R3 extends ActionContext,
+    R4 extends ActionContext,
+    R5 extends ActionContext
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveContext<C, R1>, R2>,
+    step3: StepDefinition<ResolveContext<ResolveContext<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>,
+    step5: StepDefinition<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>,R4>,R5>
+  ): TestBuilderImplementation<ResolveContext<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>, R5>>;
+  <
+    R1 extends ActionContext,
+    R2 extends ActionContext,
+    R3 extends ActionContext,
+    R4 extends ActionContext,
+    R5 extends ActionContext,
+    R6 extends ActionContext
+  >(
+    step1: StepDefinition<C, R1>,
+    step2: StepDefinition<ResolveContext<C, R1>, R2>,
+    step3: StepDefinition<ResolveContext<ResolveContext<C, R1>, R2>, R3>,
+    step4: StepDefinition<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>,
+    step5: StepDefinition<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>, R4>,R5>,
+    step6: StepDefinition<ResolveContext<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>,R3>,R4>,R5>,R6>
+  ): TestBuilderImplementation<ResolveContext<ResolveContext<ResolveContext<ResolveContext<ResolveContext<ResolveContext<C, R1>, R2>, R3>,R4>,R5>, R6>>;
+  <R extends ActionContext>(description: string, action: Action<C, R>): TestBuilderImplementation<ResolveContext<C, R>>;
+  <R extends ActionContext>(...args: StepDefinition<C, R>[] | [string, Action<C, R>]): TestBuilderImplementation<ResolveContext<C, R>>;
+}
+
+export type TestBuilderImplementation<C extends Context> = TestImplementation & {
+  step: Stepable<C>;
+  assertion(...assertions: AssertionList<C>): TestBuilderImplementation<C>;
+  assertion(description: string, check: Check<C>): TestBuilderImplementation<C>;
+  child(description: string, childFn: (inner: TestBuilderImplementation<C>) => TestBuilderImplementation<Context>): TestBuilderImplementation<C>;
+}
+

--- a/packages/suite/src/types.ts
+++ b/packages/suite/src/types.ts
@@ -17,17 +17,28 @@ export type AssertionList<C extends Context> = [AssertionDefinition<C>, ...Asser
 
 export type ActionContext = Context | void;
 
-export type ResolveContext<C extends Context, R extends ActionContext> = R extends void | undefined | null ? C : C & R;
+export type Nothing = void | undefined | null;
+
+export type ResolveContext<C extends Context, R extends ActionContext> = R extends Nothing ? C : C & R;
 
 export type Stepable<C extends Context> = {
-  <R extends ActionContext>(
+  <
+    R extends ActionContext
+  >(
     step: StepDefinition<C, R>
   ): TestBuilderImplementation<ResolveContext<C, R>>;
-  <R1 extends ActionContext, R2 extends ActionContext>(
+  <
+    R1 extends ActionContext,
+    R2 extends ActionContext
+  >(
     step1: StepDefinition<C, R1>,
     step2: StepDefinition<ResolveContext<C, R1>, R2>
   ): TestBuilderImplementation<ResolveContext<ResolveContext<C, R2>, R1>>;
-  <R1 extends ActionContext, R2 extends ActionContext, R3 extends ActionContext>(
+  <
+    R1 extends ActionContext,
+    R2 extends ActionContext,
+    R3 extends ActionContext
+  >(
     step1: StepDefinition<C, R1>,
     step2: StepDefinition<ResolveContext<C, R1>, R2>,
     step3: StepDefinition<ResolveContext<ResolveContext<C, R1>, R2>, R3>

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -84,9 +84,6 @@ test('say hello')
     description: "to whom",
     action: () => ({ to: "world" })
   }, {
-    description: "do nothing in between just for a laugh",
-    action: () => undefined
-  },{
     description: "say it",
     action: ({ say, to }) => {
       return { speech: `${say} ${to}`};

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -84,6 +84,9 @@ test('say hello')
     description: "to whom",
     action: () => ({ to: "world" })
   }, {
+  //   description: "do nothing in between just for a laugh",
+  //   action: (c) => undefined
+  // },{
     description: "say it",
     action: ({ say, to }) => {
       return { speech: `${say} ${to}`};

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -95,9 +95,9 @@ test('say hello')
     description: "feeling",            // step 4
     action: () => ( { emphasis: 'bold' } )
   }, {
-    description: "all together now",   // step 5 is he current limit.  You want more steps then you need more overloads
-    action: ({ say, to, speech, emphasis, ending }) => {
-      console.log(`${say} ${to} ${speech} ${emphasis} ${ending}`);
+    description: "all together now",   // step 5 is the current limit.  You want more steps then you need more overloads
+    action: ({ say, to, speech, emphasis }) => {
+      console.log(`${say} ${to} ${speech} ${emphasis}`);
   }})
   .assertion({
     description: "validate text",

--- a/packages/suite/types/dsl.ts
+++ b/packages/suite/types/dsl.ts
@@ -79,19 +79,26 @@ test('a test')
 test('say hello')
   .step({
     description: "what",
-    action: () => ({ say: 'hello' })
-  }, {
+    action: () => ({ say: 'hello' })   // step 0
+  }, {    
     description: "to whom",
-    action: () => ({ to: "world" })
+    action: () => ({ to: "world" })    // step 1
   }, {
-  //   description: "do nothing in between just for a laugh",
-  //   action: (c) => undefined
-  // },{
+    description: "do nothing in between just for a laugh",
+    action: () => undefined            // step 2
+  },{
     description: "say it",
-    action: ({ say, to }) => {
+    action: ({ say, to }) => {         // step 3
       return { speech: `${say} ${to}`};
     }
-  })
+  }, {
+    description: "feeling",            // step 4
+    action: () => ( { emphasis: 'bold' } )
+  }, {
+    description: "all together now",   // step 5 is he current limit.  You want more steps then you need more overloads
+    action: ({ say, to, speech, emphasis, ending }) => {
+      console.log(`${say} ${to} ${speech} ${emphasis} ${ending}`);
+  }})
   .assertion({
     description: "validate text",
     check: ({ speech }) => assert.equal('hello world', speech)


### PR DESCRIPTION
I had to resort to type overloads to fulfil the requirement of a `...steps` rest argument. 

I still got recursive compiler errors with typescript 4.1.

All take the same form and just build on the previous.

```ts
export type Nothing = void | undefined | null;

export type ActionContext = Context | void;

export type ResolveContext<C extends Context, R extends ActionContext> = R extends Nothing ? C : C & R;

export type Stepable<C extends Context> = {
  <R extends ActionContext>(
    step: StepDefinition<C, R>
  ): TestBuilderImplementation<ResolveContext<C, R>>;
  <R1 extends ActionContext, R2 extends ActionContext>(
    step1: StepDefinition<C, R1>,
    step2: StepDefinition<ResolveContext<C, R1>, R2>
  ): TestBuilderImplementation<ResolveContext<ResolveContext<C, R2>, R1>>;
// etc. etc.
```

I currently have gone 6 deep but if you want more, then you need more overloads.

I've pulled the overloads out into a separate [types file](./packages/suite/src/types.ts) to hide the ugliness.
