### PR TITLE
Start discussion CTA

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -101,9 +101,6 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          editUrl:
-            'https://github.com/thefrontside/bigtest/tree/v0/website',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/website/src/theme/DocItem/index.js
+++ b/website/src/theme/DocItem/index.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+/**
+ * WARNING:
+ * DocItem is an internal component, and have a higher breaking change probability.
+ * Keep an eye on this file, specially when updating.
+ * The only customization is between lines 110-120 and 34-45 for the styles.
+ */
+
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import DocPaginator from '@theme/DocPaginator';
+import DocVersionSuggestions from '@theme/DocVersionSuggestions';
+import TOC from '@theme/TOC';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+import {
+  useActivePlugin,
+  useVersions,
+  useActiveVersion,
+} from '@theme/hooks/useDocs';
+
+function DocItem(props) {
+  const {siteConfig} = useDocusaurusContext();
+  const {url: siteUrl, title: siteTitle, titleDelimiter} = siteConfig;
+  const {content: DocContent} = props;
+  const {metadata} = DocContent;
+  const {
+    description,
+    title,
+    permalink,
+    editUrl,
+    lastUpdatedAt,
+    lastUpdatedBy,
+  } = metadata;
+  const {
+    frontMatter: {
+      image: metaImage,
+      keywords,
+      hide_title: hideTitle,
+      hide_table_of_contents: hideTableOfContents,
+    },
+  } = DocContent;
+  const {pluginId} = useActivePlugin({
+    failfast: true,
+  });
+  const versions = useVersions(pluginId);
+  const version = useActiveVersion(pluginId); // If site is not versioned or only one version is included
+  // we don't show the version badge
+  // See https://github.com/facebook/docusaurus/issues/3362
+
+  const showVersionBadge = versions.length > 1;
+  const metaTitle = title
+    ? `${title} ${titleDelimiter} ${siteTitle}`
+    : siteTitle;
+  const metaImageUrl = useBaseUrl(metaImage, {
+    absolute: true,
+  });
+  return (
+    <>
+      <Head>
+        <title>{metaTitle}</title>
+        <meta property="og:title" content={metaTitle} />
+        {description && <meta name="description" content={description} />}
+        {description && (
+          <meta property="og:description" content={description} />
+        )}
+        {keywords && keywords.length && (
+          <meta name="keywords" content={keywords.join(',')} />
+        )}
+        {metaImage && <meta property="og:image" content={metaImageUrl} />}
+        {metaImage && <meta property="twitter:image" content={metaImageUrl} />}
+        {metaImage && (
+          <meta name="twitter:image:alt" content={`Image for ${title}`} />
+        )}
+        {permalink && <meta property="og:url" content={siteUrl + permalink} />}
+        {permalink && <link rel="canonical" href={siteUrl + permalink} />}
+      </Head>
+
+      <div className="row">
+        <div
+          className={clsx('col', {
+            [styles.docItemCol]: !hideTableOfContents,
+          })}>
+          <DocVersionSuggestions />
+          <div className={styles.docItemContainer}>
+            <article>
+              {showVersionBadge && (
+                <div>
+                  <span className="badge badge--secondary">
+                    Version: {version.label}
+                  </span>
+                </div>
+              )}
+              {!hideTitle && (
+                <header>
+                  <h1 className={styles.docTitle}>{title}</h1>
+                </header>
+              )}
+              <div className="markdown">
+                <DocContent />
+              </div>
+            </article>
+            <div className={styles.openDiscussionBox}>
+              <h3>
+                <a href="https://github.com/thefrontside/bigtest/discussions/" target="_blank" rel="nofollow">
+                 Is something confusing or isn't working for you in this page?
+                </a>
+              </h3>
+
+              <p>
+                Please <a href="https://github.com/thefrontside/bigtest/discussions/" target="_blank" rel="nofollow" className={styles.discussionCta}>open a discussion</a> in our repo and we'll help you right away. Thanks for helping us improve our docs 💙
+              </p>
+            </div>
+            {(editUrl || lastUpdatedAt || lastUpdatedBy) && (
+              <div className="margin-vert--xl">
+                <div className="row">
+                  <div className="col">
+                    {editUrl && (
+                      <a
+                        href={editUrl}
+                        target="_blank"
+                        rel="noreferrer noopener">
+                        <svg
+                          fill="currentColor"
+                          height="1.2em"
+                          width="1.2em"
+                          preserveAspectRatio="xMidYMid meet"
+                          viewBox="0 0 40 40"
+                          style={{
+                            marginRight: '0.3em',
+                            verticalAlign: 'sub',
+                          }}>
+                          <g>
+                            <path d="m34.5 11.7l-3 3.1-6.3-6.3 3.1-3q0.5-0.5 1.2-0.5t1.1 0.5l3.9 3.9q0.5 0.4 0.5 1.1t-0.5 1.2z m-29.5 17.1l18.4-18.5 6.3 6.3-18.4 18.4h-6.3v-6.2z" />
+                          </g>
+                        </svg>
+                        Edit this page
+                      </a>
+                    )}
+                  </div>
+                  {(lastUpdatedAt || lastUpdatedBy) && (
+                    <div className="col text--right">
+                      <em>
+                        <small>
+                          Last updated{' '}
+                          {lastUpdatedAt && (
+                            <>
+                              on{' '}
+                              <time
+                                dateTime={new Date(
+                                  lastUpdatedAt * 1000,
+                                ).toISOString()}
+                                className={styles.docLastUpdatedAt}>
+                                {new Date(
+                                  lastUpdatedAt * 1000,
+                                ).toLocaleDateString()}
+                              </time>
+                              {lastUpdatedBy && ' '}
+                            </>
+                          )}
+                          {lastUpdatedBy && (
+                            <>
+                              by <strong>{lastUpdatedBy}</strong>
+                            </>
+                          )}
+                          {process.env.NODE_ENV === 'development' && (
+                            <div>
+                              <small>
+                                {' '}
+                                (Simulated during dev for better perf)
+                              </small>
+                            </div>
+                          )}
+                        </small>
+                      </em>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="margin-vert--lg">
+              <DocPaginator metadata={metadata} />
+            </div>
+          </div>
+        </div>
+        {!hideTableOfContents && DocContent.rightToc && (
+          <div className="col col--3">
+            <TOC headings={DocContent.rightToc} />
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default DocItem;

--- a/website/src/theme/DocItem/styles.module.css
+++ b/website/src/theme/DocItem/styles.module.css
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docTitle {
+  font-size: 3rem;
+  margin-bottom: calc(var(--ifm-leading-desktop) * var(--ifm-leading));
+}
+
+.docItemContainer {
+  margin: 0 auto;
+  padding: 0 0.5rem;
+}
+
+@media only screen and (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}
+
+@media only screen and (max-width: 996px) {
+  .docItemContainer {
+    padding: 0 0.3rem;
+  }
+}
+
+.docLastUpdatedAt {
+  font-weight: bold;
+}
+
+.openDiscussionBox {
+  margin-top: calc(var(--ifm-leading-desktop) * var(--ifm-leading) * 2);
+  border: 1px solid rgb(119, 181, 209);
+  background: rgba(119, 181, 209, 0.2);
+  border-radius: 5px;
+  padding: 20px;
+}
+
+.discussionCta {
+  font-weight: bold;
+  border-bottom: 1px solid var(--ifm-color-primary);
+}


### PR DESCRIPTION
## Motivation

As Jen pointed out, `Edit this page` isn't very useful so we want to replace it by a call to action that can be more helpful. The decision was to add a CTA at the end of the page prompting the reader to start a discussion if they found something confusing or didn't work for them. 

## Approach

1. I disabled the Edit this page by setting the edit url to an empty string.
2. "Swizzled" the `DocItem` component and added the little piece that we needed.