### PR TITLE
Add matchers to interactors

### DIFF
--- a/.changeset/wicked-moose-tickle.md
+++ b/.changeset/wicked-moose-tickle.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Add matchers to interactors, for more flexible matching

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -12,6 +12,7 @@ import { FilterNotMatchingError } from './errors';
 import { interaction, check, Interaction, ReadonlyInteraction } from './interaction';
 import { Match } from './match';
 import { NoSuchElementError, NotAbsentError, AmbiguousElementError } from './errors';
+import { isMatcher } from './matcher';
 
 const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
 const defaultSelector = 'div';
@@ -199,7 +200,7 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
 ): InteractorConstructor<E, FP, AM> {
   function initInteractor(...args: any[]) {
     let locator, filter;
-    if(typeof(args[0]) === 'string') {
+    if(typeof(args[0]) === 'string' || isMatcher(args[0])) {
       locator = new Locator(specification.locator || defaultLocator, args[0]);
       filter = new Filter(specification, args[1] || {});
     } else {

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -1,6 +1,15 @@
 export type LocatorFn<E extends Element> = (element: E) => string;
 import { Filters, FilterFn, FilterObject, FilterParams, InteractorSpecification } from './specification';
 import { noCase } from 'change-case';
+import { isMatcher, MaybeMatcher } from './matcher';
+
+function formatValue<T>(value: MaybeMatcher<T>): string {
+  if(isMatcher(value)) {
+    return value.format();
+  } else {
+    return JSON.stringify(value);
+  }
+}
 
 export class Filter<E extends Element, F extends Filters<E>> {
   constructor(
@@ -22,7 +31,7 @@ export class Filter<E extends Element, F extends Filters<E>> {
             return `which is not ${noCase(key)}`;
           }
         } else {
-          return `with ${noCase(key)} ${JSON.stringify(value)}`
+          return `with ${noCase(key)} ${formatValue(value)}`
         }
       }).join(' and ');
     }
@@ -40,6 +49,6 @@ export class Filter<E extends Element, F extends Filters<E>> {
   }
 
   asTableHeader(): string[] {
-    return Object.entries(this.all).map(([key, value]) => `${key}: ${JSON.stringify(value)}`);
+    return Object.entries(this.all).map(([key, value]) => `${key}: ${formatValue(value)}`);
   }
 }

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -1,15 +1,7 @@
 export type LocatorFn<E extends Element> = (element: E) => string;
 import { Filters, FilterFn, FilterObject, FilterParams, InteractorSpecification } from './specification';
 import { noCase } from 'change-case';
-import { isMatcher, MaybeMatcher } from './matcher';
-
-function formatValue<T>(value: MaybeMatcher<T>): string {
-  if(isMatcher(value)) {
-    return value.format();
-  } else {
-    return JSON.stringify(value);
-  }
-}
+import { formatMatcher } from './matcher';
 
 export class Filter<E extends Element, F extends Filters<E>> {
   constructor(
@@ -31,7 +23,7 @@ export class Filter<E extends Element, F extends Filters<E>> {
             return `which is not ${noCase(key)}`;
           }
         } else {
-          return `with ${noCase(key)} ${formatValue(value)}`
+          return `with ${noCase(key)} ${formatMatcher(value)}`
         }
       }).join(' and ');
     }
@@ -49,6 +41,6 @@ export class Filter<E extends Element, F extends Filters<E>> {
   }
 
   asTableHeader(): string[] {
-    return Object.entries(this.all).map(([key, value]) => `${key}: ${formatValue(value)}`);
+    return Object.entries(this.all).map(([key, value]) => `${key}: ${formatMatcher(value)}`);
   }
 }

--- a/packages/interactor/src/index.ts
+++ b/packages/interactor/src/index.ts
@@ -16,3 +16,4 @@ export { CheckBox } from './definitions/check-box';
 export { RadioButton } from './definitions/radio-button';
 export { Select } from './definitions/select';
 export { MultiSelect } from './definitions/multi-select';
+export { Matcher } from './matcher';

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,14 +1,10 @@
 import { LocatorFn } from './specification';
-import { isMatcher, MaybeMatcher } from './matcher';
+import { formatMatcher, MaybeMatcher } from './matcher';
 
 export class Locator<E extends Element> {
   constructor(public locatorFn: LocatorFn<E>, public value: MaybeMatcher<string>) {}
 
   get description(): string {
-    if(isMatcher(this.value)) {
-      return this.value.format();
-    } else {
-      return JSON.stringify(this.value);
-    }
+    return formatMatcher(this.value);
   }
 }

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,9 +1,14 @@
 import { LocatorFn } from './specification';
