### PR TITLE
chore: gitignore vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 yarn-error.log
 /packages/*/dist
 /packages/*/docs
+
+# personal editor settings
+.vscode


### PR DESCRIPTION
This allows someone to set specific settings for BigTest within vscode such as formatting and running eslint.

Example `.vscode/settings.json`:
```settings.json
{
    "[typescript]": {
        "editor.formatOnSave": false,
        "editor.defaultFormatter": "dbaeumer.vscode-eslint",
        "editor.codeActionsOnSave": {
            "source.fixAll.eslint": true
        }
    }
}
```
