### PR TITLE
make ProxyServer a service

### DIFF
--- a/.changeset/twelve-dingos-smell.md
+++ b/.changeset/twelve-dingos-smell.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/project": minor
+"@bigtest/server": minor
+---
+
+refactor ProxyServer to Service

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -47,6 +47,7 @@ export type ProjectOptions = {
   };
   proxy: {
     port: number;
+    prefix: string;
   };
   connection: {
     port: number;
@@ -69,6 +70,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
     },
     proxy: {
       port: 24001,
+      prefix: '/__bigtest/'
     },
     connection: {
       port: 24003,

--- a/packages/server/bin/start.ts
+++ b/packages/server/bin/start.ts
@@ -14,6 +14,7 @@ main(createServer({
   },
   proxy: {
     port: 24001,
+    prefix: '/__bigtest/'
   },
   connection: {
     port: 24003,

--- a/packages/server/src/manifest-generator.ts
+++ b/packages/server/src/manifest-generator.ts
@@ -47,7 +47,7 @@ export const manifestGenerator: Service<ManifestGeneratorStatus, ManifestGenerat
   let serviceStatus = serviceSlice.slice('status');
 
   assert(!!options.files, 'no files options in ManifestGeneratorOptions');
-  assert(!!options.destinationPath, 'no destinationApth in ManifestGeneratorOptions');
+  assert(!!options.destinationPath, 'no destinationPath in ManifestGeneratorOptions');
 
   let { files, mode, destinationPath } = options;
 

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -11,7 +11,7 @@ export type OrchestratorAtomOptions = Pick<ProjectOptions, 'app' |'watchTestFile
 export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
   let manifestSrcDir = path.resolve(project.cacheDir, 'manifest/src');
   let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');
-  let agentServerConfig = new AgentServerConfig({ port: project.proxy.port, prefix: project.proxy.prefix, });
+  let agentServerConfig = new AgentServerConfig(project.proxy);
 
   let atom = new Atom<OrchestratorState>({
     manifestGenerator: {
@@ -44,7 +44,7 @@ export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
         prefix: agentServerConfig.options.prefix,
         appDir: agentServerConfig.appDir(),
         harnessUrl: agentServerConfig.harnessUrl(),
-        // TODO: this is duplication but currently we can only pass 1 slice into a service
+        // TODO: this is duplication because currently we can only pass 1 slice into a service
         // Is this problematic?
         appOptions: project.app
       }

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -2,14 +2,16 @@ import { Atom } from "@bigtest/atom";
 import { OrchestratorState } from "./state";
 import { ProjectOptions } from '@bigtest/project/dist';
 import path = require('path');
+import { AgentServerConfig } from '@bigtest/agent';
 
 // TODO: eventually we can remove this type and just use ProjectOptions.
 // But until then we can just pick the bits we need.
-export type OrchestratorAtomOptions = Pick<ProjectOptions, 'app' |'watchTestFiles' | 'cacheDir' | 'testFiles'>
+export type OrchestratorAtomOptions = Pick<ProjectOptions, 'app' |'watchTestFiles' | 'cacheDir' | 'testFiles' | 'proxy'>
 
 export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
   let manifestSrcDir = path.resolve(project.cacheDir, 'manifest/src');
   let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');
+  let agentServerConfig = new AgentServerConfig({ port: project.proxy.port, prefix: project.proxy.prefix, });
 
   let atom = new Atom<OrchestratorState>({
     manifestGenerator: {
@@ -36,7 +38,16 @@ export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
       options: project.app,
     },
     proxyService: {
-      proxyStatus: 'unstarted'
+      status: {type: 'unstarted'},
+      options: {
+        port: project.proxy.port,
+        prefix: agentServerConfig.options.prefix,
+        appDir: agentServerConfig.appDir(),
+        harnessUrl: agentServerConfig.harnessUrl(),
+        // TODO: this is duplication but currently we can only pass 1 slice into a service
+        // Is this problematic?
+        appOptions: project.app
+      }
     },
     agents: {},
     testRuns: {},

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -109,9 +109,17 @@ export interface ManifestGeneratorOptions {
   destinationPath?: string;
 };
 
-export type ProxyServiceState = {
-  proxyStatus: 'unstarted' | 'starting' | 'started';
+export type ProxyStatus = {
+  type: 'unstarted' | 'starting' | 'started';
 }
+
+export type ProxyOptions = {
+  port: number;
+  harnessUrl: string;
+  prefix?: string;
+  appDir: string;
+  appOptions: AppOptions;
+};
 
 export type OrchestratorState = {
   agents: Record<string, AgentState>;
@@ -120,7 +128,7 @@ export type OrchestratorState = {
   bundler: BundlerState;
   testRuns: Record<string, TestRunState>;
   appService: ServiceState<AppServiceStatus, AppOptions>;
-  proxyService: ProxyServiceState;
+  proxyService: ServiceState<ProxyStatus, ProxyOptions>;
 }
 
 declare const o: OrchestratorState;

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -26,7 +26,11 @@ const TestProjectOptions: OrchestratorAtomOptions = {
   },
   testFiles: ["test/fixtures/*.t.js"],
   cacheDir: "./tmp/test/orchestrator",
-  watchTestFiles: true
+  watchTestFiles: true,
+  proxy: {
+    port: 24001,
+    prefix: '/__bigtest/'
+  }
 }
 
 export const getTestProjectOptions = (overrides: DeepPartial<OrchestratorAtomOptions> = {}) =>
@@ -65,6 +69,10 @@ export const actions = {
     actions.atom
       .slice("appService", "options")
       .update(() => appOptions);
+
+    actions.atom
+      .slice('proxyService', 'options', 'appOptions')
+      .update(() => appOptions);
   },
 
   async startOrchestrator() {
@@ -77,13 +85,13 @@ export const actions = {
         project: {
           port: 24102,
           testFiles: ["test/fixtures/*.t.js"],
+          proxy: {
+            ...TestProjectOptions.proxy
+          },
           cacheDir: "./tmp/test/orchestrator",
           watchTestFiles: true,
           manifest: {
             port: 24105,
-          },
-          proxy: {
-            port: 24101,
           },
           connection: {
             port: 24103,

--- a/packages/server/test/orchestrator.test.ts
+++ b/packages/server/test/orchestrator.test.ts
@@ -34,7 +34,7 @@ describe('orchestrator', () => {
     let body: string;
 
     beforeEach(async () => {
-      response = await actions.fetch('http://localhost:24101/__bigtest/index.html');
+      response = await actions.fetch('http://localhost:24001/__bigtest/index.html');
       body = await response.text();
     });
 
@@ -51,7 +51,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.fetch('http://localhost:24101/__bigtest/harness.js');
+      response = await actions.fetch('http://localhost:24001/__bigtest/harness.js');
       body = await response.text();
     });
 
@@ -85,7 +85,7 @@ describe('orchestrator', () => {
     let response: Response;
     let body: string;
     beforeEach(async () => {
-      response = await actions.fetch('http://localhost:24101/');
+      response = await actions.fetch('http://localhost:24001/');
       body = await response.text();
     });
 
@@ -159,7 +159,7 @@ describe('orchestrator', () => {
       let response: Response;
 
       beforeEach(async () => {
-        response = await actions.fetch('http://localhost:24101/');
+        response = await actions.fetch('http://localhost:24001/');
       });
 
       it('responds successfully', () => {

--- a/packages/server/test/run-tests.test.ts
+++ b/packages/server/test/run-tests.test.ts
@@ -109,7 +109,7 @@ describe('running tests on an agent', () => {
 
     it('receives a run event on the agent', () => {
       expect(runCommand.type).toEqual('run');
-      expect(runCommand.appUrl).toEqual(`http://localhost:24101`);
+      expect(runCommand.appUrl).toEqual(`http://localhost:24001`);
       expect(runCommand.tree.description).toEqual('All tests');
     });
 


### PR DESCRIPTION
Conversion of the proxy server into a service.

Like the other services, the configuration now takes place in the `createOrchestratorAtom` and not in the orchestrator.

```ts
    proxyService: {
      status: {type: 'unstarted'},
      options: {
        port: project.proxy.port,
        prefix: agentServerConfig.options.prefix,
        appDir: agentServerConfig.appDir(),
        harnessUrl: agentServerConfig.harnessUrl(),
        appOptions: project.app
      }
    },
```

The `proxyServer` then just takes the `Slice` in the `orchestrator`

```ts
yield fork(proxyServer(options.atom.slice('proxyService')));
```