### PR TITLE
Add `changeOrigin` flag to application proxy server

### DIFF
--- a/.changeset/good-bobcats-share.md
+++ b/.changeset/good-bobcats-share.md
@@ -1,5 +1,6 @@
 ---
 "@bigtest/server": patch
+"bigtest": patch
 ---
 
 Add `changeOrigin` flag to proxy server so that app urls served over SSL will work properly

--- a/.changeset/good-bobcats-share.md
+++ b/.changeset/good-bobcats-share.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+Add `changeOrigin` flag to proxy server so that app urls served over SSL will work properly

--- a/packages/server/src/proxy.ts
+++ b/packages/server/src/proxy.ts
@@ -95,7 +95,7 @@ export const startProxyServer = (serviceSlice: Slice<ServiceState<ProxyStatus, P
 
   proxyStatus.set({ type: 'starting' });
 
-  let proxyServer = proxy.createProxyServer({ target: target, selfHandleResponse: true });
+  let proxyServer = proxy.createProxyServer({ target: target, selfHandleResponse: true, changeOrigin: true });
 
   let server = express();
 


### PR DESCRIPTION
> resolves https://github.com/thefrontside/bigtest/issues/781

Motivation
-----------

Whenever we fetch from an https proxy, by default the origin of the request to the target will be made with the host of the proxy server. However, when verifying a public url over TLS it will see that the certificate does not have `localhost` as one of its altnames and so will fail. In other words a cert for `x.com` will validate content from neither `y.com` nor `z.com` and certainly not `localhost`. It will only work for  `x.com`.


Approach
----------

This sets the `changeOrigin` flag on the proxy server which causses the outgoing requests from the proxy server [to have the same origin as the target][1]. Iin the case above, would cause the proxy request to `x.com` to have that origin as well, so that TLS validation succeeds.

It's difficult to say what other impact this change will have, which is the only thing that worries me.

[1]: https://github.com/http-party/node-http-proxy/blob/9b96cd725127a024dabebec6c7ea8c807272223d/test/lib-http-proxy-common-test.js#L291-L315