### PR TITLE
Preemptively merge gitignore for docs

### DIFF
--- a/website/docs/.gitignore
+++ b/website/docs/.gitignore
@@ -1,0 +1,20 @@
+# Dependencies
+/node_modules
+
+# Production
+/build
+
+# Generated files
+.docusaurus
+.cache-loader
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Motivation
Just to remove a minor inconvenience. Switching from `init-docusaurus` branch to another branch will persist the `./website/docs/.docusaurus` directory which I have to delete each time.

## Approach
I copied over the `.gitignore` from the `init-docusaurus` branch so that if anyone is working on the docs and also working on stuff unrelated to docs, they won't have to manually delete that directory.