### PR TITLE
Allow starting agents from remote webdriver servers

### DIFF
--- a/.changeset/remote-webdriver.md
+++ b/.changeset/remote-webdriver.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/project": minor
+"@bigtest/webdriver": minor
+"bigtest": minor
+---
+support spawning agents from an unmanaged webdriver

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -77,7 +77,7 @@ describe("@bigtest/agent", function() {
       let events: ChainableSubscription<TestEvent, CloseEvent>;
 
       beforeEach(async function() {
-        browser = await run(Local({ browserName: 'chrome', headless: true }));
+        browser = await run(Local({ type: 'local', browserName: 'chrome', headless: true }));
         await run(browser.navigateTo(config.agentUrl(`ws://localhost:8001`)));
         connection = await run(connections.expect());
         events = await run(subscribe(connection.events));

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -85,6 +85,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
       chrome: {
         module: "@bigtest/webdriver",
         options: {
+          type: 'local',
           browserName: "chrome",
           headless: false
         }
@@ -92,6 +93,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
       "chrome.headless": {
         module: "@bigtest/webdriver",
         options: {
+          type: 'local',
           browserName: "chrome",
           headless: true
         }
@@ -99,6 +101,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
       firefox: {
         module: "@bigtest/webdriver",
         options: {
+          type: 'local',
           browserName: "firefox",
           headless: false
         }
@@ -106,6 +109,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
       "firefox.headless": {
         module: "@bigtest/webdriver",
         options: {
+          type: 'local',
           browserName: "firefox",
           headless: true
         }
@@ -113,6 +117,7 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
       "safari": {
         module: "@bigtest/webdriver",
         options: {
+          type: 'local',
           browserName: "safari",
           headless: false
         }

--- a/packages/webdriver/src/driver.ts
+++ b/packages/webdriver/src/driver.ts
@@ -5,9 +5,9 @@ import { Remote } from './remote';
 import { Options } from './web-driver';
 
 export const create: DriverFactory<Options, {}> = ({options}) => {
-  if (options.type === 'local') {
-    return Local(options);
-  } else {
+  if (options.type === 'remote') {
     return Remote(options);
+  } else {
+    return Local(options);
   }
 }

--- a/packages/webdriver/src/driver.ts
+++ b/packages/webdriver/src/driver.ts
@@ -1,6 +1,13 @@
 import { DriverFactory } from '@bigtest/driver';
 
 import { Local } from './local';
+import { Remote } from './remote';
 import { Options } from './web-driver';
 
-export const create: DriverFactory<Options, {}> = (spec) => Local(spec.options);
+export const create: DriverFactory<Options, {}> = ({options}) => {
+  if (options.type === 'local') {
+    return Local(options);
+  } else {
+    return Remote(options);
+  }
+}

--- a/packages/webdriver/src/index.ts
+++ b/packages/webdriver/src/index.ts
@@ -1,3 +1,4 @@
 export { WebDriver, Options } from './web-driver';
 export { Local } from './local';
+export { Remote } from './remote';
 export { create } from './driver';

--- a/packages/webdriver/src/local.ts
+++ b/packages/webdriver/src/local.ts
@@ -6,7 +6,7 @@ import { daemon } from '@effection/node';
 
 import { findAvailablePortNumber } from './find-available-port-number';
 import { untilURLAvailable } from './until-url-available';
-import { WebDriver, Options, connect } from './web-driver';
+import { WebDriver, LocalOptions, connect } from './web-driver';
 
 /**
  * Create a local `WebDriver` resource based on `driverName` (either 'geckodriver' or
@@ -21,7 +21,7 @@ import { WebDriver, Options, connect } from './web-driver';
  * suopports a single Firefox session per driver process, we spawn a
  * new process for each local driver.
  */
-export function * Local(options: Options): Operation<WebDriver> {
+export function * Local(options: LocalOptions): Operation<WebDriver> {
   let port: number = yield findAvailablePortNumber();
   let driverURL = `http://localhost:${port}`;
 
@@ -42,7 +42,7 @@ export function * Local(options: Options): Operation<WebDriver> {
   return driver;
 }
 
-function driverNameFor(browserName: Options["browserName"]) {
+function driverNameFor(browserName: LocalOptions["browserName"]) {
   if (browserName == 'firefox') {
     return 'geckodriver';
   } else {

--- a/packages/webdriver/src/remote.ts
+++ b/packages/webdriver/src/remote.ts
@@ -1,0 +1,23 @@
+import { Operation, resource, main } from 'effection';
+
+import { WebDriver, RemoteOptions, connect, disconnect } from './web-driver';
+
+export function* Remote(options: RemoteOptions): Operation<WebDriver> {
+  let driver = new WebDriver(options.url);
+
+  yield connect(driver, options);
+
+  return yield resource(driver, function*() {
+    try {
+      yield;
+    } finally {
+      // async shutdown not supported yet!
+      // so we have to start a new effection tree
+      main(disconnect(driver))
+        .catch(error => {
+          console.error('WARNING: failed to disconnect web driver session');
+          console.error(error);
+        });
+    }
+  });
+}

--- a/packages/webdriver/src/web-driver.ts
+++ b/packages/webdriver/src/web-driver.ts
@@ -40,7 +40,7 @@ export function* connect(driver: WebDriver, options: Options): Operation<void> {
 
   let capabilities = new Atom(Capabilities);
 
-  if (options.headless != null && options.headless) {
+  if (options.headless) {
     capabilities.slice('alwaysMatch', 'goog:chromeOptions', 'args')
       .over(args => args.concat(['--headless']))
     capabilities.slice('alwaysMatch', 'moz:firefoxOptions', 'args')

--- a/packages/webdriver/test/local.test.ts
+++ b/packages/webdriver/test/local.test.ts
@@ -33,7 +33,7 @@ describe("Running a local wedriver", () => {
 
   describe('with chromedriver', () => {
     beforeEach(async () => {
-      driver = await spawn(Local({ browserName: 'chrome', headless: true }));
+      driver = await spawn(Local({ type: 'local', browserName: 'chrome', headless: true }));
       await spawn(driver.navigateTo(serverURL));
     });
 
@@ -46,7 +46,7 @@ describe("Running a local wedriver", () => {
   if (process.platform !== 'win32') {
     describe('with geckodriver', () => {
       beforeEach(async () => {
-        driver = await spawn(Local({ browserName: 'firefox', headless: true }));
+        driver = await spawn(Local({ type: 'local', browserName: 'firefox', headless: true }));
         await spawn(driver.navigateTo(serverURL));
       });
 

--- a/packages/webdriver/test/remote.test.ts
+++ b/packages/webdriver/test/remote.test.ts
@@ -67,7 +67,7 @@ describe('Connecting to a remote webdriver', () => {
 
   beforeEach(async () => {
     await spawn(function*() {
-      yield untilURLAvailable(`${driverURL}/status`, 11_000);
+      yield untilURLAvailable(`${driverURL}/status`);
       driver = yield Remote({ type: 'remote', url: driverURL, headless: true });
       yield driver.navigateTo(serverURL);
     });

--- a/packages/webdriver/test/remote.test.ts
+++ b/packages/webdriver/test/remote.test.ts
@@ -1,0 +1,80 @@
+import { describe } from 'mocha';
+import { Context, main } from 'effection';
+import { daemon } from '@effection/node';
+import { express } from '@bigtest/effection-express';
+import { Request, Response } from 'express';
+import * as expect from 'expect';
+
+import { spawn } from './helpers';
+import { findAvailablePortNumber } from '../src/find-available-port-number';
+import { untilURLAvailable } from '../src/until-url-available';
+
+import { converge } from '../../interactor/src/converge';
+import { WebDriver, Remote } from '../src/index';
+
+describe('Connecting to a remote webdriver', () => {
+  let server = express();
+  let latestRequest: Request;
+
+  server.raw.use(function(request: Request, response: Response) {
+    latestRequest = request;
+    response.write("thank you");
+    response.end();
+  });
+
+  let serverURL: string;
+
+  beforeEach(async () => {
+    latestRequest = serverURL = undefined;
+
+    let port = await spawn(findAvailablePortNumber());
+
+    serverURL = `http://localhost:${port}`;
+
+    await spawn(server.listen(port));
+
+  });
+
+  let driver: WebDriver;
+  let driverURL: string;
+  let driverProcessContext: Context;
+
+  // this is another annoying thing about not having
+  // async teardown in effection. the chromedriver process
+  // resource is shutdown while still responding to the session shutdwon
+  // request. This uses a separate effection context for the driver
+  // process and then adds an afterEach hook to tear it down only after
+  // the remote webdriver resource is no longer active.
+  // it's a hack.
+
+  beforeEach(async () => {
+    let port = await spawn(findAvailablePortNumber());
+    driverURL = `http://localhost:${port}`;
+
+    driverProcessContext = main(function*() {
+      yield daemon(`chromedriver --port=${port}`);
+      yield;
+    });
+  });
+
+  afterEach(async () => {
+    if (driver) {
+      await converge(() => expect(driver.active).toBe(false));
+    }
+    driverProcessContext.halt();
+  })
+
+
+  beforeEach(async () => {
+    await spawn(function*() {
+      yield untilURLAvailable(`${driverURL}/status`, 11_000);
+      driver = yield Remote({ type: 'remote', url: driverURL, headless: true });
+      yield driver.navigateTo(serverURL);
+    });
+  });
+
+  it('can navigate to a url', () => {
+    expect(latestRequest).toBeDefined();
+    expect(latestRequest.headers['user-agent']).toMatch('Chrome');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -14395,9 +14395,9 @@ rollup-plugin-typescript2@^0.29.0:
     tslib "2.0.1"
 
 rollup@^2.33.3:
-  version "2.34.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.1.tgz#a387230df02c58b242794a213dfb68b42de2c8fb"
-  integrity sha512-tGveB6NU5x4MS/iXaIsjfUkEv4hxzJJ4o0FRy5LO62Ndx3R2cmE1qsLYlSfRkvHUUPqWiFoxEm8pRftzh1a5HA==
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.34.0.tgz#ecc7f1d4ce2cb88bb51bec2f56b984f3c35b8271"
+  integrity sha512-dW5iLvttZzdVehjEuNJ1bWvuMEJjOWGmnuFS82WeKHTGXDkRHQeq/ExdifkSyJv9dLcR86ysKRmrIDyR6O0X8g==
   optionalDependencies:
     fsevents "~2.1.2"
 


### PR DESCRIPTION
Motivation
-----------

Currently, it is assumed that BigTest will manage your webdriver server in-process, both starting it and stopping it on demand. In fact, for things like geckodriver which only allows a single browser to be run per-server, there is a server process per web agent.

This causes a bunch of issues because it means that the bigtest user has to manage their own browser binaries since their server must ultimately start and stop browser processes. This change allows bigtest to create agents directly off of an existing webdriver server. Among other things, this opens the door to running browsers completely off-container in things like BrowserStack or Saas labs, but it could also be running off of a server started in the container before the test run.

Approach
----------
To do this, the driver options have been expanded to account for both "remote" and "local" options. The type of driver is used to resolve the url of the driver server before ultimately using that url to connect and disconnect new web drivers.