### PR TITLE
wait for appService available in @bigtest/server test helpers

### DIFF
--- a/.changeset/smart-chairs-accept.md
+++ b/.changeset/smart-chairs-accept.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+wait for appService to be available in test helpers

--- a/.changeset/smart-chairs-accept.md
+++ b/.changeset/smart-chairs-accept.md
@@ -1,5 +1,0 @@
----
-"@bigtest/server": patch
----
-
-wait for appService to be available in test helpers

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -102,6 +102,10 @@ export const actions = {
         }
       }));
 
+      await actions.fork(
+        actions.atom.slice('appService', 'status').once(status => status.type === 'available')
+      );
+
       orchestratorPromise = this.receive(delegate, { status: 'ready' });
     }
     return orchestratorPromise.then(cxt => {


### PR DESCRIPTION
I've seen this test fail in `@bigtest/server` `orchestrator.test.ts`in many different guises:

```ts
  describe('retrieving app', () => {
    let response: Response;
    let body: string;
    beforeEach(async () => {
      response = await actions.fetch('http://localhost:24100/');
      body = await response.text();
    });

    it('responds successfully', () => {
      expect(response.ok).toEqual(true);
    });

    it('serves the application', () => {
      expect(body).toContain('<title>React TodoMVC Example</title>');
    });
  });
```

I've added a wait condition to `startOrchestrator` in helpers to ensure the `appService` is open for business:

```ts
async startOrchestrator() {
  if(!orchestratorPromise) {
    let delegate = new Mailbox();

    globalWorld.fork(createOrchestrator({
      // state
    }));

    await actions.fork(
      actions.atom.slice('appService', 'status').once(status => status.type === 'available')
    );

    orchestratorPromise = this.receive(delegate, { status: 'ready' });
  }
```


