### PR TITLE
Admonition styles + tweaks

### DIFF
--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -8,7 +8,9 @@ BigTest's Interactors make your UI tests easier to write, faster, and more relia
 
 By the end of this quick start, you will be testing one of your own apps with Interactors.
 
-> If you need help or have questions along the way, please let us know in [the Discord chat](https://discord.gg/r6AvtnU).
+:::note We're here to help
+ If you need help or have questions along the way, please let us know in [the Discord chat](https://discord.gg/r6AvtnU) or [open a discussion](https://github.com/thefrontside/bigtest/discussions/) on Github.
+:::
 
 ## Prerequisites
 
@@ -128,7 +130,9 @@ Make sure to substitute "Sign In" with your own button text.
 
 Now, run your tests! Congratulations, you used your first Interactor.
 
-> There's more to BigTest than Interactors. BigTest can also run your tests on any _real_ browser! We have built a new integrated platform from the ground up to help you test more with less effort. And yes, it's free and Open Source too! [Check it out](/platform), and let us know what you think.
+:::note The BigTest Platform
+ There's more to BigTest than Interactors. BigTest can also run your tests on any _real_ browser! We have built a new integrated platform from the ground up to help you test more with less effort. And yes, it's free and Open Source too! [Check it out](/platform), and let us know what you think.
+:::
 
 ## Making test assertions
 

--- a/website/docs/interactors/2-built-in-dom.md
+++ b/website/docs/interactors/2-built-in-dom.md
@@ -35,7 +35,9 @@ Page.has({ title: 'BigTest Example App' });
 ```
 _The `Page` interactor is instantiated differently than the other built-in interactors so you do not need to call it `Page()` unless you want to pass in an argument._
 
-> We've introduced `.exists()` and `.absent()` in the previous section but there are also `.has()` and `.is()` Interactor assertion methods. We will discuss its details on the [locators filters actions](/docs/interactors/locators-filters-actions) page.
+:::note Heads up
+ We've introduced `.exists()` and `.absent()` in the previous section but there are also `.has()` and `.is()` Interactor assertion methods. We will discuss its details on the [locators filters actions](/docs/interactors/locators-filters-actions) page.
+:::
 
 And when using BigTest platform, the Page interactor can be used to navigate between routes:
 

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -41,14 +41,16 @@ Another way of narrowing down the element that you want to reference is with Fil
 TextField('Username:', { id: 'username-id' }).exists();
 ```
 
-> The locator of the `TextField` interactor is the textContent of its associated label:
-> ```html
-><label>
->  Username:
->  <input type='text' id='username-id'/>
-></label>
-> ```
-> _See the source code of the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts)_.
+:::note How is the textfield located?
+ The locator of the `TextField` interactor is the textContent of its associated label:
+ ```html
+<label>
+  Username:
+  <input type='text' id='username-id'/>
+</label>
+ ```
+ _See the source code of the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts)_.
+:::
 
 You can think of locators as the "default filter" because filters and locators both serve the same functionality. The reason why we offer both solutions is for your convenience because having to pass in an object for each interactor can be repetitive.
 
