### PR TITLE
Changes codeblock theme to nightowl

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,6 +12,9 @@ module.exports = {
       disableSwitch: true,
       respectPrefersColorScheme: true,
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/nightOwl'),
+    },
     navbar: {
       title: '',
       logo: {


### PR DESCRIPTION
## Motivation

We want to get to a point where our syntax highlighting has more Frontside personality. Custom themes in docusaurus are not that simple to implement, so for now we're at least moving to a better theme. 

## Approach

Night Owl is a quite popular theme for vscode that has better contrast and a palette more blue-ish which fits our website better. 

## Next steps

Find a way to modify the tokenizer so we can highlight interactors and their methods. 