### PR TITLE
Add missing eslint rules

### DIFF
--- a/.changeset/curly-squids-double.md
+++ b/.changeset/curly-squids-double.md
@@ -1,0 +1,18 @@
+---
+"@bigtest/agent": patch
+"@bigtest/atom": patch
+"@bigtest/bundler": patch
+"@bigtest/cli": patch
+"@bigtest/client": patch
+"@bigtest/effection": patch
+"@bigtest/effection-express": patch
+"@bigtest/globals": patch
+"@bigtest/interactor": patch
+"@bigtest/logging": patch
+"@bigtest/project": patch
+"@bigtest/server": patch
+"@bigtest/suite": patch
+"@bigtest/webdriver": patch
+---
+
+enable eslint rules from the latest @typescript-eslint/recommended

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,6 @@
 {
   "extends": "@frontside",
   "rules": {
-    "@typescript-eslint/ban-types": "off",
-    "@typescript-eslint/explicit-module-boundary-types": "off",
     "eol-last": "off",
     "@typescript-eslint/no-extra-semi": "off",
     "no-multi-spaces": "off",

--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -2,8 +2,12 @@ import { parse } from 'bowser';
 import { QueryParams } from './query-params';
 import { Agent } from '../shared/agent';
 import { run } from './runner';
+import { Controller, Operation, OperationFn, Sequence } from 'effection';
 
-export function* createAgent(queryParams: QueryParams) {
+// union of values that is yielded from createAgent
+type CreateAgentValue = Operation<Agent> | OperationFn<void> | Sequence<void> | PromiseLike<void> | Controller<void>;
+
+export function* createAgent(queryParams: QueryParams): Generator<CreateAgentValue, void, Agent> {
   console.log('[agent] connecting to', queryParams.connectTo);
 
   let createSocket = () => new WebSocket(queryParams.connectTo);

--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -5,7 +5,12 @@ import { run } from './runner';
 import { Controller, Operation, OperationFn, Sequence } from 'effection';
 
 // union of values that is yielded from createAgent
-type CreateAgentValue = Operation<Agent> | OperationFn<void> | Sequence<void> | PromiseLike<void> | Controller<void>;
+type CreateAgentValue =
+  | Operation<Agent>
+  | OperationFn<void>
+  | Sequence<void> 
+  | PromiseLike<void> 
+  | Controller<void>;
 
 export function* createAgent(queryParams: QueryParams): Generator<CreateAgentValue, void, Agent> {
   console.log('[agent] connecting to', queryParams.connectTo);

--- a/packages/agent/app/agent.ts
+++ b/packages/agent/app/agent.ts
@@ -2,17 +2,9 @@ import { parse } from 'bowser';
 import { QueryParams } from './query-params';
 import { Agent } from '../shared/agent';
 import { run } from './runner';
-import { Controller, Operation, OperationFn, Sequence } from 'effection';
+import { Operation } from 'effection';
 
-// union of values that is yielded from createAgent
-type CreateAgentValue =
-  | Operation<Agent>
-  | OperationFn<void>
-  | Sequence<void> 
-  | PromiseLike<void> 
-  | Controller<void>;
-
-export function* createAgent(queryParams: QueryParams): Generator<CreateAgentValue, void, Agent> {
+export function* createAgent(queryParams: QueryParams): Operation<void> {
   console.log('[agent] connecting to', queryParams.connectTo);
 
   let createSocket = () => new WebSocket(queryParams.connectTo);

--- a/packages/agent/app/clear-persistent-storage.ts
+++ b/packages/agent/app/clear-persistent-storage.ts
@@ -1,4 +1,4 @@
-import { Context, fork, Operation } from 'effection';
+import { fork, Operation } from 'effection';
 import { getIndexedDBConfig } from './indexed-db-config';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/agent/app/clear-persistent-storage.ts
+++ b/packages/agent/app/clear-persistent-storage.ts
@@ -1,7 +1,6 @@
 import { fork, Operation } from 'effection';
 import { getIndexedDBConfig } from './indexed-db-config';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function* clearPersistentStorage(): Operation<void> {
   localStorage.clear();
   sessionStorage.clear();

--- a/packages/agent/app/clear-persistent-storage.ts
+++ b/packages/agent/app/clear-persistent-storage.ts
@@ -1,7 +1,8 @@
-import { fork } from 'effection';
+import { Context, fork, Operation } from 'effection';
 import { getIndexedDBConfig } from './indexed-db-config';
 
-export function* clearPersistentStorage() {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function* clearPersistentStorage(): Generator<Generator<Operation<Context<any>>>> {
   localStorage.clear();
   sessionStorage.clear();
 

--- a/packages/agent/app/clear-persistent-storage.ts
+++ b/packages/agent/app/clear-persistent-storage.ts
@@ -2,7 +2,7 @@ import { Context, fork, Operation } from 'effection';
 import { getIndexedDBConfig } from './indexed-db-config';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function* clearPersistentStorage(): Generator<Generator<Operation<Context<any>>>> {
+export function* clearPersistentStorage(): Operation<void> {
   localStorage.clear();
   sessionStorage.clear();
 

--- a/packages/agent/app/lane-config.ts
+++ b/packages/agent/app/lane-config.ts
@@ -22,7 +22,7 @@ interface LaneConfigurable {
  * Set information about the lane to run so that the test frame can retrieve it.
  * should only be called from the agent frame.
  */
-export function setLaneConfigFromAgentFrame(config: LaneConfig) {
+export function setLaneConfigFromAgentFrame(config: LaneConfig): void {
   let context: typeof globalThis = window.window;
   let bigtest: LaneConfigurable = context.__bigtest as LaneConfigurable;
   if (!bigtest) {

--- a/packages/agent/app/log-config.ts
+++ b/packages/agent/app/log-config.ts
@@ -19,7 +19,7 @@ interface LogConfigurable {
  * Set information about the lane to run so that the test frame can retrieve it.
  * should only be called from the agent frame.
  */
-export function setLogConfig(config: LogConfig) {
+export function setLogConfig(config: LogConfig): void {
   let context: typeof globalThis = window.window;
   let bigtest: LogConfigurable = context.__bigtest as LogConfigurable;
   if (!bigtest) {

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -1,4 +1,4 @@
-import { Operation, fork, spawn } from 'effection';
+import { Operation, fork, spawn, OperationFn, Sequence, Controller, Context } from 'effection';
 import { on } from '@effection/events';
 import { bigtestGlobals } from '@bigtest/globals';
 import { TestImplementation, Context as TestContext } from '@bigtest/suite';
@@ -13,7 +13,19 @@ import { setLogConfig, getLogConfig } from './log-config';
 import { clearPersistentStorage } from './clear-persistent-storage';
 import { addCoverageMap } from './coverage';
 
-export function* runLane(config: LaneConfig) {
+// union of types yielded from runLane  
+type RunLaneValues = 
+  | OperationFn<void>
+  | Sequence<void>
+  | PromiseLike<void>
+  | Controller<void>
+  | OperationFn<TestImplementation>
+  | Operation<TestImplementation>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | Generator<Generator<Operation<Context<any>>>>
+  | undefined;
+
+export function* runLane(config: LaneConfig): Generator<RunLaneValues, void, TestImplementation> {
   setLogConfig({ events: [] });
 
   let { events, command, path } = config;

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -13,19 +13,7 @@ import { setLogConfig, getLogConfig } from './log-config';
 import { clearPersistentStorage } from './clear-persistent-storage';
 import { addCoverageMap } from './coverage';
 
-// union of types yielded from runLane  
-type RunLaneValues = 
-  | OperationFn<void>
-  | Sequence<void>
-  | PromiseLike<void>
-  | Controller<void>
-  | OperationFn<TestImplementation>
-  | Operation<TestImplementation>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | Generator<Generator<Operation<Context<any>>>>
-  | undefined;
-
-export function* runLane(config: LaneConfig): Generator<RunLaneValues, void, TestImplementation> {
+export function* runLane(config: LaneConfig): Operation<TestImplementation> {
   setLogConfig({ events: [] });
 
   let { events, command, path } = config;

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -1,4 +1,4 @@
-import { Operation, fork, spawn, OperationFn, Sequence, Controller, Context } from 'effection';
+import { Operation, fork, spawn } from 'effection';
 import { on } from '@effection/events';
 import { bigtestGlobals } from '@bigtest/globals';
 import { TestImplementation, Context as TestContext } from '@bigtest/suite';

--- a/packages/agent/shared/agent.ts
+++ b/packages/agent/shared/agent.ts
@@ -1,7 +1,7 @@
 import { Operation, resource, spawn } from 'effection';
 import { on, once } from '@effection/events';
-import { createSubscription } from '@effection/subscription';
-import { AgentProtocol, AgentEvent, Command } from './protocol';
+import { ChainableSubscribable, createSubscription } from '@effection/subscription';
+import { AgentProtocol, AgentEvent, Command, Run } from './protocol';
 
 export * from './protocol';
 
@@ -43,7 +43,7 @@ export class Agent implements AgentProtocol {
     return agent;
   }
 
-  get commands() {
+  get commands(): ChainableSubscribable<Run, void> {
     let { socket } = this;
     return createSubscription<Command, void>(function*(publish) {
       yield spawn(
@@ -59,7 +59,7 @@ export class Agent implements AgentProtocol {
     });
   }
 
-  send(message: AgentEvent) {
+  send(message: AgentEvent): void {
     this.socket.send(JSON.stringify({ ...message, agentId: this.options.agentId }));
   }
 

--- a/packages/agent/src/server-config.ts
+++ b/packages/agent/src/server-config.ts
@@ -8,14 +8,14 @@ interface Options {
 export class AgentServerConfig {
   constructor(public options: Options) {}
 
-  url() {
+  url(): string {
     let url = new URL('http://localhost');
     url.port = this.options.port.toString();
     url.pathname = this.options.prefix || '/';
     return url.toString();
   }
 
-  agentUrl(connectionUrl: string, agentId?: string) {
+  agentUrl(connectionUrl: string, agentId?: string): string {
     let url = new URL(this.url());
     url.pathname = url.pathname + 'index.html';
     url.searchParams.append('connectTo', connectionUrl);
@@ -25,11 +25,11 @@ export class AgentServerConfig {
     return url.toString();
   }
 
-  harnessUrl() {
+  harnessUrl(): string {
     return `${this.url()}harness.js`;
   }
 
-  appDir() {
+  appDir(): string {
     return Path.join(__dirname, '../app');
   }
 }

--- a/packages/atom/src/atom.ts
+++ b/packages/atom/src/atom.ts
@@ -142,7 +142,7 @@ export function createAtom<S>(init: S, { channelMaxListeners = DefaultChannelMax
 }
 
 // This is purely for testing purposes
-export function resetAtom<S>(atom: Slice<S>, initializer?: (initial: S, curr: S) => S | undefined) {
+export function resetAtom<S>(atom: Slice<S>, initializer?: (initial: S, curr: S) => S | undefined): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (atom as any)._reset(initializer)
 }

--- a/packages/atom/src/unique.ts
+++ b/packages/atom/src/unique.ts
@@ -1,4 +1,4 @@
-export const unique = <S>(current: S) => (state: S) => {
+export const unique = <S>(current: S) => (state: S): boolean => {
   if (current !== state) {
     current = state;
     return true;

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -1,6 +1,6 @@
 import { Operation, resource, timeout } from 'effection';
 import { on } from '@effection/events';
-import { Subscribable, SymbolSubscribable } from '@effection/subscription';
+import { Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Channel } from '@effection/channel';
 import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
 import { defaultTSConfig } from '@bigtest/project';
@@ -94,7 +94,7 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
 
   constructor(public options: BundleOptions) {};
 
-  [SymbolSubscribable]() {
+  [SymbolSubscribable](): Operation<Subscription<BundlerMessage, undefined>> {
     return this.channel[SymbolSubscribable]();
   }
 

--- a/packages/cli/src/format-helpers.ts
+++ b/packages/cli/src/format-helpers.ts
@@ -28,7 +28,7 @@ export function statusIcon(status: ResultStatus, okayIcon = '✓'): string {
 export const stepStatusIcon = (status: ResultStatus): string => statusIcon(status, '↪');
 export const assertionStatusIcon = (status: ResultStatus): string => statusIcon(status, '✓');
 
-export function printStackTrace(printer: Printer, error: ErrorDetails) {
+export function printStackTrace(printer: Printer, error: ErrorDetails): void {
   if(error.stack) {
     for(let stackFrame of error.stack) {
       let location = stackFrame.source || stackFrame;
@@ -53,7 +53,7 @@ export function printStackTrace(printer: Printer, error: ErrorDetails) {
   }
 }
 
-export function printError(printer: Printer, error?: ErrorDetails) {
+export function printError(printer: Printer, error?: ErrorDetails): void {
   if(error) {
     printer.red.words('ERROR', error.name, error.message);
 
@@ -63,7 +63,7 @@ export function printError(printer: Printer, error?: ErrorDetails) {
   }
 }
 
-export function printLogEvent(printer: Printer, event: LogEvent) {
+export function printLogEvent(printer: Printer, event: LogEvent): void {
   if(event.type === 'error') {
     printError(printer.prefix(chalk.red('⨯ '), chalk.red('│ ')), event.error);
   } else {
@@ -78,7 +78,7 @@ export function printLogEvent(printer: Printer, event: LogEvent) {
   }
 }
 
-export function printLog(printer: Printer, events?: LogEvent[]) {
+export function printLog(printer: Printer, events?: LogEvent[]): void {
   if(!events) return;
   printer.blue.line(chalk.blue('┌ Console'));
 
@@ -87,7 +87,7 @@ export function printLog(printer: Printer, events?: LogEvent[]) {
   }
 }
 
-export function printStepResult(printer: Printer, step: StepResult) {
+export function printStepResult(printer: Printer, step: StepResult): void {
   printer.words(stepStatusIcon(step.status), step.description);
 
   if(step.status === 'failed') {
@@ -96,7 +96,7 @@ export function printStepResult(printer: Printer, step: StepResult) {
   }
 }
 
-export function printAssertionResult(printer: Printer, assertion: AssertionResult) {
+export function printAssertionResult(printer: Printer, assertion: AssertionResult): void {
   printer.words(assertionStatusIcon(assertion.status), assertion.description);
 
   if(assertion.status === 'failed') {
@@ -105,7 +105,7 @@ export function printAssertionResult(printer: Printer, assertion: AssertionResul
   }
 }
 
-export function printResults(printer: Printer, result: TestResult) {
+export function printResults(printer: Printer, result: TestResult): void {
   if(result.status !== 'ok') {
     printer.line(`☲ ${result.description}`);
 
@@ -123,7 +123,7 @@ export function printResults(printer: Printer, result: TestResult) {
   }
 }
 
-export function printStandardFooter(printer: Printer, { testRun }: TestResults) {
+export function printStandardFooter(printer: Printer, { testRun }: TestResults): void {
   testRun.agents.forEach(({ agent, summary, result }) => {
     printer.grey.line('────────────────────────────────────────────────────────────────────────────────');
     printer.line(`${agent.agentId}`);

--- a/packages/cli/src/printer.ts
+++ b/packages/cli/src/printer.ts
@@ -8,7 +8,7 @@ export class Printer {
   constructor(public stream: Writable, public basePrefix = '', public trailingPrefix = basePrefix, public colorValue?: Color) {
   }
 
-  write(...text: string[]) {
+  write(...text: string[]): void {
     let result = text.join('').split(/\r?\n(?!$)/).map((l, index) => (index === 0 ? this.basePrefix : this.trailingPrefix) + l).join(os.EOL).replace(/\r?\n$/, os.EOL);
     if(this.colorValue) {
       result = chalk[this.colorValue](result);
@@ -16,11 +16,11 @@ export class Printer {
     this.stream.write(result);
   }
 
-  line(...lines: string[]) {
+  line(...lines: string[]): void {
     this.write(lines.join(os.EOL) + os.EOL);
   }
 
-  words(...words: (string | undefined)[]) {
+  words(...words: (string | undefined)[]): void {
     this.write(words.filter(Boolean).join(' '), os.EOL);
   }
 
@@ -36,10 +36,10 @@ export class Printer {
     return new Printer(this.stream, this.basePrefix, this.trailingPrefix, value);
   }
 
-  get red() { return this.color('red'); }
-  get grey() { return this.color('grey'); }
-  get white() { return this.color('white'); }
-  get yellow() { return this.color('yellow'); }
-  get green() { return this.color('green'); }
-  get blue() { return this.color('blue'); }
+  get red(): Printer { return this.color('red'); }
+  get grey(): Printer { return this.color('grey'); }
+  get white(): Printer { return this.color('white'); }
+  get yellow(): Printer { return this.color('yellow'); }
+  get green(): Printer { return this.color('green'); }
+  get blue(): Printer { return this.color('blue'); }
 }

--- a/packages/cli/src/project-options.ts
+++ b/packages/cli/src/project-options.ts
@@ -27,7 +27,7 @@ export function *loadOptions(filePath?: string): Operation<ProjectOptions> {
   });
 }
 
-export function applyStartArgs(options: ProjectOptions, args: StartArgs) {
+export function applyStartArgs(options: ProjectOptions, args: StartArgs): void {
   if(args.launch) {
     options.launch = args.launch;
   }
@@ -45,7 +45,7 @@ export function applyStartArgs(options: ProjectOptions, args: StartArgs) {
   }
 }
 
-export function validateOptions(options: ProjectOptions) {
+export function validateOptions(options: ProjectOptions): void {
   if (!options.app?.url) {
     throw new MainError({
       exitCode: 1,

--- a/packages/cli/src/prompt.ts
+++ b/packages/cli/src/prompt.ts
@@ -20,7 +20,7 @@ export class Prompt {
 
   private constructor(private rl: ReadLine) {}
 
-  write(data: string) {
+  write(data: string): void {
     process.stdout.write(data);
   }
 

--- a/packages/cli/src/query.ts
+++ b/packages/cli/src/query.ts
@@ -33,7 +33,7 @@ const fragments = `
   }
 `
 
-export function run() {
+export function run(): string {
   return fragments + `
     subscription(
       $files: [String!]! = [],
@@ -54,7 +54,7 @@ export function run() {
     }`
 }
 
-export function test() {
+export function test(): string {
   return fragments + `
     fragment TestDetails on TestResult {
       description

--- a/packages/cli/src/start-server.ts
+++ b/packages/cli/src/start-server.ts
@@ -11,7 +11,7 @@ interface Options {
 
 // TODO: this is what the server package should be doing in the first place
 // See: https://github.com/thefrontside/bigtest/issues/295
-export function* startServer(project: ProjectOptions, options: Options) {
+export function* startServer(project: ProjectOptions, options: Options): Generator<Operation<Record<string, unknown>>> {
   return yield readyResource({}, function*(ready) {
     let delegate = new Mailbox();
     let atom = createOrchestratorAtom(project);

--- a/packages/cli/src/start-server.ts
+++ b/packages/cli/src/start-server.ts
@@ -11,7 +11,7 @@ interface Options {
 
 // TODO: this is what the server package should be doing in the first place
 // See: https://github.com/thefrontside/bigtest/issues/295
-export function* startServer(project: ProjectOptions, options: Options): Generator<Operation<Record<string, unknown>>> {
+export function* startServer(project: ProjectOptions, options: Options): Operation<Record<string, unknown>> {
   return yield readyResource({}, function*(ready) {
     let delegate = new Mailbox();
     let atom = createOrchestratorAtom(project);

--- a/packages/cli/test/helpers/stream.ts
+++ b/packages/cli/test/helpers/stream.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'effection';
 import { resource, Operation } from 'effection';
 import { subscribe } from '@effection/subscription';
 import { Channel } from '@effection/channel';
@@ -7,7 +8,7 @@ import { World } from './world';
 export class Stream {
   public output = "";
   private semaphore = new Channel<true>();
-  append = (chunk: string) => this.output += chunk;
+  append = (chunk: string): string => this.output += chunk;
 
   static *of(channel: Channel<string>, verbose = false): Operation<Stream> {
     let testStream = new Stream(channel, verbose);
@@ -35,7 +36,7 @@ export class Stream {
     return;
   }
 
-  detect(text: string) {
+  detect(text: string): Context<void> {
     return World.spawn(this.waitFor(text));
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,3 +1,4 @@
+import type { ChainableSubscribable } from '@effection/subscription'
 import { w3cwebsocket } from 'websocket';
 import { resource, Operation, spawn } from 'effection';
 import { on, once } from '@effection/events';
@@ -51,11 +52,11 @@ export class Client {
     return this.send<T>("mutation", source, false, variables).expect();
   }
 
-  liveQuery<T>(source: string, variables?: Variables) {
+  liveQuery<T>(source: string, variables?: Variables): ChainableSubscribable<T, unknown> {
     return this.send<T>("query", source, true, variables);
   }
 
-  subscription<T, TReturn>(source: string, variables?: Variables) {
+  subscription<T, TReturn>(source: string, variables?: Variables): ChainableSubscribable<T, TReturn> {
     return this.send<T, TReturn>("subscription", source, false, variables);
   }
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -1,3 +1,3 @@
 export class NoServerError extends Error {
-  get name() { return 'NoServerError' }
+  get name(): string { return 'NoServerError' }
 }

--- a/packages/client/test/client.test.ts
+++ b/packages/client/test/client.test.ts
@@ -49,7 +49,7 @@ describe('@bigtest/client', () => {
       });
 
       describe('when the server responds', () => {
-        let response: {};
+        let response: Response;
         beforeEach(async () => {
           await connection.send({
             done: true,

--- a/packages/client/test/helpers.ts
+++ b/packages/client/test/helpers.ts
@@ -49,7 +49,7 @@ export class TestConnection {
 
   constructor(private socket: Socket) {}
 
-  receive(): Promise<Message> {
+  receive(): Promise<Message | undefined> {
     return run(subscribe(this.incoming).first());
   }
 

--- a/packages/client/test/helpers.ts
+++ b/packages/client/test/helpers.ts
@@ -49,11 +49,11 @@ export class TestConnection {
 
   constructor(private socket: Socket) {}
 
-  receive() {
+  receive(): Promise<Message> {
     return run(subscribe(this.incoming).first());
   }
 
-  send(response: Response) {
+  send(response: Response): Promise<void> {
     return run(this.socket.send(response));
   }
 
@@ -74,7 +74,7 @@ export class TestServer {
     return server;
   }
 
-  async connection() {
+  async connection(): Promise<TestConnection> {
     let connection = await run(subscribe(this.connections).first());
     if (!connection) {
       throw new Error(`connection stream closed while still waiting`);

--- a/packages/effection-express/src/index.ts
+++ b/packages/effection-express/src/index.ts
@@ -55,8 +55,7 @@ export class Express {
 
   constructor(public raw: ews.Application) {}
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  *use(handler: OperationRequestHandler): Operation<{}> {
+  *use(handler: OperationRequestHandler): Operation<Record<string, never>> {
     return yield resource({}, (controls) => {
       this.raw.use((req, res) => {
         controls.spawn(function*() {
@@ -66,8 +65,7 @@ export class Express {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  *get(path: string, handler: OperationRequestHandler): Operation<{}> {
+  *get(path: string, handler: OperationRequestHandler): Operation<Record<string, never>> {
     return yield resource({}, (controls) => {
       this.raw.get(path, (req, res) => {
         controls.spawn(function*() {
@@ -77,8 +75,7 @@ export class Express {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  *ws(path: string, handler: WsOperationRequestHandler): Operation<{}> {
+  *ws(path: string, handler: WsOperationRequestHandler): Operation<Record<string, never>> {
     return yield resource({}, (controls) => {
       this.raw.ws(path, (socket, req) => {
         controls.spawn(function*(): Operation<void> {

--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -36,11 +36,11 @@ export class Mailbox<T = any> {
     });
   }
 
-  setMaxListeners(value: number) {
+  setMaxListeners(value: number): void {
     this.subscriptions.setMaxListeners(value);
   }
 
-  send(message: T) {
+  send(message: T): void {
     this.messages.add(message);
     setTimeout(() => this.subscriptions.emit('message', message), 0);
   }
@@ -68,7 +68,7 @@ export class Mailbox<T = any> {
     };
   }
 
-  *pipe(other: Mailbox<T>) {
+  *pipe(other: Mailbox<T>): Generator<Operation<unknown>> {
     let that = this; // eslint-disable-line @typescript-eslint/no-this-alias
     return yield spawn(function*(): Operation<unknown> {
       while(true) {

--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -68,7 +68,7 @@ export class Mailbox<T = any> {
     };
   }
 
-  *pipe(other: Mailbox<T>): Generator<Operation<unknown>> {
+  *pipe(other: Mailbox<T>): Operation<Context<void>> {
     let that = this; // eslint-disable-line @typescript-eslint/no-this-alias
     return yield spawn(function*(): Operation<unknown> {
       while(true) {

--- a/packages/effection/src/mailbox.ts
+++ b/packages/effection/src/mailbox.ts
@@ -1,4 +1,4 @@
-import { Operation, spawn, fork, resource } from 'effection';
+import { Operation, spawn, fork, resource, Context } from 'effection';
 import { EventEmitter } from 'events';
 
 import { compile } from './pattern';

--- a/packages/effection/src/pattern.ts
+++ b/packages/effection/src/pattern.ts
@@ -14,7 +14,7 @@ export function compile(pattern: unknown): (target: unknown) => boolean {
   };
 }
 
-export function any(type: unknown) {
+export function any(type: unknown): (value: unknown) => boolean {
   if(type === "array") {
     return function anyMatcher(value: unknown) {
       return Array.isArray(value);

--- a/packages/effection/test/helpers.ts
+++ b/packages/effection/test/helpers.ts
@@ -3,7 +3,7 @@ import { main, Context, Operation, Controls } from 'effection';
 type World<T = unknown> = Context<T> & Controls<T>;
 
 let World: World;
-export function spawn<T>(operation: Operation) {
+export function spawn<T>(operation: Operation): Context<T> {
   return World.spawn<T>(operation);
 }
 

--- a/packages/globals/src/index.ts
+++ b/packages/globals/src/index.ts
@@ -88,7 +88,7 @@ export const bigtestGlobals = {
     options().appUrl = value;
   },
 
-  reset() {
+  reset(): void {
     delete globalThis.__bigtest;
     delete globalThis.__bigtestManifest;
   }

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -27,7 +27,7 @@ const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "
  * @returns You will need to call the returned builder to create an interactor.
  */
 export function createInteractor<E extends Element>(interactorName: string): InteractorBuilder<E> {
-  return function<F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A> {
+  return function<F extends Filters<E> = Record<string, never>, A extends Actions<E> = Record<string, never>>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A> {
     let InteractorClass = class extends Interactor<E, F, A> {};
 
     for(let [actionName, action] of Object.entries(specification.actions || {})) {

--- a/packages/interactor/src/errors.ts
+++ b/packages/interactor/src/errors.ts
@@ -1,15 +1,15 @@
 export class NoSuchElementError extends Error {
-  get name() { return "NoSuchElementError" }
+  get name(): string { return "NoSuchElementError" }
 }
 
 export class AmbiguousElementError extends Error {
-  get name() { return "AmbiguousElementError" }
+  get name(): string { return "AmbiguousElementError" }
 }
 
 export class NotAbsentError extends Error {
-  get name() { return "NotAbsentError" }
+  get name(): string { return "NotAbsentError" }
 }
 
 export class FilterNotMatchingError extends Error {
-  get name() { return "FilterNotMatchingError" }
+  get name(): string { return "FilterNotMatchingError" }
 }

--- a/packages/interactor/src/fill-in.ts
+++ b/packages/interactor/src/fill-in.ts
@@ -60,7 +60,7 @@ function setValue(element: TextFieldElement, value: string): void {
  * @param element The element to fill in text in
  * @param value The text value to fill in
  */
-export function fillIn(element: TextFieldElement, value: string) {
+export function fillIn(element: TextFieldElement, value: string): void {
   let originalValue = element.value;
 
   element.focus();

--- a/packages/interactor/src/format-table.ts
+++ b/packages/interactor/src/format-table.ts
@@ -13,7 +13,7 @@ function formatValue(value: string, width: number) {
   }
 }
 
-export function formatTable(options: TableOptions) {
+export function formatTable(options: TableOptions): string {
   let columnWidths = options.headers.map((h, index) => {
     return Math.min(MAX_COLUMN_WIDTH, Math.max(h.length, ...options.rows.map((r) => r[index].length)));
   });

--- a/packages/interactor/src/perform.ts
+++ b/packages/interactor/src/perform.ts
@@ -1,9 +1,8 @@
-import { Interaction } from './interaction';
 import { Interactor } from "./interactor";
 import { Filters, Actions } from "./specification";
 
 export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends unknown[]>(fn: (element: E, ...args: T) => void) {
-  return async (interactor: Interactor<E, F, A>, ...args: T): Promise<Interaction<void>> => {
+  return async (interactor: Interactor<E, F, A>, ...args: T): Promise<void> => {
     return await interactor.perform(element => {
       fn(element, ...args);
     });

--- a/packages/interactor/src/perform.ts
+++ b/packages/interactor/src/perform.ts
@@ -1,8 +1,9 @@
+import { Interaction } from './interaction';
 import { Interactor } from "./interactor";
 import { Filters, Actions } from "./specification";
 
 export function perform<E extends Element, F extends Filters<E>, A extends Actions<E>, T extends unknown[]>(fn: (element: E, ...args: T) => void) {
-  return async (interactor: Interactor<E, F, A>, ...args: T) => {
+  return async (interactor: Interactor<E, F, A>, ...args: T): Promise<Interaction<void>> => {
     return await interactor.perform(element => {
       fn(element, ...args);
     });

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -46,7 +46,7 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
    * returned from the locator function.
    */
   locator?: LocatorFn<E>;
-}
+} 
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
   [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, Record<string, never>, Record<string, never>>, ...args: infer TArgs) => Promise<infer TReturn>)
@@ -128,5 +128,7 @@ export interface InteractorBuilder<E extends Element> {
    * @typeParam F the filters of this interactor, this is usually inferred from the specification
    * @typeParam A the actions of this interactor, this is usually inferred from the specification
    */
+  // <F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A>;
+  // eslint-disable-next-line @typescript-eslint/ban-types
   <F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A>;
 }

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -128,7 +128,6 @@ export interface InteractorBuilder<E extends Element> {
    * @typeParam F the filters of this interactor, this is usually inferred from the specification
    * @typeParam A the actions of this interactor, this is usually inferred from the specification
    */
-  // <F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A>;
   // eslint-disable-next-line @typescript-eslint/ban-types
   <F extends Filters<E> = {}, A extends Actions<E> = {}>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A>;
 }

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -3,7 +3,7 @@
 import { Interactor } from './interactor';
 import { Interaction } from './interaction';
 
-export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, {}, {}>, ...args: any[]) => Promise<unknown>;
+export type ActionFn<E extends Element> = (interactor: InteractorInstance<E, Record<string, never>, Record<string, never>>, ...args: any[]) => Promise<unknown>;
 
 export type FilterFn<T, E extends Element> = (element: E) => T;
 
@@ -49,7 +49,7 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
-  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, {}, {}>, ...args: infer TArgs) => Promise<infer TReturn>)
+  [P in keyof A]: A[P] extends ((interactor: InteractorInstance<E, Record<string, never>, Record<string, never>>, ...args: infer TArgs) => Promise<infer TReturn>)
     ? ((...args: TArgs) => Interaction<TReturn>)
     : never;
 }

--- a/packages/interactor/test/helpers.ts
+++ b/packages/interactor/test/helpers.ts
@@ -1,10 +1,10 @@
 import { beforeEach } from 'mocha';
 import { bigtestGlobals } from '@bigtest/globals';
-import { JSDOM } from 'jsdom';
+import { DOMWindow, JSDOM } from 'jsdom';
 
 let jsdom: JSDOM;
 
-export function dom(html: string) {
+export function dom(html: string): DOMWindow {
   jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
   bigtestGlobals.document = jsdom.window.document;
   return jsdom.window;

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -9,14 +9,14 @@ const HIDDEN_LOGS = {
 
 const { debug, log, warn, error } = console;
 
-export function resetLogLevel() {
+export function resetLogLevel(): void {
   console.debug = debug
   console.log = log
   console.warn = warn
   console.error = error
 }
 
-export function setLogLevel(level: Levels) {
+export function setLogLevel(level: Levels): void {
   resetLogLevel();
   HIDDEN_LOGS[level].forEach((level) => {
     console[level as Levels] = function() {

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -3,6 +3,8 @@ import { DriverSpec } from '@bigtest/driver';
 import path from 'path';
 import { existsSync } from 'fs';
 import fs from 'fs';
+import type { CompilerOptions } from 'typescript';
+import { ScriptTarget } from 'typescript';
 
 const { readFile } = fs.promises;
 
@@ -131,11 +133,11 @@ export function defaultConfig(configFilePath: string): ProjectOptions {
   }
 };
 
-export function defaultTSConfig() {
+export function defaultTSConfig(): {compilerOptions: Pick<CompilerOptions, 'skipLibCheck' | 'target' | 'lib'>} {
   return {
     compilerOptions: {
       skipLibCheck: true,
-      target: "es6",
+      target: "es6" as unknown as ScriptTarget,
       lib: ["esnext", "dom"]
     }
   }

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,4 @@
-import { fork } from 'effection';
+import { Context, fork, Operation } from 'effection';
 import { OrchestratorState } from './orchestrator/state';
 import { Slice } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';
@@ -8,7 +8,7 @@ export interface LoggerOptions {
   out: <A extends unknown[]>(...args: A) => void;
 }
 
-export function* createLogger({ atom, out }: LoggerOptions) {
+export function* createLogger({ atom, out }: LoggerOptions): Generator<Operation<Context<undefined>>> {
   yield fork(subscribe(atom.slice('bundler')).forEach(function* (event) {
     if(event.type === 'ERRORED'){
       out("[manifest builder] build error:");

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -8,7 +8,7 @@ export interface LoggerOptions {
   out: <A extends unknown[]>(...args: A) => void;
 }
 
-export function* createLogger({ atom, out }: LoggerOptions): Generator<Operation<Context<undefined>>> {
+export function* createLogger({ atom, out }: LoggerOptions): Operation<void> {
   yield fork(subscribe(atom.slice('bundler')).forEach(function* (event) {
     if(event.type === 'ERRORED'){
       out("[manifest builder] build error:");

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -1,4 +1,4 @@
-import { Context, fork, Operation } from 'effection';
+import { fork, Operation } from 'effection';
 import { OrchestratorState } from './orchestrator/state';
 import { Slice } from '@bigtest/atom';
 import { subscribe } from '@effection/subscription';

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -1,4 +1,4 @@
-import { createAtom } from "@bigtest/atom";
+import { createAtom, Slice } from "@bigtest/atom";
 import { OrchestratorState } from "./state";
 import { ProjectOptions } from '@bigtest/project';
 import path = require('path');
@@ -8,7 +8,7 @@ import { AgentServerConfig } from '@bigtest/agent';
 // But until then we can just pick the bits we need.
 export type OrchestratorAtomOptions = Pick<ProjectOptions, 'app' |'watchTestFiles' | 'cacheDir' | 'testFiles' | 'proxy'>
 
-export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
+export const createOrchestratorAtom = (project: OrchestratorAtomOptions): Slice<OrchestratorState> => {
   let manifestSrcDir = path.resolve(project.cacheDir, 'manifest/src');
   let manifestSrcPath = path.resolve(manifestSrcDir, 'manifest.js');
   let agentServerConfig = new AgentServerConfig(project.proxy);
@@ -52,20 +52,17 @@ export const createOrchestratorAtom = (project: OrchestratorAtomOptions) => {
     connectionService: {
       status: {
         type: 'unstarted',
-      },
-      options: {}
+      }
     },
     commandService: {
       status: {
         type: 'unstarted',
-      },
-      options: {}
+      }
     },
     manifestServer: {
       status: {
         type: 'unstarted',
-      },
-      options: {}
+      }
     },
     agents: {},
     testRuns: {},

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -53,10 +53,8 @@ export type ServiceStatus = {
   type: string;
 };
 
-export type ServiceState<S extends ServiceStatus, O> = {
-  options: O;
-  status: S;
-};
+export type ServiceState<S extends ServiceStatus, O = never> =
+  [O] extends [never] ? { status: S } : { status: S; options: O }
 
 export type Service<S extends ServiceStatus, O> = {
   (state: Slice<ServiceState<S, O>>): Operation<void>;
@@ -139,9 +137,9 @@ export type OrchestratorState = {
   bundler: BundlerState;
   testRuns: Record<string, TestRunState>;
   manifestGenerator: ServiceState<ManifestGeneratorStatus, ManifestGeneratorOptions>;
-  manifestServer: ServiceState<ManifestServerStatus, {}>;
+  manifestServer: ServiceState<ManifestServerStatus>;
   appService: ServiceState<AppServiceStatus, AppOptions>;
   proxyService: ServiceState<ProxyStatus, ProxyOptions>;
-  connectionService: ServiceState<ConnectionStatus, {}>;
-  commandService: ServiceState<CommandStatus, {}>;
+  connectionService: ServiceState<ConnectionStatus>;
+  commandService: ServiceState<CommandStatus>;
 }

--- a/packages/server/src/result-aggregator/aggregator.ts
+++ b/packages/server/src/result-aggregator/aggregator.ts
@@ -35,7 +35,7 @@ export abstract class Aggregator<T extends {status: unknown }, O extends Aggrega
     throw new Error("override me in subclass");
   }
 
-  *run(): Generator<Operation<ResultStatus>> {
+  *run(): Operation<ResultStatus> {
     try {
       return yield this.perform();
     } finally {

--- a/packages/server/src/result-aggregator/aggregator.ts
+++ b/packages/server/src/result-aggregator/aggregator.ts
@@ -27,7 +27,7 @@ export abstract class Aggregator<T extends {status: unknown }, O extends Aggrega
     return this.options.events;
   }
 
-  get statusSlice() {
+  get statusSlice(): Slice<T["status"]> {
     return this.slice.slice('status');
   }
 
@@ -35,7 +35,7 @@ export abstract class Aggregator<T extends {status: unknown }, O extends Aggrega
     throw new Error("override me in subclass");
   }
 
-  *run() {
+  *run(): Generator<Operation<ResultStatus>> {
     try {
       return yield this.perform();
     } finally {

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -52,7 +52,7 @@ describe('command server', () => {
   });
 
   describe('running the entire suite', () => {
-    let result: GraphQLPayload<{run: {}}>;
+    let result: GraphQLPayload<{run: unknown}>;
     beforeEach(async () => {
       result = await mutation('run');
     });

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -33,7 +33,7 @@ const TestProjectOptions: OrchestratorAtomOptions = {
   }
 }
 
-export const getTestProjectOptions = (overrides: DeepPartial<OrchestratorAtomOptions> = {}) =>
+export const getTestProjectOptions = (overrides: DeepPartial<OrchestratorAtomOptions> = {}): OrchestratorAtomOptions =>
   merge(TestProjectOptions, overrides) as OrchestratorAtomOptions;
 
 export const actions = {
@@ -43,7 +43,7 @@ export const actions = {
     return currentWorld.fork(operation);
   },
 
-  receive(mailbox: Mailbox, pattern: unknown) {
+  receive(mailbox: Mailbox, pattern: unknown): Context {
     return actions.fork(mailbox.receive(pattern));
   },
 
@@ -51,7 +51,7 @@ export const actions = {
     return actions.fork(currentWorld.fetch(resource, init));
   },
 
-  async createAgent(agentId: string) {
+  async createAgent(agentId: string): Promise<Agent> {
     // the types are broken in the 'websocket' package.... the `w3cwebsocket` class
     // _is_ in fact an EventTarget, but it is not declared as such. So we have
     // to dynamically cast it.
@@ -65,7 +65,7 @@ export const actions = {
     }));
   },
 
-  updateApp(appOptions: AppOptions) {
+  updateApp(appOptions: AppOptions): void {
     actions.atom
       .slice("appService", "options")
       .update(() => appOptions);
@@ -75,7 +75,7 @@ export const actions = {
       .update(() => appOptions);
   },
 
-  async startOrchestrator() {
+  async startOrchestrator(): Promise<any> {
     if(!orchestratorPromise) {
       let delegate = new Mailbox();
 

--- a/packages/server/test/helpers/world.ts
+++ b/packages/server/test/helpers/world.ts
@@ -8,11 +8,11 @@ export class World {
     this.execution = main(function*() { yield; }) as Context & Controls;
   }
 
-  destroy() {
+  destroy(): void {
     this.execution.halt();
   }
 
-  ensure(hook: () => void) {
+  ensure(hook: () => void): void {
     this.execution.ensure(hook);
   }
 

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -8,7 +8,7 @@ import { TestImplementation, Context, Step, Assertion } from './interfaces';
  * @param description The description to apply to the test, a human readable text which describes the test's purpose.
  * @typeParam C test steps and assertions receive a context as an argument, and can extend this context through their return values, the context usually starts out empty.
  */
-export function test<C extends Context = {}>(description: string): TestBuilder<C> {
+export function test<C extends Context = Record<string, unknown>>(description: string): TestBuilder<C> {
   return new TestBuilder<C>({
     description,
     steps: [],

--- a/packages/webdriver/src/driver.ts
+++ b/packages/webdriver/src/driver.ts
@@ -4,7 +4,7 @@ import { Local } from './local';
 import { Remote } from './remote';
 import { Options } from './web-driver';
 
-export const create: DriverFactory<Options, {}> = ({options}) => {
+export const create: DriverFactory<Options, unknown> = ({options}) => {
   if (options.type === 'remote') {
     return Remote(options);
   } else {

--- a/packages/webdriver/src/web-driver.ts
+++ b/packages/webdriver/src/web-driver.ts
@@ -9,11 +9,11 @@ export class WebDriver implements Driver<WDSession> {
 
   constructor(public serverURL: string) { }
 
-  get description() {
+  get description(): string {
     return `WebDriver<${this.serverURL}/session/${this.session.sessionId}>`;
   }
 
-  get data() { return this.session; }
+  get data(): WDSession { return this.session; }
 
   connect(agentURL: string): Operation<void> {
     return this.navigateTo(agentURL);


### PR DESCRIPTION
Enables the following from `@typescript-eslint/recommended`:

- `@typescript-eslint/ban-types` this mainly affects the duplicitous `{}` type that really is a top type for all non-null types.
- `@typescript-eslint/explicit-module-boundary-types`

Enabling these rules will make things a bit stricter and a bit better.