### PR TITLE
readd @babel/preset-typescript to bundler

### DIFF
--- a/.changeset/itchy-ladybugs-compete.md
+++ b/.changeset/itchy-ladybugs-compete.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": minor
+---
+
+readd @babel/preset-typescript to @bigtest/bundler

--- a/packages/bundler/package.json
+++ b/packages/bundler/package.json
@@ -20,6 +20,7 @@
     "@babel/core": "^7.12.9",
     "@babel/plugin-transform-runtime": "^7.12.1",
     "@babel/preset-env": "^7.12.7",
+    "@babel/preset-typescript": "^7.12.7",
     "@babel/runtime": "^7.12.5",
     "@bigtest/effection": "^0.6.0",
     "@bigtest/project": "^0.13.0",

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -31,8 +31,9 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
     plugins: [
       resolve({
         mainFields: ["browser", "module", "main"],
-        extensions: [...RESOLVE_DEFAULTS.extensions, '.jsx'],
+        extensions: [...RESOLVE_DEFAULTS.extensions, '.ts', '.tsx', '.jsx'],
       }),
+      commonjs(),
       typescript({
         tsconfig: bundle.tsconfig,
         tsconfigDefaults: defaultTSConfig(),
@@ -44,18 +45,13 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
       }),
       babel({
         babelHelpers: 'runtime',
-        exclude: /node_modules/,
         extensions: [
-          ...DEFAULT_EXTENSIONS
+          ...DEFAULT_EXTENSIONS,
+          '.ts',
+          '.tsx'
         ],
-        sourceType: 'unambiguous',
-        presets: ['@babel/preset-env'],
-        plugins: [
-          ['@babel/plugin-transform-runtime']
-        ]
-      }),
-      commonjs({
-        ignoreGlobal: true,
+        presets: ['@babel/preset-env', '@babel/preset-typescript'],
+        plugins: ['@babel/plugin-transform-runtime']
       }),
       injectProcessEnv({
         NODE_ENV: 'production'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1217,6 +1217,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-syntax-typescript@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.1.tgz#460ba9d77077653803c3dd2e673f76d66b4029e5"
+  integrity sha512-UZNEcCY+4Dp9yYRCAHrHDU+9ZXLYaY9MgBXSRLkB9WjYFRR6quJBumfVrEkUxrePPBwFcpWfNKXqVRQQtm7mMA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
 "@babel/plugin-transform-arrow-functions@^7.10.1":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz#cb5ee3a36f0863c06ead0b409b4cc43a889b295b"
@@ -2033,6 +2040,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-typescript@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.12.1.tgz#d92cc0af504d510e26a754a7dbc2e5c8cd9c7ab4"
+  integrity sha512-VrsBByqAIntM+EYMqSm59SiMEf7qkmI9dqMt6RbD/wlwueWmYcI0FFK5Fj47pP6DRZm+3teXjosKlwcZJ5lIMw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/plugin-syntax-typescript" "^7.12.1"
+
 "@babel/plugin-transform-typescript@^7.9.0":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.4.tgz#8b01cb8d77f795422277cc3fcf45af72bc68ba78"
@@ -2408,6 +2424,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-transform-typescript" "^7.9.0"
+
+"@babel/preset-typescript@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.12.7.tgz#fc7df8199d6aae747896f1e6c61fc872056632a3"
+  integrity sha512-nOoIqIqBmHBSEgBXWR4Dv/XBehtIFcw9PqZw6rFYuKrzsZmOQm3PR5siLBnKZFEsDb03IegG8nSjU/iXXXYRmw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-validator-option" "^7.12.1"
+    "@babel/plugin-transform-typescript" "^7.12.1"
 
 "@babel/runtime-corejs3@^7.8.3":
   version "7.10.4"


### PR DESCRIPTION
This PR is to basically back out the changes I made in #689 in which I removed the `@babel/preset-typescript`.

This caused problems in projects where they have monorepo packages like `@org/interactors` which has no `tsconfig.json` and therefore no compiled output.

Files are directly imported as `.ts` files.

When rollup encounters a reference like 

`import { Logo, Table } from '@org/interactors'`;

The `rollup-plugin-typescript2` does not find a match because by default, it will look in the current package for `**/*.ts+(|x)` and not outside so it was not transpiling the import.

The file was getting passed straight to babel which was barfing because the file contained type annotations.

I am of the opinion that you either use `@babel/preset-typescript` or `rollup-plugin-typescript2` and both seems overkill.  You could argue type checking is the job of CI and the code editor and not the job of bigtest but I've readded the babel preset.