### PR TITLE
Add `extend` method to builder API

### DIFF
--- a/.changeset/shy-frogs-carry.md
+++ b/.changeset/shy-frogs-carry.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Add `extend` method to interactor builder API, to downcast to a subtype of the element

--- a/packages/interactor/src/builder.ts
+++ b/packages/interactor/src/builder.ts
@@ -16,5 +16,8 @@ export function makeBuilder<T, E extends Element, FP extends FilterParams<any, a
     actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>> => {
       return createConstructor(name, { ...specification, actions: Object.assign({}, specification.actions, actions) });
     },
+    extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, AM> => {
+      return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, AM>;
+    },
   });
 }

--- a/packages/interactor/src/builder.ts
+++ b/packages/interactor/src/builder.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification, InteractorConstructor, FilterParams, ActionMethods } from './specification';
 import { createConstructor } from './constructor';
+import { MergeObjects } from './merge-objects';
 
 export function makeBuilder<T, E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(base: T, name: string, specification: InteractorSpecification<E, any, any>): T & InteractorBuilder<E, FP, AM> {
   return Object.assign(base, {
@@ -10,10 +11,10 @@ export function makeBuilder<T, E extends Element, FP extends FilterParams<any, a
     locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, AM> => {
       return createConstructor(name, { ...specification, locator: value });
     },
-    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM> => {
+    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM> => {
       return createConstructor(name, { ...specification, filters: { ...specification.filters, ...filters } });
     },
-    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>> => {
+    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>> => {
       return createConstructor(name, { ...specification, actions: Object.assign({}, specification.actions, actions) });
     },
     extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, AM> => {

--- a/packages/interactor/src/builder.ts
+++ b/packages/interactor/src/builder.ts
@@ -1,18 +1,19 @@
-import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification, InteractorConstructor } from './specification';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification, InteractorConstructor, FilterParams, ActionMethods } from './specification';
 import { createConstructor } from './constructor';
 
-export function makeBuilder<T, E extends Element, F extends Filters<E>, A extends Actions<E>>(base: T, name: string, specification: InteractorSpecification<E, F, A>): T & InteractorBuilder<E, F, A> {
+export function makeBuilder<T, E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(base: T, name: string, specification: InteractorSpecification<E, any, any>): T & InteractorBuilder<E, FP, AM> {
   return Object.assign(base, {
-    selector: (value: string): InteractorConstructor<E, F, A> => {
+    selector: (value: string): InteractorConstructor<E, FP, AM> => {
       return createConstructor(name, { ...specification, selector: value });
     },
-    locator: (value: LocatorFn<E>): InteractorConstructor<E, F, A> => {
+    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, AM> => {
       return createConstructor(name, { ...specification, locator: value });
     },
-    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, F & FR, A> => {
+    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM> => {
       return createConstructor(name, { ...specification, filters: { ...specification.filters, ...filters } });
     },
-    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, F, A & AR> => {
+    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>> => {
       return createConstructor(name, { ...specification, actions: Object.assign({}, specification.actions, actions) });
     },
   });

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -193,10 +193,10 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
   return interactor as Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>;
 }
 
-export function createConstructor<E extends Element, F extends Filters<E>, A extends Actions<E>>(
+export function createConstructor<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(
   name: string,
-  specification: InteractorSpecification<E, F, A>,
-): InteractorConstructor<E, F, A> {
+  specification: InteractorSpecification<E, any, any>,
+): InteractorConstructor<E, FP, AM> {
   function initInteractor(...args: any[]) {
     let locator, filter;
     if(typeof(args[0]) === 'string') {
@@ -208,5 +208,5 @@ export function createConstructor<E extends Element, F extends Filters<E>, A ext
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] });
   }
 
-  return makeBuilder(initInteractor, name, specification);
+  return makeBuilder(initInteractor, name, specification) as unknown as InteractorConstructor<E, FP, AM>;
 }

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,4 +1,4 @@
-import { EmptyObject, InteractorSpecificationBuilder, InteractorSpecification, InteractorConstructor, Filters, Actions } from './specification';
+import { EmptyObject, InteractorSpecificationBuilder, InteractorSpecification, InteractorConstructor, Filters, Actions, FilterParams, ActionMethods } from './specification';
 import { createConstructor } from './constructor';
 import { makeBuilder } from './builder';
 
@@ -21,7 +21,7 @@ import { makeBuilder } from './builder';
  * @returns You will need to call the returned builder to create an interactor.
  */
 export function createInteractor<E extends Element>(name: string): InteractorSpecificationBuilder<E> {
-  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A> {
+  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>> {
     return createConstructor(name, specification);
   }
   return makeBuilder(cons, name, {

--- a/packages/interactor/src/merge-objects.ts
+++ b/packages/interactor/src/merge-objects.ts
@@ -1,0 +1,2 @@
+// A utility type for merging two object types
+export type MergeObjects<A, B> = B & Omit<A, keyof B>;

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -3,6 +3,7 @@
 import { Filter } from './filter';
 import { Locator } from './locator';
 import { Interaction, ReadonlyInteraction } from './interaction';
+import { MergeObjects } from './merge-objects';
 
 export type EmptyObject = Record<never, never>;
 
@@ -188,8 +189,8 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
 export interface InteractorBuilder<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> {
   selector(value: string): InteractorConstructor<E, FP, AM>;
   locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
-  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM>;
-  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>>;
+  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM>;
+  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>>;
   extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, AM>;
 }
 

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -185,11 +185,11 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
     never;
 }
 
-export interface InteractorBuilder<E extends Element, F extends Filters<E>, A extends Actions<E>> {
-  selector(value: string): InteractorConstructor<E, F, A>;
-  locator(value: LocatorFn<E>): InteractorConstructor<E, F, A>;
-  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, F & FR, A>;
-  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, F, A & AR>;
+export interface InteractorBuilder<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> {
+  selector(value: string): InteractorConstructor<E, FP, AM>;
+  locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
+  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM>;
+  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>>;
 }
 
 /**
@@ -204,7 +204,7 @@ export interface InteractorBuilder<E extends Element, F extends Filters<E>, A ex
  * @typeParam F the filters of this interactor, this is usually inferred from the specification
  * @typeParam A the actions of this interactor, this is usually inferred from the specification
  */
-export interface InteractorConstructor<E extends Element, F extends Filters<E>, A extends Actions<E>> extends InteractorBuilder<E, F, A> {
+export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> extends InteractorBuilder<E, FP, AM> {
   /**
    * The constructor can be called with filters only:
    *
@@ -220,7 +220,7 @@ export interface InteractorConstructor<E extends Element, F extends Filters<E>, 
    *
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (filters?: FilterParams<E, F>): Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>;
+  (filters?: FP): Interactor<E, FP> & AM;
   /**
    * The constructor can be called with a locator:
    *
@@ -237,7 +237,7 @@ export interface InteractorConstructor<E extends Element, F extends Filters<E>, 
    * @param value The locator value, which should match the value of applying the locator function defined in the {@link InteractorSpecification} to the element.
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (value: string, filters?: FilterParams<E, F>): Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>;
+  (value: string, filters?: FP): Interactor<E, FP> & AM;
 }
 
 /**
@@ -256,7 +256,7 @@ export interface InteractorSpecificationBuilder<E extends Element> extends Inter
    * @typeParam A the actions of this interactor, this is usually inferred from the specification
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  <F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, F, A>;
+  <F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>>;
 }
 
 export type InteractorOptions<E extends Element, F extends Filters<E>, A extends Actions<E>> = {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -190,6 +190,7 @@ export interface InteractorBuilder<E extends Element, FP extends FilterParams<an
   locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM>;
   actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>>;
+  extend<ER extends Element = E>(name: string): InteractorConstructor<ER, FP, AM>;
 }
 
 /**

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -190,7 +190,7 @@ export interface InteractorBuilder<E extends Element, FP extends FilterParams<an
   locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, FP & FilterParams<E, FR>, AM>;
   actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, AM & ActionMethods<E, AR>>;
-  extend<ER extends Element = E>(name: string): InteractorConstructor<ER, FP, AM>;
+  extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, AM>;
 }
 
 /**

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+import { bigtestGlobals } from '@bigtest/globals';
+
+import { createInteractor, perform } from '../src/index';
+
+const HTML = createInteractor<HTMLElement>('element')
+  .filters({
+    title: (element) => element.title,
+  })
+  .actions({
+    click: perform(element => { element.click() }),
+  });
+
+const Link = HTML.extend<HTMLLinkElement>('link')
+  .selector('a')
+  .filters({
+    href: (element) => element.href,
+  })
+  .actions({
+    setHref: perform((element, value: string) => { element.href = value })
+  })
+
+const Header = createInteractor('header')
+  .selector('h1,h2,h3,h4,h5,h6')
+
+describe('@bigtest/interactor', () => {
+  describe('.extend', () => {
+    it('can use filters from base interactor', async () => {
+      dom(`
+        <p><a href="/foobar" title="Foo">Foo Bar</a></p>
+      `);
+
+      await expect(Link('Foo Bar').has({ title: "Foo" })).resolves.toBeUndefined();
+      await expect(Link('Foo Bar').has({ title: "Quox" })).rejects.toHaveProperty('message', [
+        'link "Foo Bar" does not match filters:', '',
+        '┃ title: "Quox" ┃',
+        '┣━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "Foo"       ┃',
+      ].join('\n'));
+    });
+
+    it('can use filters from extended interactor', async () => {
+      dom(`
+        <p><a href="/foobar" title="Foo">Foo Bar</a></p>
+      `);
+
+      await expect(Link('Foo Bar').has({ href: "/foobar" })).resolves.toBeUndefined();
+      await expect(Link('Foo Bar').has({ href: "/quox" })).rejects.toHaveProperty('message', [
+        'link "Foo Bar" does not match filters:', '',
+        '┃ href: "/quox" ┃',
+        '┣━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "/foobar"   ┃',
+      ].join('\n'));
+    });
+
+    it('can use actions from base interactor', async () => {
+      dom(`
+        <a id="foo" href="/foobar">Foo Bar</a>
+        <div id="target"></div>
+        <script>
+          foo.onclick = () => {
+            target.innerHTML = '<h1>Hello!</h1>';
+          }
+        </script>
+      `);
+
+      await Link('Foo Bar').click();
+      await Header('Hello!').exists();
+    });
+
+    it('can use actions from extended interactor', async () => {
+      dom(`
+        <a id="foo" href="/foobar">Foo Bar</a>
+      `);
+
+      await Link('Foo Bar').setHref('/monkey');
+      await Link({ href: '/monkey' }).exists();
+    });
+  });
+});

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
-import { bigtestGlobals } from '@bigtest/globals';
 
 import { createInteractor, perform } from '../src/index';
 
@@ -20,6 +19,19 @@ const Link = HTML.extend<HTMLLinkElement>('link')
   })
   .actions({
     setHref: perform((element, value: string) => { element.href = value })
+  })
+
+const Thing = HTML.extend<HTMLLinkElement>('div')
+  .selector('div')
+  .filters({
+    title: (element) => parseInt(element.dataset.title || '0'),
+  })
+  .actions({
+    click(interactor, value: number) {
+      return interactor.perform((element) => {
+        element.dataset.title = value.toString();
+      });
+    }
   })
 
 const Header = createInteractor('header')
@@ -77,6 +89,15 @@ describe('@bigtest/interactor', () => {
 
       await Link('Foo Bar').setHref('/monkey');
       await Link({ href: '/monkey' }).exists();
+    });
+
+    it('can use overridden filters and actions', async () => {
+      dom(`
+        <div></div>
+      `);
+
+      await Thing().click(4);
+      await Thing().has({ title: 4 });
     });
   });
 });

--- a/packages/interactor/types/extend.ts
+++ b/packages/interactor/types/extend.ts
@@ -1,10 +1,12 @@
 import { createInteractor } from '../src/index';
 
-const HTML = createInteractor<HTMLElement>('html')({
-  filters: {
+const HTML = createInteractor<HTMLElement>('html')
+  .filters({
     id: (element) => element.id,
-  }
-});
+  })
+  .actions({
+    click: (interactor) => interactor.perform((element) => element.click()),
+  });
 
 // cannot pass supertype
 // $ExpectError
@@ -32,4 +34,38 @@ HTML.extend<HTMLLinkElement>('link')
       element;
       return element.href;
     }
+  })
+  .actions({
+    setHref: (interactor, value: string) => interactor.perform((element) => {
+      // $ExpectType HTMLLinkElement
+      element;
+      element.href = value;
+    })
   });
+
+// overriding filters and actions
+const Thing = HTML.extend('thing')
+  .filters({
+    id: (element) => 4
+  })
+  .actions({
+    click: async (interactor, value: number) => {
+      interactor.perform((element) => {
+        element.textContent = `Value: ${value}`;
+      });
+    }
+  })
+
+// uses overridden type for filter
+Thing('thing', { id: 4 });
+
+// cannot use original type for filter
+// $ExpectError
+Thing('thing', { id: 'thing' });
+
+// uses overridden type for action
+Thing('thing').click(5);
+
+// cannot use original type for action
+// $ExpectError
+Thing('thing').click();

--- a/packages/interactor/types/extend.ts
+++ b/packages/interactor/types/extend.ts
@@ -1,0 +1,35 @@
+import { createInteractor } from '../src/index';
+
+const HTML = createInteractor<HTMLElement>('html')({
+  filters: {
+    id: (element) => element.id,
+  }
+});
+
+// cannot pass supertype
+// $ExpectError
+HTML.extend<Element>('foo');
+
+// cannot pass other random type
+// $ExpectError
+HTML.extend<number>('div')
+
+// without type parameter
+HTML.extend('div')
+  .filters({
+    id: (element) => {
+      // $ExpectType HTMLElement
+      element;
+      return element.id;
+    }
+  });
+
+// with type parameter
+HTML.extend<HTMLLinkElement>('link')
+  .filters({
+    href: (element) => {
+      // $ExpectType HTMLLinkElement
+      element;
+      return element.href;
+    }
+  });

--- a/packages/interactor/types/merge-objects.ts
+++ b/packages/interactor/types/merge-objects.ts
@@ -1,0 +1,47 @@
+import { MergeObjects } from '../src/merge-objects';
+
+type Empty = Record<never, never>;
+
+type A = {
+  a: string;
+  b?: string;
+}
+
+type B = {
+  a: number;
+  b?: number;
+}
+
+type C = MergeObjects<A, B>;
+type D = MergeObjects<B, A>;
+
+let c: C = { a: 1, b: 2 };
+let d: D = { a: "thing", b: "blah" };
+
+// can assign a number
+c.a = 4;
+c.b = 4;
+
+// cannot assign a string
+// $ExpectError
+c.a = "thing";
+// $ExpectError
+c.b = "thing";
+
+// can assign a string
+d.a = "foo";
+d.b = "foo";
+
+// cannot assign a number
+// $ExpectError
+d.a = 1;
+// $ExpectError
+d.b = 2;
+
+let e: MergeObjects<Empty, A> = { a: "foo", b: "bar" };
+
+e.a = "blah";
+
+let f: MergeObjects<MergeObjects<Empty, A>, B> = { a: 123, b: 12 };
+
+f.a = 3


### PR DESCRIPTION
This makes it possible to both rename the interactor, and crucially to use a subtype of the element. To make this work we need to "forget" the element type of those actions and filters which have already been defined, otherwise we run into thorny variance issues. The type parameter `E` of `InteractorBuilder` must be *covariant* for this to work.