### PR TITLE
Modify generated tsconfig file name to bigtest.tsconfig.json

### DIFF
--- a/.changeset/brown-rocks-clean.md
+++ b/.changeset/brown-rocks-clean.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/cli": minor
+---
+
+Modify default name of generated tsconfig of bigtest cli init command

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -72,7 +72,7 @@ export function* init(configFile: string): Operation<void> {
     if(yield prompt.boolean('Do you want to set up a separate TypeScript `tsconfig` file for BigTest?', { defaultValue: true })) {
       options.tsconfig = yield prompt.string('Where should the custom `tsconfig` be located?', {
         name: 'tsconfig',
-        defaultValue: options.tsconfig || './tsconfig.bigtest.ts',
+        defaultValue: options.tsconfig || './bigtest.tsconfig.json',
       })
     }
   }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -334,7 +334,7 @@ describe('@bigtest/cli', function() {
     });
   });
 
-  describe.only('init', () => {
+  describe('init', () => {
     describe('running the init command', () => {
       let child: TestProcess;
       let status: ExitStatus;


### PR DESCRIPTION
## Motivation
To resolve #676 

## Approach
- Changed the default value of the tsconfig filename from `tsconfig.bigtest.ts` to `bigtest.tsconfig.json`
- Add to the current CLI test and checking its generated tsconfig against the tsconfig specified in `@bigtest/project`.