### PR TITLE
Bump all @frontside/typescript to v1.1.0

### DIFF
--- a/.changeset/loud-ladybugs-burn.md
+++ b/.changeset/loud-ladybugs-burn.md
@@ -1,0 +1,20 @@
+---
+"@bigtest/agent": patch
+"@bigtest/atom": patch
+"bigtest": patch
+"@bigtest/bundler": patch
+"@bigtest/cli": patch
+"@bigtest/driver": patch
+"@bigtest/effection": patch
+"@bigtest/effection-express": patch
+"@bigtest/globals": patch
+"@bigtest/interactor": patch
+"@bigtest/logging": patch
+"@bigtest/project": patch
+"@bigtest/server": patch
+"@bigtest/suite": patch
+"@bigtest/todomvc": patch
+"@bigtest/webdriver": patch
+---
+
+Upgrade @frontside/typescript to v1.1.0

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -29,7 +29,7 @@
     "@bigtest/suite": "^0.11.0",
     "@bigtest/webdriver": "^0.6.4",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/express": "^4.17.2",
     "@types/istanbul-lib-coverage": "^2.0.3",
     "@types/localforage": "^0.0.34",

--- a/packages/atom/package.json
+++ b/packages/atom/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@bigtest/performance": "^0.5.0",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "@types/ramda": "types/npm-ramda#dist",

--- a/packages/bigtest/package.json
+++ b/packages/bigtest/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/node": "^13.13.4",
     "ts-node": "*",
     "typescript": "3.9.7"

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/node": "^13.13.4",
     "@types/parcel-bundler": "^1.12.1",
     "expect": "^25.1.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "@effection/events": "^0.7.8",
     "@effection/subscription": "^0.11.0",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/capture-console": "1.0.0",
     "@types/istanbul-lib-coverage": "^2.0.3",
     "@types/istanbul-lib-report": "^3.0.0",

--- a/packages/driver/package.json
+++ b/packages/driver/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^14.0.11",
     "expect": "^24.9.0",

--- a/packages/effection-express/package.json
+++ b/packages/effection-express/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "expect": "^24.9.0",