+import { isMatcher, MaybeMatcher } from './matcher';
 
 export class Locator<E extends Element> {
-  constructor(public locatorFn: LocatorFn<E>, public value: string) {}
+  constructor(public locatorFn: LocatorFn<E>, public value: MaybeMatcher<string>) {}
 
   get description(): string {
-    return `${JSON.stringify(this.value)}`;
+    if(isMatcher(this.value)) {
+      return this.value.format();
+    } else {
+      return JSON.stringify(this.value);
+    }
   }
 }

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -3,6 +3,7 @@ import { Locator } from './locator';
 import { Filter } from './filter';
 import { Filters } from './specification';
 import { escapeHtml } from './escape-html';
+import { MaybeMatcher, isMatcher } from './matcher';
 
 const check = (value: unknown): string => value ? "✓" : "⨯";
 
@@ -52,7 +53,7 @@ export class Match<E extends Element, F extends Filters<E>> {
 
 export class MatchLocator<E extends Element> {
   public matches: boolean;
-  public expected: string | null;
+  public expected: MaybeMatcher<string> | null;
   public actual: string | null;
 
   constructor(
@@ -61,7 +62,11 @@ export class MatchLocator<E extends Element> {
   ) {
     this.expected = locator.value;
     this.actual = locator.locatorFn(element);
-    this.matches = this.actual === this.expected;
+    if(isMatcher(this.expected)) {
+      this.matches = this.expected.match(this.actual);
+    } else {
+      this.matches = isEqual(this.actual, this.expected);
+    }
   }
 
   formatActual(): string {
@@ -79,7 +84,7 @@ export class MatchLocator<E extends Element> {
 
 export class MatchFilter<E extends Element, F extends Filters<E>> {
   public matches: boolean;
-  public items: MatchFilterItem<E, F>[];
+  public items: MatchFilterItem<unknown, E, F>[];
 
   constructor(
     public element: E,
@@ -100,24 +105,28 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
   }
 }
 
-export class MatchFilterItem<E extends Element, F extends Filters<E>> {
-  public actual: unknown;
+export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
+  public actual: T;
   public matches: boolean;
 
   constructor(
     public element: E,
     public filter: Filter<E, F>,
     public key: string,
-    public expected: unknown
+    public expected: MaybeMatcher<T>,
   ) {
     if(this.filter.specification.filters && this.filter.specification.filters[this.key]) {
       let definition = this.filter.specification.filters[this.key];
       if(typeof(definition) === 'function') {
-        this.actual = definition(this.element);
+        this.actual = definition(this.element) as T;
       } else {
-        this.actual = definition.apply(this.element);
+        this.actual = definition.apply(this.element) as T;
       }
-      this.matches = isEqual(this.actual, this.expected);
+      if(isMatcher(this.expected)) {
+        this.matches = this.expected.match(this.actual);
+      } else {
+        this.matches = isEqual(this.actual, this.expected);
+      }
     } else {
       throw new Error(`interactor does not define a filter named ${JSON.stringify(this.key)}`);
     }

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -1,9 +1,8 @@
-import isEqual from 'lodash.isequal';
 import { Locator } from './locator';
 import { Filter } from './filter';
 import { Filters } from './specification';
 import { escapeHtml } from './escape-html';
-import { MaybeMatcher, isMatcher } from './matcher';
+import { MaybeMatcher, applyMatcher } from './matcher';
 
 const check = (value: unknown): string => value ? "✓" : "⨯";
 
@@ -62,11 +61,7 @@ export class MatchLocator<E extends Element> {
   ) {
     this.expected = locator.value;
     this.actual = locator.locatorFn(element);
-    if(isMatcher(this.expected)) {
-      this.matches = this.expected.match(this.actual);
-    } else {
-      this.matches = isEqual(this.actual, this.expected);
-    }
+    this.matches = applyMatcher(this.expected, this.actual);
   }
 
   formatActual(): string {
@@ -122,11 +117,7 @@ export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
       } else {
         this.actual = definition.apply(this.element) as T;
       }
-      if(isMatcher(this.expected)) {
-        this.matches = this.expected.match(this.actual);
-      } else {
-        this.matches = isEqual(this.actual, this.expected);
-      }
+      this.matches = applyMatcher(this.expected, this.actual);
     } else {
       throw new Error(`interactor does not define a filter named ${JSON.stringify(this.key)}`);
     }

--- a/packages/interactor/src/matcher.ts
+++ b/packages/interactor/src/matcher.ts
@@ -1,5 +1,6 @@
+import isEqual from 'lodash.isequal';
+
 export interface Matcher<T> {
-  bigtestMatcher: true;
   match(actual: T): boolean;
   format(): string;
 }
@@ -7,5 +8,21 @@ export interface Matcher<T> {
 export type MaybeMatcher<T> = Matcher<T> | T;
 
 export function isMatcher<T>(value: MaybeMatcher<T>): value is Matcher<T> {
-  return value && (value as any).bigtestMatcher === true;
+  return value && typeof (value as Matcher<T>).match === 'function' && typeof (value as Matcher<T>).format === 'function';
+}
+
+export function formatMatcher<T>(value: MaybeMatcher<T>): string {
+  if(isMatcher(value)) {
+    return value.format();
+  } else {
+    return JSON.stringify(value);
+  }
+}
+
+export function applyMatcher<T>(value: MaybeMatcher<T>, actual: T): boolean {
+  if(isMatcher(value)) {
+    return value.match(actual);
+  } else {
+    return isEqual(value, actual);
+  }
 }

--- a/packages/interactor/src/matcher.ts
+++ b/packages/interactor/src/matcher.ts
@@ -1,0 +1,11 @@
+export interface Matcher<T> {
+  bigtestMatcher: true;
+  match(actual: T): boolean;
+  format(): string;
+}
+
+export type MaybeMatcher<T> = Matcher<T> | T;
+
+export function isMatcher<T>(value: MaybeMatcher<T>): value is Matcher<T> {
+  return value && (value as any).bigtestMatcher === true;
+}

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -4,6 +4,7 @@ import { Filter } from './filter';
 import { Locator } from './locator';
 import { Interaction, ReadonlyInteraction } from './interaction';
 import { MergeObjects } from './merge-objects';
+import { MaybeMatcher } from './matcher';
 
 export type EmptyObject = Record<never, never>;
 
@@ -180,9 +181,9 @@ export type ActionMethods<E extends Element, A extends Actions<E>> = {
 export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {
   [P in keyof F]?:
     F[P] extends FilterFn<infer TArg, E> ?
-    TArg :
+    MaybeMatcher<TArg> :
     F[P] extends FilterObject<infer TArg, E> ?
-    TArg :
+    MaybeMatcher<TArg> :
     never;
 }
 
@@ -239,7 +240,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
    * @param value The locator value, which should match the value of applying the locator function defined in the {@link InteractorSpecification} to the element.
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (value: string, filters?: FP): Interactor<E, FP> & AM;
+  (value: MaybeMatcher<string>, filters?: FP): Interactor<E, FP> & AM;
 }
 
 /**

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -2,14 +2,14 @@ import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
 
-import { createInteractor, perform } from '../src/index';
+import { createInteractor } from '../src/index';
 
 const HTML = createInteractor<HTMLElement>('element')
   .filters({
     title: (element) => element.title,
   })
   .actions({
-    click: perform(element => { element.click() }),
+    click: ({ perform }) => perform(element => { element.click() }),
   });
 
 const Link = HTML.extend<HTMLLinkElement>('link')
@@ -18,7 +18,7 @@ const Link = HTML.extend<HTMLLinkElement>('link')
     href: (element) => element.href,
   })
   .actions({
-    setHref: perform((element, value: string) => { element.href = value })
+    setHref: ({ perform }, value: string) => perform((element) => { element.href = value })
   })
 
 const Thing = HTML.extend<HTMLLinkElement>('div')

--- a/packages/interactor/test/matcher.test.ts
+++ b/packages/interactor/test/matcher.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from 'mocha';
 import expect from 'expect';
 import { dom } from './helpers';
-import { bigtestGlobals } from '@bigtest/globals';
 
 import { createInteractor, Matcher } from '../src/index';
 
@@ -13,7 +12,6 @@ const Link = createInteractor<HTMLLinkElement>('link')
 
 function shouted(value: string): Matcher<string> {
   return {
-    bigtestMatcher: true,
     match(actual: string): boolean {
       return actual === value.toUpperCase();
     },

--- a/packages/interactor/test/matcher.test.ts
+++ b/packages/interactor/test/matcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+import { bigtestGlobals } from '@bigtest/globals';
+
+import { createInteractor, Matcher } from '../src/index';
+
+const Link = createInteractor<HTMLLinkElement>('link')
+  .selector('a')
+  .filters({
+    title: (element) => element.title,
+  })
+
+function shouted(value: string): Matcher<string> {
+  return {
+    bigtestMatcher: true,
+    match(actual: string): boolean {
+      return actual === value.toUpperCase();
+    },
+    format(): string {
+      return `uppercase ${JSON.stringify(value.toUpperCase())}`;
+    },
+  }
+}
+
+describe('@bigtest/interactor', () => {
+  describe('matchers', () => {
+    it('can use matcher on locator when locating element', async () => {
+      dom(`
+        <p><a href="/foobar">FOO</a></p>
+        <p><a href="/foobar">BAR</a></p>
+      `);
+
+      await expect(Link(shouted('Foo')).exists()).resolves.toBeUndefined();
+      await expect(Link(shouted('Quox')).exists()).rejects.toHaveProperty('message', [
+        'did not find link uppercase "QUOX", did you mean one of:', '',
+        '┃ link    ┃',
+        '┣━━━━━━━━━┫',
+        '┃ ⨯ "FOO" ┃',
+        '┃ ⨯ "BAR" ┃',
+      ].join('\n'));
+    });
+
+    it('can use matcher on filter when locating element', async () => {
+      dom(`
+        <p><a href="/foobar" title="FOO">Foo Bar</a></p>
+        <p><a href="/foobar" title="BAR">Quox</a></p>
+      `);
+
+      await expect(Link('Foo Bar', { title: shouted('foo') }).exists()).resolves.toBeUndefined();
+      await expect(Link('Foo Bar', { title: shouted('bar') }).exists()).rejects.toHaveProperty('message', [
+        'did not find link "Foo Bar" with title uppercase "BAR", did you mean one of:', '',
+        '┃ link        ┃ title: uppercase "BAR" ┃',
+        '┣━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━━━━━━━━━━┫',
+        '┃ ✓ "Foo Bar" ┃ ⨯ "FOO"                ┃',
+        '┃ ⨯ "Quox"    ┃ ✓ "BAR"                ┃',
+      ].join('\n'));
+    });
+
+    it('can use matcher on filter when matching element', async () => {
+      dom(`
+        <p><a href="/foobar" title="FOO">Foo Bar</a></p>
+        <p><a href="/foobar" title="BAR">Quox</a></p>
+      `);
+
+      await expect(Link('Foo Bar').has({ title: shouted('foo') })).resolves.toBeUndefined();
+      await expect(Link('Foo Bar').has({ title: shouted('bar') })).rejects.toHaveProperty('message', [
+        'link "Foo Bar" does not match filters:', '',
+        '┃ title: uppercase "BAR" ┃',
+        '┣━━━━━━━━━━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "FOO"                ┃',
+      ].join('\n'));
+    });
+  });
+});

--- a/packages/interactor/types/matcher.ts
+++ b/packages/interactor/types/matcher.ts
@@ -1,0 +1,61 @@
+import { createInteractor, Matcher } from '../src/index';
+
+function shouted(value: string): Matcher<string> {
+  return {
+    bigtestMatcher: true,
+    match(actual: string): boolean {
+      return actual === value.toUpperCase();
+    },
+    format(): string {
+      return value.toUpperCase();
+    }
+  }
+}
+
+let isEven: Matcher<number> = {
+  bigtestMatcher: true,
+  match(actual: number): boolean {
+    return actual % 2 === 0;
+  },
+  format(): string {
+    return "is even";
+  }
+}
+
+let Link = createInteractor<HTMLLinkElement>('whatever')
+  .filters({
+    href: (element) => element.href,
+    number: () => 3
+  })
+
+//// With filter
+
+Link({ href: shouted("Foobar") });
+Link({ number: isEven });
+
+// $ExpectError
+Link({ href: isEven });
+
+// $ExpectError
+Link({ href: { not: "a matcher" } });
+
+//// With filter matcher
+
+Link().has({ href: shouted("Foobar") });
+Link().has({ number: isEven });
+
+// $ExpectError
+Link().has({ href: { not: "a matcher" } });
+
+// $ExpectError
+Link().has({ href: isEven });
+
+//// With locator
+
+Link(shouted("Foobar"));
+
+// $ExpectError
+Link(isEven);
+
+// $ExpectError
+Link({ not: "a matcher" });

--- a/packages/interactor/types/matcher.ts
+++ b/packages/interactor/types/matcher.ts
@@ -52,8 +52,11 @@ Link().has({ href: isEven });
 
 Link(shouted("Foobar"));
 
-// $ExpectError
+// TODO: this should be rejected, but it will require breaking backward compatibility with the specification syntax
 Link(isEven);
+
+// $ExpectError
+Link(isEven, { href: "foo" });
 
 // $ExpectError
 Link({ not: "a matcher" });

--- a/packages/interactor/types/matcher.ts
+++ b/packages/interactor/types/matcher.ts
@@ -2,7 +2,6 @@ import { createInteractor, Matcher } from '../src/index';
 
 function shouted(value: string): Matcher<string> {
   return {
-    bigtestMatcher: true,
     match(actual: string): boolean {
       return actual === value.toUpperCase();
     },
@@ -13,7 +12,6 @@ function shouted(value: string): Matcher<string> {
 }
 
 let isEven: Matcher<number> = {
-  bigtestMatcher: true,
   match(actual: number): boolean {
     return actual % 2 === 0;
   },


### PR DESCRIPTION
Matchers can be used for more flexible matching in cases where equality is not a good candidate. This change does not ship with any matchers, but in the future we can ship these along with the library.

See #772