### PR TITLE
don't include the typescript plugin if there is no tsconfig option

### DIFF
--- a/.changeset/honest-jeans-ring.md
+++ b/.changeset/honest-jeans-ring.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": minor
+---
+
+don't include the typescript plugin if there is no tsconfig option

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -33,7 +33,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
         extensions: ['.js', '.ts'],
       }),
       commonjs(),
-      typescript({
+      bundle.tsconfig && typescript({
         tsconfig: bundle.tsconfig,
         tsconfigDefaults: defaultTSConfig(),
         tsconfigOverride: {
@@ -51,7 +51,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
       injectProcessEnv({
         NODE_ENV: 'production'
       }),
-    ]
+    ].filter(Boolean)
   }
 }
 

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -45,7 +45,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
       babel({
         babelHelpers: 'runtime',
         extensions: ['.js', '.ts'],
-        presets: ['@babel/preset-env', '@babel/preset-typescript'],
+        presets: ['@babel/preset-env'],
         plugins: ['@babel/plugin-transform-runtime']
       }),
       injectProcessEnv({

--- a/packages/bundler/test/bundler.test.ts
+++ b/packages/bundler/test/bundler.test.ts
@@ -4,9 +4,12 @@ import { promises as fs, existsSync } from 'fs';
 import expect from 'expect';
 import rmrf from 'rimraf';
 import { subscribe } from '@effection/subscription';
+import path from 'path';
 
 import { spawn } from './world';
 import { Bundler } from '../src/index';
+
+const tsconfig = path.join(process.cwd(), 'tsconfig.json');
 
 describe("Bundler", function() {
   this.timeout(5000);
@@ -94,6 +97,7 @@ describe("Bundler", function() {
           entry: "./build/test/sources/input.ts",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
+          tsconfig
         }));
 
         await spawn(subscribe(bundler).match({ type: 'UPDATE' }).first());
@@ -113,6 +117,7 @@ describe("Bundler", function() {
           entry: "./build/test/sources/input.ts",
           outFile: "./build/test/output/manifest.js",
           globalName: "__bigtestManifest",
+          tsconfig
         }));
       });
 
@@ -132,7 +137,7 @@ describe("Bundler", function() {
         watch: true,
         entry: "./build/test/sources/input.js",
         outFile: "./build/test/output/manifest.js",
-        globalName: "__bigtestManifest"
+        globalName: "__bigtestManifest",
       }));
 
       await fs.writeFile("./build/test/sources/input.js", "export default {hello: 'world'}\n");


### PR DESCRIPTION
This solution all hangs on the assumption that if there is no option for `tsconfig` then we can assume this is not a typescript project.

This is to silence the

> rpt2: config error TS18003: No inputs were found in config file 'tsconfig.json'. Specified 'include' paths were '["**/*"]' and 'exclude' paths were '[]'.

issue #679

slightly speculative at this stage.   

```ts
    plugins: [
      resolve({
        mainFields: ["browser", "module", "main"],
        extensions: ['.js', '.ts'],
      }),
      commonjs(),
      bundle.tsconfig && typescript({
        tsconfig: bundle.tsconfig,
        tsconfigDefaults: defaultTSConfig(),
        tsconfigOverride: {
          compilerOptions: {
            module: "ESNext",
          }
        }
      }),
      babel({
        babelHelpers: 'runtime',
        extensions: ['.js', '.ts'],
        presets: ['@babel/preset-env', '@babel/preset-typescript'],
        plugins: ['@babel/plugin-transform-runtime']
      }),
      injectProcessEnv({
        NODE_ENV: 'production'
      }),
    ].filter(Boolean)
```