--- a/packages/effection/package.json
+++ b/packages/effection/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "expect": "^24.9.0",

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "expect": "^24.9.0",

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/jsdom": "^16.2.3",
     "@types/lodash.isequal": "^4.5.5",
     "@types/mocha": "^7.0.1",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@types/node": "^13.13.4",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "ts-node": "*"
   },
   "volta": {

--- a/packages/project/package.json
+++ b/packages/project/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "expect": "^24.9.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@bigtest/todomvc": "^0.5.5",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/express": "^4.17.3",
     "@types/graphql": "^14.5.0",
     "@types/http-proxy": "^1.17.0",

--- a/packages/suite/package.json
+++ b/packages/suite/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",
     "dtslint": "^3.5.2",

--- a/packages/todomvc/package.json
+++ b/packages/todomvc/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/express": "^4.17.2",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",

--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@bigtest/effection-express": "^0.9.0",
     "@frontside/eslint-config": "^1.1.2",
-    "@frontside/typescript": "^1.0.1",
+    "@frontside/typescript": "^1.1.0",
     "@types/express": "^4.17.6",
     "@types/mocha": "^7.0.1",
     "@types/node": "^13.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2132,12 +2132,7 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34":
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
-  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
-
-"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -2239,6 +2234,22 @@
   dependencies:
     effection "^0.7.0"
 
+"@eslint/eslintrc@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
+  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
+
 "@frontside/eslint-config@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@frontside/eslint-config/-/eslint-config-1.1.2.tgz#83eb23e890868d3ce793f08315f23f987b3468c2"
@@ -2253,19 +2264,19 @@
   resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-0.0.1.tgz#f7481d8681fed3d2274991271e6f36fa5e3ed32f"
   integrity sha512-BQyLcpBIV9WQsBFQQqK/SIoEeKImWYMmu7kqLYpE3SCbCjY6ZN/yBpY63AMCCrv7V70Z5itATHTWvMAlkzkJPQ==
 
-"@frontside/tsconfig@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-1.0.0.tgz#425a2abfb039d43fbebb56485f5b67fa731b43d9"
-  integrity sha512-Lx76lqOLPXpyfyEaEjTbYA3RthHCNmX87zlo/5+FKq2EDEC94EkhKxH1YBxSAjGyguUD92h5retTQfr/smWSLw==
+"@frontside/tsconfig@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@frontside/tsconfig/-/tsconfig-1.1.0.tgz#4370d62d6cc01711ca4618e0547b4f8db164fcf2"
+  integrity sha512-6TwSIsbWkujljxBV1+xSBi+X9sUISdwuXoNagX+tx9D5jM9Ok3eBNlPA73nMg1DbLz2cyMV06BLRd8A5XSrzVg==
 
-"@frontside/typescript@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@frontside/typescript/-/typescript-1.0.1.tgz#8ece0bd23ccc7d8c07da16a876128878f4a7b49a"
-  integrity sha512-l25Ll8yIh394C8B57Qlg8KVqDk5sq3c8rFnNzllUuiB2HYCDTJTrE93IjV0Lh9voLAqEev5dobiuU/EnnFieYg==
+"@frontside/typescript@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@frontside/typescript/-/typescript-1.1.0.tgz#58680adc1b0aaf9fbf36be6712ff2d26828dfbc6"
+  integrity sha512-p6z0YUndsqSdttiFJ0Wa2Um6btY69oyVwg07DpGosHqOyg/cFWXvaxE48rvzWPw6JX4cJFrWCCrGcCK+SO1D3w==
   dependencies:
-    "@frontside/tsconfig" "1.0.0"
-    eslint "7.4.0"
-    typescript "3.9.6"
+    "@frontside/tsconfig" "1.1.0"
+    eslint "7.8.1"
+    typescript "^4.0.2"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -3405,10 +3416,10 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
-acorn@^7.3.1:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
-  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 address@1.1.2, address@^1.0.1:
   version "1.1.2"
@@ -3467,6 +3478,16 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -6432,24 +6453,25 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-utils@^2.0.0:
+eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.2.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint@7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.4.0.tgz#4e35a2697e6c1972f9d6ef2b690ad319f80f206f"
-  integrity sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==
+eslint@7.8.1:
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.8.1.tgz#e59de3573fb6a5be8ff526c791571646d124a8fa"
+  integrity sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
+    "@eslint/eslintrc" "^0.1.3"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -6457,9 +6479,9 @@ eslint@7.4.0:
     doctrine "^3.0.0"
     enquirer "^2.3.5"
     eslint-scope "^5.1.0"
-    eslint-utils "^2.0.0"
-    eslint-visitor-keys "^1.2.0"
-    espree "^7.1.0"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^1.3.0"
+    espree "^7.3.0"
     esquery "^1.2.0"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
@@ -6473,7 +6495,7 @@ eslint@7.4.0:
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.4.1"
-    lodash "^4.17.14"
+    lodash "^4.17.19"
     minimatch "^3.0.4"
     natural-compare "^1.4.0"
     optionator "^0.9.1"
@@ -6538,12 +6560,12 @@ espree@^6.1.2:
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
-espree@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.2.0.tgz#1c263d5b513dbad0ac30c4991b93ac354e948d69"
-  integrity sha512-H+cQ3+3JYRMEIOl87e7QdHX70ocly5iW4+dttuR8iYSPr/hXKFb+7dBsZ7+u1adC4VrnPlTkv0+OwuPnDop19g==
+espree@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.0.tgz#dc30437cf67947cf576121ebd780f15eeac72348"
+  integrity sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==
   dependencies:
-    acorn "^7.3.1"
+    acorn "^7.4.0"
     acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.3.0"
 
@@ -8034,6 +8056,14 @@ import-fresh@^3.0.0, import-fresh@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
   integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
+  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -9611,7 +9641,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5:
+lodash@4.17.19, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -13786,7 +13816,7 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
-strip-json-comments@^3.1.0:
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
@@ -14382,15 +14412,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
-
 typescript@3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 typescript@^4.0.3:
   version "4.0.3"
@@ -15310,41 +15340,10 @@ yaml@^1.7.2:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@13.1.2, yargs-parser@^13.1.2:
+yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^11.1.1, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
-
-yargs-parser@^11.1.1:
-  version "11.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
-  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^15.0.1:
-  version "15.0.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.1.tgz#54786af40b820dcb2fb8025b11b4d659d76323b3"
-  integrity sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==
-  dependencies:
-    camelcase "^5.0.0"
-    decamelize "^1.2.0"
-
-yargs-parser@^18.1.1:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
-  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## Motvation
To bump all of `@frontside/typescript` from `v1.0.1` to `v1.1.0`.

## Approach
Not adding changesets because I don't think this constitutes a patch bump.