### PR TITLE
Add a gitignore to the sample app

### DIFF
--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.bigtest
+.cache
+dist

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigtest-sample",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigtest-sample",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "BigTest Sample App",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.com>",


### PR DESCRIPTION
This PR adds a gitignore to the sample app that is created with `npx bigtest-sample`.

Although `npx bigtest-sample` does not initialize the project as a git repo, I think it's probably common that the users will. Without this, if you run `git init`, VSCode gets a bit upset.