### PR TITLE
Add a generic `assert` to `Interactor`

### DIFF
--- a/.changeset/chatty-eagles-deliver.md
+++ b/.changeset/chatty-eagles-deliver.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+`perform` will throw an error if run inside an assertion context

--- a/.changeset/fair-files-shop.md
+++ b/.changeset/fair-files-shop.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Add `assertion` method to `Interactor`

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -15,6 +15,7 @@
   ],
   "scripts": {
     "lint": "eslint \"{src,test}/**/*.ts\"",
+    "mocha": "mocha -r ts-node/register",
     "test:unit": "mocha -r ts-node/register \"test/**/*.test.ts\"",
     "test:types": "dtslint types --localTs ../../node_modules/typescript/lib --expectOnly",
     "test:cypress": "yarn bigtest-todomvc 3000 & wait-on http://localhost:3000 & yarn cypress run --spec 'test/integrations/cypress/integration/*.spec.ts'",

--- a/packages/interactor/src/interactor.ts
+++ b/packages/interactor/src/interactor.ts
@@ -98,7 +98,32 @@ export class Interactor<E extends Element, F extends Filters<E>, A extends Actio
    * ```
    */
   perform(fn: (element: E) => void): Interaction<void> {
-    return interaction(`${this.description} performs`, () => {
+    return interaction(`${this.description} performs`, async () => {
+      if(bigtestGlobals.runnerState === 'assertion') {
+        throw new Error(`tried to run perform on ${this.description} in an assertion, perform should only be run in steps`);
+      }
+      return await converge(() => {
+        fn(this.unsafeSyncResolveUnique());
+      });
+    });
+  }
+
+  /**
+   * Perform a one-off assertion on the given interactor. Takes a function which
+   * receives an element. This function converges, which means that it is rerun
+   * in a loop until it does not throw an error or times out.
+   *
+   * We recommend using this function for debugging only. You should normally
+   * define a filter in an {@link InteractorSpecification}.
+   *
+   * ## Example
+   *
+   * ``` typescript
+   * await Link('Next').assert((e) => assert(e.tagName === 'A'));
+   * ```
+   */
+  assert(fn: (element: E) => void): Interaction<void> {
+    return interaction(`${this.description} asserts`, () => {
       return converge(() => {
         fn(this.unsafeSyncResolveUnique());
       });

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -66,18 +66,6 @@ const MainNav = createInteractor('main nav')({
 });
 
 describe('@bigtest/interactor', () => {
-  describe('instantiation', () => {
-    describe('no arguments', () => {
-      it('just uses the selector to locate', async () => {
-        dom(`
-          <nav id="main-nav"></nav>
-        `);
-
-        await expect(MainNav().exists()).resolves.toBeUndefined();
-      });
-    });
-  });
-
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -1,0 +1,130 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+import { bigtestGlobals } from '@bigtest/globals';
+
+import { createInteractor, Link, Heading } from '../src/index';
+
+const MainNav = createInteractor('main nav')({
+  selector: 'nav'
+});
+
+describe('@bigtest/interactor', () => {
+  describe('instantiation', () => {
+    describe('no arguments', () => {
+      it('just uses the selector to locate', async () => {
+        dom(`
+          <nav id="main-nav"></nav>
+        `);
+
+        await expect(MainNav().exists()).resolves.toBeUndefined();
+      });
+    });
+  });
+
+  describe('.perform', () => {
+    it('can use action to interact with element', async () => {
+      dom(`
+        <a id="foo" href="/foobar">Foo Bar</a>
+        <div id="target"></div>
+        <script>
+          foo.onclick = () => {
+            target.innerHTML = '<h1>Hello!</h1>';
+          }
+        </script>
+      `);
+
+      await Link('Foo Bar').perform((e) => e.click());
+      await Heading('Hello!').exists();
+    });
+
+    it('does nothing unless awaited', async () => {
+      dom(`
+        <a id="foo" href="/foobar">Foo Bar</a>
+        <div id="target"></div>
+        <script>
+          foo.onclick = () => {
+            target.innerHTML = '<h1>Hello!</h1>';
+          }
+        </script>
+      `);
+
+      Link('Foo Bar').perform((e) => e.click());
+      await Heading('Hello!').absent();
+    });
+
+    it('can return description of interaction', () => {
+      expect(Link('Foo Bar').perform((e) => e.click()).description).toEqual('link "Foo Bar" performs');
+    });
+
+    it('throws an error if ambiguous', async () => {
+      dom(`
+        <p><a href="/foo">Foo</a></p>
+        <p><a href="/bar&quot;">Foo</a></p>
+      `);
+
+      await expect(Link('Foo').perform((e) => e.click())).rejects.toHaveProperty('message', [
+        'link "Foo" matches multiple elements:', '',
+        '- <a href="/foo">',
+        '- <a href="/bar&quot;">',
+      ].join('\n'))
+    });
+
+    it('throws an error if runner is currently in assertion state', async () => {
+      dom(`
+        <p><a href="/foo">Foo</a></p>
+      `);
+
+      bigtestGlobals.runnerState = 'assertion';
+
+      await expect(Link('Foo').perform((e) => e.click())).rejects.toHaveProperty('message',
+        'tried to run perform on link "Foo" in an assertion, perform should only be run in steps'
+      );
+    });
+  });
+
+  describe('.assert', () => {
+    it('can assert on state', async () => {
+      dom(`
+        <a data-foo="foo" href="/foobar">Foo Bar</a>
+      `);
+
+      await Link('Foo Bar').assert((e) => expect(e.dataset.foo).toEqual('foo'));
+    });
+
+    it('is rejected if assertion fails', async () => {
+      dom(`
+        <a data-foo="foo" href="/foobar">Foo Bar</a>
+      `);
+
+      await expect(Link('Foo Bar').assert((e) => expect(e.dataset.foo).toEqual('incorrect'))).rejects;
+    });
+
+    it('can return description of interaction', () => {
+      expect(Link('Foo Bar').assert(() => true).description).toEqual('link "Foo Bar" asserts');
+    });
+
+    it('throws an error if ambiguous', async () => {
+      dom(`
+        <p><a href="/foo">Foo</a></p>
+        <p><a href="/bar&quot;">Foo</a></p>
+      `);
+
+      await expect(Link('Foo').assert(() => true)).rejects.toHaveProperty('message', [
+        'link "Foo" matches multiple elements:', '',
+        '- <a href="/foo">',
+        '- <a href="/bar&quot;">',
+      ].join('\n'))
+    });
+
+    it('can be used normally if runner is currently in assertion state', async () => {
+      dom(`
+        <a data-foo="foo" href="/foobar">Foo Bar</a>
+      `);
+
+      bigtestGlobals.runnerState = 'assertion';
+
+      await Link('Foo Bar').assert((e) => expect(e.dataset.foo).toEqual('foo'));
+    });
+  });
+});


### PR DESCRIPTION
Also throw error if using perform in assertion context. This will allow us an escape hatch when we need to make a non-standard assertion.