### PR TITLE
Remove last of the delegates

### DIFF
--- a/.changeset/new-queens-check.md
+++ b/.changeset/new-queens-check.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Remove delegate mailboxes in orchestrator

--- a/packages/server/src/app-server.ts
+++ b/packages/server/src/app-server.ts
@@ -17,7 +17,7 @@ const startApp = (serviceSlice: Slice<ServiceState<AppServiceStatus, AppOptions>
   assert(!!options.url, 'no app url given');
 
   let appServiceStatus = serviceSlice.slice('status')
-  
+
   if (options.command) {
     let child: Process = yield exec(options.command as string, {
       cwd: options.dir,
@@ -37,7 +37,7 @@ const startApp = (serviceSlice: Slice<ServiceState<AppServiceStatus, AppOptions>
     yield timeout(100);
   }
 
-  appServiceStatus.set({ type: 'ready' });
+  appServiceStatus.set({ type: 'available' });
 
   yield;
 }

--- a/packages/server/src/connection-server.ts
+++ b/packages/server/src/connection-server.ts
@@ -25,10 +25,13 @@ export function* createConnectionServer(options: ConnectionServerOptions): Opera
   let [tx, rx] = createDuplexChannel<Outgoing, Incoming>({ maxListeners: 100000 });
 
   return yield resource({ channel: tx }, function*() {
-    let handler: ChainableSubscription<AgentConnection, void> = yield createAgentHandler(options.port);
     let statusSlice = options.atom.slice('connectionService', 'status');
 
-    statusSlice.set({ type: 'ready' });
+    statusSlice.set({ type: 'starting' });
+
+    let handler: ChainableSubscription<AgentConnection, void> = yield createAgentHandler(options.port);
+
+    statusSlice.set({ type: 'started' });
 
     while(true) {
       let connection: AgentConnection = yield handler.expect();

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -20,7 +20,7 @@ export function* createLogger({ atom, out }: LoggerOptions) {
   }));
 
   yield fork(subscribe(atom.slice('appService', 'status')).forEach(function* (status) {
-    if(status.type === 'ready') {
+    if(status.type === 'available') {
       out("[app] successfully connected to application!");
     }
     if(status.type === 'exited') {

--- a/packages/server/src/manifest-server.ts
+++ b/packages/server/src/manifest-server.ts
@@ -1,17 +1,21 @@
 import { Operation } from 'effection';
-import { Mailbox } from '@bigtest/effection';
+import { Atom } from '@bigtest/atom';
 import { express } from '@bigtest/effection-express';
 import { static as staticMiddleware } from 'express';
+import { OrchestratorState } from './orchestrator/state';
 
 interface ManifestServerOptions {
-  delegate: Mailbox;
   dir: string;
   port: number;
   proxyPort: number;
+  atom: Atom<OrchestratorState>;
 };
 
 export function* createManifestServer(options: ManifestServerOptions): Operation {
+  let status = options.atom.slice('manifestServer', 'status');
   let app = express();
+
+  status.set({ type: 'starting' });
 
   app.raw.use(staticMiddleware(options.dir, {
     setHeaders(res) {
@@ -21,7 +25,7 @@ export function* createManifestServer(options: ManifestServerOptions): Operation
 
   yield app.listen(options.port);
 
-  options.delegate.send({ status: "ready" });
+  status.set({ type: 'started' });
 
   yield
 }

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -51,7 +51,19 @@ export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
     },
     connectionService: {
       status: {
-        type: 'pending',
+        type: 'unstarted',
+      },
+      options: {}
+    },
+    commandService: {
+      status: {
+        type: 'unstarted',
+      },
+      options: {}
+    },
+    manifestServer: {
+      status: {
+        type: 'unstarted',
       },
       options: {}
     },

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -81,7 +81,7 @@ export type AppServiceStatus =
       type: "started";
     }
   | {
-      type: "ready";
+      type: "available";
     }
   | {
       type: "stopping";
@@ -103,6 +103,10 @@ export type ManifestGeneratorStatus = {
   type: "pending" | "ready";
 };
 
+export type ManifestServerStatus = {
+  type: 'unstarted' | 'starting' | 'started';
+}
+
 export interface ManifestGeneratorOptions {
   files?: string[];
   mode: 'idle' | 'watch' | 'build';
@@ -110,10 +114,14 @@ export interface ManifestGeneratorOptions {
 };
 
 export type ConnectionStatus = {
-  type: "pending" | "ready";
+  type: 'unstarted' | 'starting' | 'started';
 };
 
 export type ProxyStatus = {
+  type: 'unstarted' | 'starting' | 'started';
+}
+
+export type CommandStatus = {
   type: 'unstarted' | 'starting' | 'started';
 }
 
@@ -127,13 +135,15 @@ export type ProxyOptions = {
 
 export type OrchestratorState = {
   agents: Record<string, AgentState>;
-  manifestGenerator: ServiceState<ManifestGeneratorStatus, ManifestGeneratorOptions>;
   manifest: Manifest;
   bundler: BundlerState;
   testRuns: Record<string, TestRunState>;
+  manifestGenerator: ServiceState<ManifestGeneratorStatus, ManifestGeneratorOptions>;
+  manifestServer: ServiceState<ManifestServerStatus, {}>;
   appService: ServiceState<AppServiceStatus, AppOptions>;
   proxyService: ServiceState<ProxyStatus, ProxyOptions>;
   connectionService: ServiceState<ConnectionStatus, {}>;
+  commandService: ServiceState<CommandStatus, {}>;
 }
 
 declare const o: OrchestratorState;

--- a/packages/server/test/app-server.test.ts
+++ b/packages/server/test/app-server.test.ts
@@ -23,16 +23,16 @@ describe('app service', () => {
       });
     });
 
-    it("should be transition from 'started' to 'ready'", async () => {
+    it("should be transition from 'started' to 'available'", async () => {
       let appStatus = atom.slice('appService', 'status');
 
       expect(appStatus.get().type).toBe('started');
 
       await actions.fork(
-        appStatus.once(status => status.type === 'ready')
+        appStatus.once(status => status.type === 'available')
       );
 
-      expect(appStatus.get().type).toBe('ready');
+      expect(appStatus.get().type).toBe('available');
     });
   });
 

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -18,14 +18,12 @@ import { RunOptions } from '../src/runner';
 let COMMAND_PORT = 24200;
 
 describe('command server', () => {
-  let delegate: Mailbox
   let agents: Slice<Record<string, AgentState>, OrchestratorState>;
   let manifest: Slice<Manifest, OrchestratorState>;
   let runs: Mailbox<RunOptions>;
 
   beforeEach(async () => {
     runs = new Mailbox();
-    delegate = new Mailbox();
     let atom = createOrchestratorAtom(getTestProjectOptions());
     agents = atom.slice('agents');
     manifest = atom.slice('manifest');
@@ -38,12 +36,11 @@ describe('command server', () => {
           throw new Error('not implemented');
         }
       },
-      delegate,
       atom,
       port: COMMAND_PORT,
     }));
 
-    await actions.receive(delegate, { status: 'ready' });
+    await actions.fork(atom.slice('commandService', 'status', 'type').once((t) => t === 'started'));
   });
 
   describe('fetching the agents at the start', () => {

--- a/packages/server/test/orchestrator.test.ts
+++ b/packages/server/test/orchestrator.test.ts
@@ -138,7 +138,7 @@ describe('orchestrator', () => {
 
       await actions.fork(
         actions.atom.slice('appService', 'status').once(status => {
-          return status.type === 'ready'
+          return status.type === 'available'
         })
       );
     });


### PR DESCRIPTION
The delegate pattern is no more. Now all service state is centralized in the atom. This is just a first step towards a few additional improvements I'd like to make around startup synchronization.

I've also tried to make the various service states a bit more consistent. Generally we use `starting` -> `started`, for server like things, but `pending` -> `ready` for static things.