### PR TITLE
Fix path to main entry point of CLI package

### DIFF
--- a/.changeset/twenty-ties-worry.md
+++ b/.changeset/twenty-ties-worry.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": patch
+"bigtest": patch
+---
+
+Fix broken CLI package distributions

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Use BigTest",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
-  "main": "dist/src/index.js",
+  "main": "dist/index.js",
   "license": "MIT",
   "files": [
     "bin/*",


### PR DESCRIPTION
When we removed the typescript-compiled binary file in #674, we inadvertently changed the layout of the `dist` folder, which now puts the `src` files in the root. This causes the package to be broken when prepacked.