### PR TITLE
add netlify dev setup for docs website

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,12 @@
   command = "yarn build"
   publish = "public/"
 
+[dev]
+  command = "yarn start"
+  publish = "public/"
+  targetPort = 3000
+  framework = "#custom"
+
 [[redirects]]
   from = "/*"
   to = "/bigtest/:splat"


### PR DESCRIPTION
If you have `netlify` cli setup, you can run `ntl dev` in the `website` directory and version of the app that will be as nearly similar to what you would see on our netlify deploy. This is particularly helpful for testing the redirects and environment variables.