### PR TITLE
skip tests on documentation only edits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ name: Test
 on:
   pull_request:
     branches:
-      - "v[0-9]+"
+      - 'v[0-9]+'
     paths-ignore:
-      - "website/**"
-      - "**.md"
+      - 'website/**'
+      - '**.md'
 
 jobs:
   prepack:
@@ -47,21 +47,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         # keeping platform as a single item so test-*.yml files can be identical except for this value
-        package:
-          [
-            agent,
-            cli,
-            effection,
-            logging,
-            bundler,
-            project,
-            server,
-            suite,
-            interactor,
-            todomvc,
-            atom,
-            webdriver,
-          ]
+        package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
     steps:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
@@ -109,4 +95,4 @@ jobs:
         with:
           working-directory: packages/interactor/
           start: yarn bigtest-todomvc 3000
-          wait-on: "http://localhost:3000"
+          wait-on: 'http://localhost:3000'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,10 @@ name: Test
 on:
   pull_request:
     branches:
-      - 'v[0-9]+'
+      - "v[0-9]+"
+    paths-ignore:
+      - "website/**"
+      - "**.md"
 
 jobs:
   prepack:
@@ -44,7 +47,21 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         # keeping platform as a single item so test-*.yml files can be identical except for this value
-        package: [agent, cli, effection, logging, bundler, project, server, suite, interactor, todomvc, atom, webdriver]
+        package:
+          [
+            agent,
+            cli,
+            effection,
+            logging,
+            bundler,
+            project,
+            server,
+            suite,
+            interactor,
+            todomvc,
+            atom,
+            webdriver,
+          ]
     steps:
       - uses: actions/checkout@v2
       - name: Get yarn cache directory path
@@ -92,4 +109,4 @@ jobs:
         with:
           working-directory: packages/interactor/
           start: yarn bigtest-todomvc 3000
-          wait-on: 'http://localhost:3000' 
+          wait-on: "http://localhost:3000"


### PR DESCRIPTION
This should "scope" test running to when there is a real value in running them, ie when the code changes. If the documentation or website is the only change, there isn't a real need to run the tests.