### PR TITLE
remove setMaxListeners from Atom and add configuration

### DIFF
--- a/.changeset/bright-points-fail.md
+++ b/.changeset/bright-points-fail.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": minor
+---
+
+add atom configuration and remove setMaxListeners

--- a/packages/atom/src/sliceable.ts
+++ b/packages/atom/src/sliceable.ts
@@ -1,6 +1,10 @@
 import { Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Operation } from 'effection';
 
+export interface AtomConfig {
+  channelMaxListeners?: number;
+}
+
 export interface Slice<S> extends Subscribable<S,undefined> {
   get(): S;
   set(value: S): void;
@@ -14,7 +18,6 @@ export interface Slice<S> extends Subscribable<S,undefined> {
 
 export type Atom<S> = Omit<Slice<S>, 'remove' | 'over'> & {
   reset(initializer?: (initial: S, curr: S) => S): void;
-  setMaxListeners(value: number): void;
 }
 
 export type Sliceable<S> = {

--- a/packages/atom/test/atom.test.ts
+++ b/packages/atom/test/atom.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import * as expect from 'expect';
-import { createAtom } from '../src/atom';
+import { createAtom, DefaultChannelMaxListeners } from '../src/atom';
 import { never, spawn, when } from './helpers';
 import { Atom } from '../src/sliceable';
 import { subscribe, ChainableSubscription, Subscription } from '@effection/subscription';
@@ -260,8 +260,6 @@ describe('@bigtest/atom createAtom', () => {
     let subscription: ChainableSubscription<Subject, undefined>;
 
     beforeEach(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      subject = createAtom(undefined as any)
       result = [];
       let bar = { foo: 'bar' };
       let baz = { foo: 'baz' };
@@ -290,4 +288,20 @@ describe('@bigtest/atom createAtom', () => {
       });
     });
   });
+
+  describe('channel maxListeners', () => {
+    it('should set a default value for the channel max listeners' , () => {
+      let atom = createAtom(undefined);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((atom as any)._channelMaxListeners).toBe(DefaultChannelMaxListeners);
+    });
+
+    it('should be able to override channel max listeners' , () => {
+      let atom = createAtom(undefined, { channelMaxListeners: 33 });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((atom as any)._channelMaxListeners).toBe(33);
+    });
+  })
 });

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -70,7 +70,6 @@ export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
     agents: {},
     testRuns: {},
   });
-  atom.setMaxListeners(100000);
 
   return atom;
 }


### PR DESCRIPTION
I've removed `setMaxListeners` from the `Atom` interface and replaced it with an Atom configuration object that defaults to the following when calling `createAtom`:

```ts
export function createAtom<S>(init: S, { channelMaxListeners = DefaultChannelMaxListeners }: AtomConfig = {}): Atom<S> {
```

This is default object restructuring and the config object is optional for `createAtom`

The default `maxListeners` is currently `100000`.