@@ -80,9 +82,11 @@ If you take a look at the [TextField source code](https://github.com/thefrontsid
 ### Asserting with filters
 Filters can be very convenient for finding matching UI elements, but where they really shine is in making assertions about what you expect your application to be showing.
 
-In the [quick start](/docs/interactors/#making-test-assertions) we briefly touched on the assertion methods that are available on all interactors, `exists()` and `absent()`. There is also `has()` which allows you pass in a filter as its argument. 
+In the [quick start](/docs/interactors/#making-test-assertions) we briefly touched on the assertion methods that are available on all interactors, `exists()` and `absent()`. There is also `has()` which allows you pass in a filter as its argument.
 
-> These assertion methods are equivalents of Jest's `expect` and Cypress' `should`. When refactoring your test with Interactors, you would replace those constructs with the interactors' assertion methods.
+:::note
+ These assertion methods are equivalents of Jest's `expect` and Cypress' `should`. When refactoring your test with Interactors, you would replace those constructs with the interactors' assertion methods.
+:::
 
 Continuing from the last example, this is how we would assert the placeholder against a textfield:
 

--- a/website/docs/interactors/4-write-your-own.md
+++ b/website/docs/interactors/4-write-your-own.md
@@ -7,7 +7,12 @@ Nearly every app has at least one user interaction that is unusual or special, l
 
 In this section, you will learn how to create a new Interactor for any interface and use it in your tests. We will start with a simple example for learning purposes, level up to a more complex example, and then cover common questions.
 
-> :exclamation: There are new, exciting changes in the works for the `createInteractor()` API. Those changes will deprecate the syntax you see in the examples below, but the refactoring process will be very simple. We will output clear instructions in your console on how you can update to the new syntax so you can use Interactors today without worrying too much about tomorrow.
+:::info Heads up
+
+There are new, exciting changes in the works for the `createInteractor()` API. Those changes will deprecate the syntax you see in the examples below, but the refactoring process will be very simple. We will output clear instructions in your console on how you can update to the new syntax so you can use Interactors today without worrying too much about tomorrow.
+
+:::
+
 
 ## Writing your first interactor
 
@@ -36,7 +41,9 @@ export const TextField = createInteractor<HTMLInputElement>('my-textfield-intera
 });
 ```
 
-> `fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts). You can use any of the functions defined by BigTest or implement your own.
+:::note
+ `fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts). You can use any of the functions defined by BigTest or implement your own.
+:::
 
 In this example we've configured the selector as `input[type=text]` which will search for all `<input type='text'>` elements in your testing environment. Filters and locators are used to narrow down the list of results.
 
@@ -236,7 +243,9 @@ export const TableCell = createInteractor('table cell')({
 });
 ```
 
-> This example uses [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which is available in Node >=14.
+:::note Check your node version
+ This example uses [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which is available in Node >=14.
+:::
 
 You'll notice we created `columnTitle` and `rowNumber` filters that will access its parent elements to get the appropriate value we're looking for. The locator was not specified, so it will default to `element.textContent`.
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -26,7 +26,9 @@
   --ifm-code-font-size: 0.80em;
   --ifm-navbar-link-color: var(--ifm-color-primary);
   --fs-pink: #f74d7b;
+  --fs-skyblue: #26abe8;
   --ifm-link-hover-decoration: none;
+  --ra-color-text-dark: var(--ifm-color-primary);
 }
 
 html[data-theme='dark'] {
@@ -77,6 +79,11 @@ body {
   transform: translateX(-50%);
 }
 
+.navbar__link[href$="interactors"] {
+  width: 164px;
+  text-align: center;
+}
+
 .navbar__link[href$="interactors"]:after {
   content: 'beta';
   font-size: 0.7em;
@@ -87,6 +94,11 @@ body {
   margin-left: 0.5rem;
   text-transform: uppercase;
   font-weight: normal;
+}
+
+.navbar__link[href$="platform"] {
+  width: 156px;
+  text-align: center;
 }
 
 .navbar__link[href$="platform"]:after {
@@ -102,7 +114,7 @@ body {
 }
 
 .navbar__link {
-  letter-spacing: 0.15px;
+  letter-spacing: 0.05px;
 }
 
 .navbar__link--active {
@@ -184,22 +196,6 @@ body {
 
 .markdown a:hover {
   border-color: var(--fs-pink);
-}
-
-.markdown > h2 {
-  margin-top: 0;
-}
-
-.markdown .anchor {
-  display: block;
-  padding-top: calc(var(--ifm-h2-vertical-rhythm-top) * var(--ifm-leading));
-  /* line-height: 32px;
-  top: 10px; */
-  /* height: calc(var(--ifm-navbar-height) * 2);
-  padding-bottom: var(--ifm-navbar-height);
-
-  line-height: var(--ifm-navbar-height);
-  margin-top: var(--ifm-navbar-height); */
 }
 
 .table-of-contents {
@@ -298,4 +294,21 @@ body {
   border-radius: var(--ifm-global-radius);
   border: 1px solid var(--ifm-color-primary);
   color: var(--ifm-color-primary);
+}
+
+.admonition h5 {
+  color: var(--ra-admonition-icon-color);
+}
+
+.alert--secondary {
+  --ifm-alert-background-color: #25abe826;
+  --ifm-alert-border-color: #25abe826;
+  --ifm-alert-color: var(--ifm-font-color-base);
+}
+
+.alert--info {
+  --ifm-alert-background-color: #ff92ae2e;
+  --ifm-alert-border-color: var(--fs-pink);
+  --ifm-alert-color: var(--ifm-font-color-base);
+  --ra-admonition-icon-color: var(--fs-pink);
 }


### PR DESCRIPTION
## Motivation 

Docusaurus provides [admonition/callout blocks](https://v2.docusaurus.io/docs/markdown-features/#calloutsadmonitions) within markdown. So far, we had used `>` to mark notes and such but I think we can use these blocks for better semantics/styles.

## Approach

- This PR replaces all instances of notes with `>` on the Interactors guides with a `:::note` block. Can y'all check if they make sense? specially the little titles that I added @minkimcello @jenweber 
- I only made styles for `::note` and `:::info`, we can create styles for `:::tip`, `:::caution` or `:::danger` when we need them. If that's already something we want to use, let me know and I'll make them now.
- Small tweaks: fixes #751, also the jiggly topnav reported on #683 (before there was a 3px change on the link width caused by bold fonts, now links have a fixed width to prevent that).

[Link to page that uses two types of admonitions](https://deploy-preview-754--bigtest.netlify.app/bigtest/docs/interactors/write-your-own)