### PR TITLE
Configures BigTest GA id

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -94,6 +94,9 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} The Frontside Software, Inc.`,
     },
+    googleAnalytics: {
+      trackingID: 'UA-44597640-4'
+    },
   },
   presets: [
     [


### PR DESCRIPTION
## Motivation

We'd like to know about our visitors behavior on the documentation site.

## Approach

We currently use Google Analytics in Frontside's website, and it was also used the previous BigTest website. Docusaurus provides built-in support for GA so we just need to configure the ID.  I also updated GA admin to point to the new URL.