### PR TITLE
Don't wait for manifest builder to start orchestrator

### DIFF
--- a/.changeset/large-horses-jog.md
+++ b/.changeset/large-horses-jog.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/server": minor
+"bigtest": minor
+---
+
+Don't wait for manifest builder to start orchestrator

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -114,10 +114,6 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
       console.debug(`[orchestrator] app server ${status.type}`);
     });
     yield fork(function* () {
-      yield options.atom.slice('bundler').once(({ type }) => type === 'GREEN' || type === 'ERRORED');
-      console.debug('[orchestrator] manifest builder ready');
-    });
-    yield fork(function* () {
       yield options.atom.slice("manifestServer", "status").once(({ type }) => type === 'started');
       console.debug('[orchestrator] manifest server ready');
     });


### PR DESCRIPTION
## Motivation

Currently we block the orchestrator readiness until the manifest builder has completed. This is actually unnecessary, since each individual test run also waits for this to complete. The orchestrator is perfectly usable before this, and doing this will allows us to use the orchestrator before the manifest is ready.

## Approach

Simply skip the step

### Possible Drawbacks or Risks

There is a slight downside in that requesting a listing of the manifest might return a blank value. However with the changes outlines in #593, we will no longer provide this option anyway.