### PR TITLE
Do not wrap action functions in a convergence

### DIFF
--- a/.changeset/pink-flowers-grab.md
+++ b/.changeset/pink-flowers-grab.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Interactor actions are not automatically wrapped in a convergence

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -4,7 +4,6 @@ import { Locator } from './locator';
 import { Filter } from './filter';
 import { Interactor } from './interactor';
 import { interaction } from './interaction';
-import { converge } from './converge';
 
 const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
 
@@ -23,9 +22,7 @@ export function createInteractor<E extends Element>(interactorName: string) {
             if(bigtestGlobals.runnerState === 'assertion') {
               throw new Error(`tried to ${actionDescription} on ${this.description} in an assertion, actions should only be performed in steps`);
             }
-            return await converge(() => {
-              return action(this, ...args);
-            });
+            return action(this, ...args);
           });
         },
         configurable: true,

--- a/packages/interactor/src/perform.ts
+++ b/packages/interactor/src/perform.ts
@@ -1,10 +1,10 @@
 import { Interactor } from "./interactor";
 import { Filters, Actions } from "./specification";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends any[]>(fn: (element: E, ...args: T) => void) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (interactor: Interactor<E, F, A>, ...args: T) => interactor.perform(element => {
-    fn(element, ...args);
-  });
+export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends unknown[]>(fn: (element: E, ...args: T) => void) {
+  return async (interactor: Interactor<E, F, A>, ...args: T) => {
+    return await interactor.perform(element => {
+      fn(element, ...args);
+    });
+  };
 }

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { Interactor } from './interactor';
+import { Interaction } from './interaction';
 
-export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}>, ...args: any[]) => unknown;
+export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}>, ...args: any[]) => Promise<unknown>;
 
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
@@ -25,8 +26,8 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
-  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}>, ...args: infer TArgs) => infer TReturn)
-    ? ((...args: TArgs) => TReturn)
+  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}>, ...args: infer TArgs) => Promise<infer TReturn>)
+    ? ((...args: TArgs) => Interaction<TReturn>)
     : never;
 }
 


### PR DESCRIPTION
Closes #691

This removes the automatically inserted convergence for action functions, which means that actions do not converge automatically anymore. Instead the user will need to ensure they converge by awaiting a converging function inside the action. This could be either an action/assertion on another interactor, or it could be one of the built in converging functions on the interactor itself. Most likely, the user will want to call `perform`. To remove some boilerplate for this, we have the `perform` function, which most actions already use, so this will not be a breaking change for most interactors.

This also means that "normal" actions which use `perform` to not nest calls of converge. Additionally, this change explicitly awaits the converge call in the `perform` helper function, removing the useless wrapping in an interaction as well.

I've been wracking my brain trying to come up with a way of testing this, but any test for this change would really be testing on the absence of something, e.g. testing that the async function is *not* exectuted multiple times, which seems like a bit of a silly test to me.