### PR TITLE
Enable sameorigin iframe embedding

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,3 +6,9 @@
 [[redirects]]
   from = "/*"
   to = "/bigtest/:splat"
+
+[[headers]]
+  for = "/bigtest/asciinema/iframes/cross-platform.html"
+
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"


### PR DESCRIPTION
## Motivation 

The iframe on /platform cannot be loaded due to Neltify's default `DENY` policy. 

## Approach

I set `SAMEORIGIN` as policy for the file that we want to embed, the other routes keep the default policy.