### PR TITLE
Bump @bigtest/bundler test timeout to 60000

### DIFF
--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
-    "test": "mocha -r ts-node/register test/**/*.test.ts",
+    "test": "mocha -r ts-node/register --timeout 60000 test/**/*.test.ts",
     "prepack": "tsc --outDir dist --declaration --sourcemap --module commonjs"
   },
   "dependencies": {

--- a/packages/bundler/test/bundler.test.ts
+++ b/packages/bundler/test/bundler.test.ts
@@ -9,7 +9,6 @@ import { spawn } from './world';
 import { Bundler } from '../src/index';
 
 describe("Bundler", function() {
-  this.timeout(5000);
   let bundler: Bundler;
 
   beforeEach((done) => rmrf('./build', done));


### PR DESCRIPTION
The bundler tests are among the slower, even on fast machines, and so with the changes in computational environment, this just brings this timeout along to the threshold of our other timeouts in order to ensure that it passes on windows and ubuntu.