### PR TITLE
cause less fetch calls and less resets by having 1 it block in each describe

### DIFF
--- a/packages/server/test/orchestrator.test.ts
+++ b/packages/server/test/orchestrator.test.ts
@@ -20,11 +20,8 @@ describe('orchestrator', () => {
       body = await response.json();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('contains the ping text', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toEqual({"data": {"echo": "Hello World"}})
     });
   });
@@ -38,11 +35,8 @@ describe('orchestrator', () => {
       body = await response.text();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('returns the agent html', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toContain('<title>BigTest</title>');
     });
   });
@@ -55,11 +49,8 @@ describe('orchestrator', () => {
       body = await response.text();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('returns the harness script', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toContain('harness');
     });
   });
@@ -72,11 +63,8 @@ describe('orchestrator', () => {
       body = await response.text();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('serves the application', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toContain('<title>React TodoMVC Example</title>');
     });
   });
@@ -89,15 +77,9 @@ describe('orchestrator', () => {
       body = await response.text();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('proxies to the application', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toContain('<title>React TodoMVC Example</title>');
-    });
-
-    it('injects the harness script tag', () => {
       expect(body).toMatch(new RegExp(`<script src="http://localhost:\\d+/__bigtest/harness.js"></script>`, 'mg'));
     });
   });
@@ -111,11 +93,8 @@ describe('orchestrator', () => {
       body = await response.text();
     });
 
-    it('responds successfully', () => {
-      expect(response.ok).toEqual(true);
-    });
-
     it('serves the application', () => {
+      expect(response.ok).toEqual(true);
       expect(body).toContain('Signing In');
     });
   });


### PR DESCRIPTION
when I was looking at a failing test in the monocle PR, I noticed that each `describe` block in `orchestrator.test.ts` was performing 2 fetches and also performing 2 `Atom#reset` calls before each test or `it` via the `beforeEach` in `helpers`.

For example:

```ts
  describe('retrieving app', () => {
    let response: Response;
    let body: string;
    beforeEach(async () => {
      response = await actions.fetch('http://localhost:24100/');
      body = await response.text();
    });

    it('responds successfully', () => {
      expect(response.ok).toEqual(true);
    });

    it('serves the application', () => {
      expect(body).toContain('<title>React TodoMVC Example</title>');
    });
  });
```

This will call `fetch` twice but it will also invoke the `beforeEach` block in `helpers` twice which resets the atom twice.

```ts
beforeEach(() => {
  actions.atom.reset(initial => ({ ...initial, manifest, bundler }));

  currentWorld = new World();
});
```

Do you think calling `reset` before each test that uses the helpers is correct?

In this PR, each `describe` only has one `it` or test.  This literally took minutes so no problem turning this PR down if I am wrong.

```ts
  describe('retrieving app', () => {
    let response: Response;
    let body: string;
    beforeEach(async () => {
      response = await actions.fetch('http://localhost:24100/');
      body = await response.text();
    });

    it('serves the application', () => {
      expect(response.ok).toEqual(true);
      expect(body).toContain('<title>React TodoMVC Example</title>');
    });
  });
```