### PR TITLE
ensure tsconfig config option is present and gets passed to the bundler

### DIFF
--- a/.changeset/lucky-emus-ring.md
+++ b/.changeset/lucky-emus-ring.md
@@ -1,4 +1,5 @@
 ---
+"@bigtest/agent": patch
 "@bigtest/server": patch
 ---
 

--- a/.changeset/lucky-emus-ring.md
+++ b/.changeset/lucky-emus-ring.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+ensure tsconfig config option is present and gets passed to the bundler

--- a/packages/cli/src/ensure-configuration.ts
+++ b/packages/cli/src/ensure-configuration.ts
@@ -1,6 +1,5 @@
 import { ProjectOptions } from '@bigtest/project';
 import fs from 'fs';
-import path from 'path';
 
 export const ensureConfiguration = (config: ProjectOptions) => {
   if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {

--- a/packages/cli/src/ensure-configuration.ts
+++ b/packages/cli/src/ensure-configuration.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 
 export const ensureConfiguration = (config: ProjectOptions): void => {
   if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {
-    let message = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
+    let message = `The \`tsconfig\` option of (\`${config.tsconfig}\`) is invalid.`;
     
     throw new MainError({ exitCode: 1, message });
   }

--- a/packages/cli/src/ensure-configuration.ts
+++ b/packages/cli/src/ensure-configuration.ts
@@ -1,15 +1,11 @@
 import { ProjectOptions } from '@bigtest/project';
+import { MainError } from '@effection/node';
 import fs from 'fs';
 
 export const ensureConfiguration = (config: ProjectOptions): void => {
   if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {
-    let errorMessage = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
+    let message = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
     
-    console.error(errorMessage);
-
-    // is process.exit(1); sufficient from an effection standpoint or
-    // or should I use
-    // throw new Error(errorMessage);
-    process.exit(1);
+    throw new MainError({ exitCode: 1, message });
   }
 }

--- a/packages/cli/src/ensure-configuration.ts
+++ b/packages/cli/src/ensure-configuration.ts
@@ -1,0 +1,16 @@
+import { ProjectOptions } from '@bigtest/project';
+import fs from 'fs';
+import path from 'path';
+
+export const ensureConfiguration = (config: ProjectOptions) => {
+  if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {
+    let errorMessage = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
+    
+    console.error(errorMessage);
+
+    // is process.exit(1); sufficient from an effection standpoint or
+    // or should I use
+    // throw new Error(errorMessage);
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/ensure-configuration.ts
+++ b/packages/cli/src/ensure-configuration.ts
@@ -1,7 +1,7 @@
 import { ProjectOptions } from '@bigtest/project';
 import fs from 'fs';
 
-export const ensureConfiguration = (config: ProjectOptions) => {
+export const ensureConfiguration = (config: ProjectOptions): void => {
   if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {
     let errorMessage = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
     

--- a/packages/cli/src/start-server.ts
+++ b/packages/cli/src/start-server.ts
@@ -4,6 +4,7 @@ import { MainError } from '@effection/node';
 import { Mailbox, readyResource } from '@bigtest/effection';
 import { ProjectOptions } from '@bigtest/project';
 import { createOrchestratorAtom, createOrchestrator } from '@bigtest/server';
+import { ensureConfiguration } from './ensure-configuration';
 
 interface Options {
   timeout: number;
@@ -14,6 +15,9 @@ interface Options {
 export function* startServer(project: ProjectOptions, options: Options): Operation<Record<string, unknown>> {
   return yield readyResource({}, function*(ready) {
     let delegate = new Mailbox();
+
+    ensureConfiguration(project);
+    
     let atom = createOrchestratorAtom(project);
     yield spawn(createOrchestrator({ atom, delegate, project }));
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -8,7 +8,6 @@ import { promises as fs } from 'fs';
 
 import { World } from './helpers/world';
 import { Stream } from './helpers/stream';
-import path from 'path';
 
 export interface TestProcess {
   stdin: { write(data: string): void };
@@ -203,7 +202,6 @@ describe('@bigtest/cli', function() {
       let status: ExitStatus
 
       beforeEach(async () => {
-        let config = path.resolve
         child = await run('ci', '--config-file', './test/config/invalid-tsconfig-path.json',  './test/fixtures');
         status = await child.join();
       });

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -8,6 +8,7 @@ import { promises as fs } from 'fs';
 
 import { World } from './helpers/world';
 import { Stream } from './helpers/stream';
+import path from 'path';
 
 export interface TestProcess {
   stdin: { write(data: string): void };
@@ -194,6 +195,22 @@ describe('@bigtest/cli', function() {
         expect(child.stdout.output).toContain('↪ third step');
         expect(child.stdout.output).toContain('✓ check the thing');
         expect(child.stdout.output).toContain('⨯ child second step');
+      });
+    });
+
+    describe('running with an invalid tsconfig.json file',  () => {
+      let child: TestProcess;
+      let status: ExitStatus
+
+      beforeEach(async () => {
+        let config = path.resolve
+        child = await run('ci', '--config-file', './test/config/invalid-tsconfig-path.json',  './test/fixtures');
+        status = await child.join();
+      });
+
+      it('exits with error code', async () => {
+        expect(status.code).toEqual(1);
+        expect(child.stderr.output).toContain('./does-not-exist.json');
       });
     });
 

--- a/packages/cli/test/config/invalid-tsconfig-path.json
+++ b/packages/cli/test/config/invalid-tsconfig-path.json
@@ -1,0 +1,13 @@
+{
+  "app": {
+    "command": "yarn bigtest-todomvc 36000",
+    "url": "http://localhost:36000"
+  },
+  "testFiles": ["./test/fixtures/*.test.{ts,js}"],
+  "launch": ["chrome.headless"],
+  "coverage": {
+    "directory": "./tmp/coverage",
+    "reports": ["lcov", "html"]
+  },
+  "tsconfig": "./does-not-exist.json"
+}

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -90,6 +90,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     srcPath: manifestSrcPath,
     distDir: manifestDistDir,
     buildDir: manifestBuildDir,
+    tsconfig: options.project.tsconfig
   }));
 
   yield function* () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^26.6.2":
-  version "26.6.2"
-  resolved "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
-  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+"@jest/types@^26.6.0":
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
+  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -3733,14 +3733,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0":
-  version "15.0.13"
-  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
-  integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^15.0.3":
+"@types/yargs@^15.0.0", "@types/yargs@^15.0.3":
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
@@ -9839,11 +9832,11 @@ jest-mock@^24.0.0, jest-mock@^24.9.0:
     "@jest/types" "^24.9.0"
 
 jest-mock@^26.6.0:
-  version "26.6.2"
-  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
-  integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
+  version "26.6.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.0.tgz#5d13a41f3662a98a55c7742ac67c482e232ded13"
+  integrity sha512-HsNmL8vVIn1rL1GWA21Drpy9Cl+7GImwbWz/0fkWHrUXVzuaG7rP0vwLtE+/n70Mt0U8nPkz8fxioi3SC0wqhw==
   dependencies:
-    "@jest/types" "^26.6.2"
+    "@jest/types" "^26.6.0"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,10 +3088,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^26.6.0":
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
-  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -3733,7 +3733,14 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yargs@^15.0.0", "@types/yargs@^15.0.3":
+"@types/yargs@^15.0.0":
+  version "15.0.13"
+  resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz#34f7fec8b389d7f3c1fd08026a5763e072d3c6dc"
+  integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.3":
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
@@ -9832,11 +9839,11 @@ jest-mock@^24.0.0, jest-mock@^24.9.0:
     "@jest/types" "^24.9.0"
 
 jest-mock@^26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.6.0.tgz#5d13a41f3662a98a55c7742ac67c482e232ded13"
-  integrity sha512-HsNmL8vVIn1rL1GWA21Drpy9Cl+7GImwbWz/0fkWHrUXVzuaG7rP0vwLtE+/n70Mt0U8nPkz8fxioi3SC0wqhw==
+  version "26.6.2"
+  resolved "https://registry.npmjs.org/jest-mock/-/jest-mock-26.6.2.tgz#d6cb712b041ed47fe0d9b6fc3474bc6543feb302"
+  integrity sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
   dependencies:
-    "@jest/types" "^26.6.0"
+    "@jest/types" "^26.6.2"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.1:


### PR DESCRIPTION
Fixes #800 where the `tsconfig` option of `bigtest.json` was not getting passed to the `manifest-builder` from the `orchestrator` and subsequently the `bundler`.

The option now gets passed from the `orchestrator`.

```ts
  yield fork(createManifestBuilder({
    watch: options.project.watchTestFiles,
    atom: options.atom,
    srcPath: manifestSrcPath,
    distDir: manifestDistDir,
    buildDir: manifestBuildDir,
    tsconfig: options.project.tsconfig
  }));
```
I struggled to write a test for this because there is so much going on in orchestrator and `undefined` is a valid value for `tsconfig` for non-typescript projects.

I added the following runtime check to `cli` which is a better check than a unit test IMHO.
 
 ```ts
export const ensureConfiguration = (config: ProjectOptions) => {
  if (typeof config.tsconfig !== 'undefined' && fs.existsSync(config.tsconfig) === false) {
    let errorMessage = `The \`tsconfig\` option of bigtest.json (\`${config.tsconfig}\`) is invalid.`;
    
    console.error(errorMessage);

    process.exit(1);
 }
```


