### PR TITLE
commonjs plugin needs to come after babel plugin

### DIFF
--- a/.changeset/short-stingrays-deny.md
+++ b/.changeset/short-stingrays-deny.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": patch
+---
+
+move commonjs down the rollup plugin order

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -20,7 +20,6 @@
     "@babel/core": "^7.10.4",
     "@babel/plugin-transform-runtime": "^7.10.4",
     "@babel/preset-env": "^7.10.4",
-    "@babel/preset-typescript": "^7.10.4",
     "@babel/runtime": "^7.10.4",
     "@bigtest/effection": "^0.5.4",
     "@bigtest/project": "^0.12.0",

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -32,7 +32,6 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
         mainFields: ["browser", "module", "main"],
         extensions: ['.js', '.ts'],
       }),
-      commonjs(),
       typescript({
         tsconfig: bundle.tsconfig,
         tsconfigDefaults: defaultTSConfig(),
@@ -48,6 +47,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
         presets: ['@babel/preset-env', '@babel/preset-typescript'],
         plugins: ['@babel/plugin-transform-runtime']
       }),
+      commonjs(),
       injectProcessEnv({
         NODE_ENV: 'production'
       }),

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -50,10 +50,15 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
         extensions: [
           ...DEFAULT_EXTENSIONS
         ],
+        sourceType: 'unambiguous',
         presets: ['@babel/preset-env'],
-        plugins: ['@babel/plugin-transform-runtime']
+        plugins: [
+          ['@babel/plugin-transform-runtime']
+        ]
       }),
-      commonjs(),
+      commonjs({
+        ignoreGlobal: true,
+      }),
       injectProcessEnv({
         NODE_ENV: 'production'
       }),
@@ -124,7 +129,10 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
       yield messages.forEach(function* (message) {
         channel.send(message);
       });
-    } finally {
+    } catch(errr) {
+      console.dir(errr)
+    } 
+    finally {
       console.debug('[bundler] shutting down');
       rollup.close();
     }
@@ -139,6 +147,7 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
 
       this.channel.send({ type: 'UPDATE' });
     } catch(error) {
+      console.log(error)
       this.channel.send({ type: 'ERROR', error });
     }
   }

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -4,7 +4,9 @@ import { Subscribable, SymbolSubscribable } from '@effection/subscription';
 import { Channel } from '@effection/channel';
 import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
 import { defaultTSConfig } from '@bigtest/project';
-import resolve from '@rollup/plugin-node-resolve';
+import resolve, {
+  DEFAULTS as RESOLVE_DEFAULTS,
+} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from 'rollup-plugin-typescript2';
 import injectProcessEnv from 'rollup-plugin-inject-process-env';
@@ -12,6 +14,7 @@ import injectProcessEnv from 'rollup-plugin-inject-process-env';
 // @ts-ignore
 import babel from '@rollup/plugin-babel';
 import { BundlerMessage } from './types';
+import { DEFAULT_EXTENSIONS } from '@babel/core';
 
 interface BundleOptions {
   entry: string;
@@ -30,7 +33,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
     plugins: [
       resolve({
         mainFields: ["browser", "module", "main"],
-        extensions: ['.js', '.ts'],
+        extensions: [...RESOLVE_DEFAULTS.extensions, '.jsx'],
       }),
       typescript({
         tsconfig: bundle.tsconfig,
@@ -43,8 +46,11 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
       }),
       babel({
         babelHelpers: 'runtime',
-        extensions: ['.js', '.ts'],
-        presets: ['@babel/preset-env', '@babel/preset-typescript'],
+        exclude: /node_modules/,
+        extensions: [
+          ...DEFAULT_EXTENSIONS
+        ],
+        presets: ['@babel/preset-env'],
         plugins: ['@babel/plugin-transform-runtime']
       }),
       commonjs(),

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -129,10 +129,7 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
       yield messages.forEach(function* (message) {
         channel.send(message);
       });
-    } catch(errr) {
-      console.dir(errr)
-    } 
-    finally {
+    } finally {
       console.debug('[bundler] shutting down');
       rollup.close();
     }
@@ -147,7 +144,6 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
 
       this.channel.send({ type: 'UPDATE' });
     } catch(error) {
-      console.log(error)
       this.channel.send({ type: 'ERROR', error });
     }
   }

--- a/packages/server/test/manifest-builder.test.ts
+++ b/packages/server/test/manifest-builder.test.ts
@@ -160,7 +160,7 @@ describe('manifest builder', () => {
 
       let error = bundlerState.error;
 
-      expect(error.frame).toBeTruthy();
+      expect(error).toBeInstanceOf(SyntaxError);
     });
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,7 +1511,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-typescript@^7.10.4", "@babel/plugin-transform-typescript@^7.9.0":
+"@babel/plugin-transform-typescript@^7.9.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.4.tgz#8b01cb8d77f795422277cc3fcf45af72bc68ba78"
   integrity sha512-3WpXIKDJl/MHoAN0fNkSr7iHdUMHZoppXjf2HJ9/ed5Xht5wNIsXllJXdityKOxeA3Z8heYRb1D3p2H5rfCdPw==
@@ -1799,14 +1799,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
-
-"@babel/preset-typescript@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz#7d5d052e52a682480d6e2cc5aa31be61c8c25e36"
-  integrity sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-transform-typescript" "^7.10.4"
 
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.4"
@@ -4717,10 +4709,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@~86.0.0:
-  version "86.0.0"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-86.0.0.tgz#4b9504d5bbbcd4c6bd6d6fd1dd8247ab8cdeca67"
-  integrity sha512-byLJWhAfuYOmzRYPDf4asJgGDbI4gJGHa+i8dnQZGuv+6WW1nW1Fg+8zbBMOfLvGn7sKL41kVdmCEVpQHn9oyg==
+chromedriver@~87.0.0:
+  version "87.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-87.0.0.tgz#e8390deed8ada791719a67ad6bf1116614f1ba2d"
+  integrity sha512-PY7FnHOQKfH0oPfSdhpLx5nEy5g4dGYySf2C/WZGkAaCaldYH8/3lPPucZ8MlOCi4bCSGoKoCUTeG6+wYWavvw==
   dependencies:
     "@testim/chrome-version" "^1.0.7"
     axios "^0.19.2"


### PR DESCRIPTION
While looking at #680 I discovered that the `commonjs` needs to follow the babel plugin.

This PR moves it down:

```ts
      babel({
        babelHelpers: 'runtime',
        extensions: ['.js', '.ts'],
        presets: ['@babel/preset-env', '@babel/preset-typescript'],
        plugins: ['@babel/plugin-transform-runtime']
      }),
      commonjs(),
```