### PR TITLE
Match HTML description of interactors to heading

### DIFF
--- a/website/src/pages/interactors.js
+++ b/website/src/pages/interactors.js
@@ -98,7 +98,7 @@ function Interactors() {
   return (
     <Layout
       title="Interactors"
-      description="Test your app as a person uses it">
+      description="Test your app as real people use it">
       <header>
         <div className={clsx("container", styles.heroContainer)}>
           <div className={styles.heroText}>


### PR DESCRIPTION
## Motivation

<img width="708" alt="image" src="https://user-images.githubusercontent.com/74687/104125311-e112d280-5323-11eb-905d-b73a03c8f4e1.png">

Posted that in Discord and found `Test your app as a person uses it` awkward to read. Then found a better version on the actual page.

## Approach

Update HTML description so it matches the description on the website.
