### PR TITLE
ensure bundler errors go right up the stack

### DIFF
--- a/.changeset/twenty-wombats-switch.md
+++ b/.changeset/twenty-wombats-switch.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/server": patch
+---
+
+ensure bundler errors go right up the stack

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -128,7 +128,6 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
         } catch(error) {
           console.debug("[manifest builder] error loading manifest");
           bundlerSlice.update(() => ({ type: 'ERRORED', error }));
-          throw error;
         }
 
         break;

--- a/packages/server/src/manifest-builder.ts
+++ b/packages/server/src/manifest-builder.ts
@@ -128,6 +128,7 @@ export function* createManifestBuilder(options: ManifestBuilderOptions): Operati
         } catch(error) {
           console.debug("[manifest builder] error loading manifest");
           bundlerSlice.update(() => ({ type: 'ERRORED', error }));
+          throw error;
         }
 
         break;

--- a/packages/server/test/fixtures/exceptions/invalid-test-object.t.js
+++ b/packages/server/test/fixtures/exceptions/invalid-test-object.t.js
@@ -1,0 +1,3 @@
+module.exports = {
+  description: 'no assertions or children'
+}

--- a/packages/server/test/fixtures/exceptions/no-default-export.t.js
+++ b/packages/server/test/fixtures/exceptions/no-default-export.t.js
@@ -1,0 +1,3 @@
+import { test } from '@bigtest/suite';
+
+export const t = test("No default export");

--- a/packages/suite/src/validate-test.ts
+++ b/packages/suite/src/validate-test.ts
@@ -64,7 +64,7 @@ export function validateTest(test: Test): true {
     }
 
     if ( validateTestKeys(test, ['assertions', 'children'], some) === false) {
-      throw new TestValidationError(`Invalid Test: Test contains no assertions or children.\n\nTest: ${[test.description].join(' → ')}`, test.path);
+      throw new TestValidationError(`Invalid Test: Test contains no assertions or children.\n\nTest: ${path.join(' → ')}`, test.path);
     }
 
     findDuplicates(test.assertions.map((a) => a.description), (duplicate) => {

--- a/packages/suite/src/validate-test.ts
+++ b/packages/suite/src/validate-test.ts
@@ -19,9 +19,10 @@ export class TestValidationError extends Error {
   }
 }
 
-type ArrayValidationFn = typeof Array.prototype.some | typeof Array.prototype.every;
+const every = Array.prototype.every;
+const some = Array.prototype.some;
 
-function validateTestKeys (test: Test, keys: (keyof Test)[], validationFn: ArrayValidationFn): boolean {
+function validateTestKeys (test: Test, keys: (keyof Test)[], validationFn: typeof some | typeof every): boolean {
   // the disable comment below is because eslint is not recognising k as used in !!test?.[k].
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return validationFn.call(keys, (k: keyof Test) => !!test?.[k]);
@@ -58,11 +59,11 @@ export function validateTest(test: Test): true {
       throw new TestValidationError(`Invalid Test: is too deeply nested, maximum allowed depth of nesting is ${MAXIMUM_DEPTH}\n\nTest: ${path.join(' → ')}`, file)
     }
 
-    if ( validateTestKeys(test, ['description'], Array.prototype.every) === false) {
+    if ( validateTestKeys(test, ['description'], every) === false) {
       throw new TestValidationError(`Invalid Test: Test contains no description.\n\nDoes the test file contain a default export? Test: ${path.join(' → ')}`, file);
     }
 
-    if ( validateTestKeys(test, ['assertions', 'children'], Array.prototype.some) === false) {
+    if ( validateTestKeys(test, ['assertions', 'children'], some) === false) {
       throw new TestValidationError(`Invalid Test: Test contains no assertions or children.\n\nTest: ${[test.description].join(' → ')}`, test.path);
     }
 


### PR DESCRIPTION
Fixes #801 

This is to ensure bundler errors get raised right to the cli and we give the user a chance to create a github issue:

![error](https://user-images.githubusercontent.com/118328/106498262-0aec8e80-64b7-11eb-9431-bb38fbc27c0a.png)

The original issue was caused by a user with a test file that did not have a default export.  

This fix still does not let the user know what the error was.

As I may have mentioned a few times :), I am not a fan of this default export requirement.

But as it stands we are not doing any runtime check.

We could potentially check in the manifest-generator that the files have a default export but doing this on a file by file basis is not great.