### PR TITLE
Run CLI tests on macOS on CircleCI

### DIFF
--- a/.changeset/gentle-gorillas-compare.md
+++ b/.changeset/gentle-gorillas-compare.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/webdriver": patch
+"bigtest": patch
+---
+
+Fix path discovery of Safari driver

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ executors:
   linux:
     docker:
       - image: circleci/node:15-browsers
+  macos:
+    macos:
+      xcode: "12.4.0"
 commands:
   yarn_install:
     steps:
@@ -20,6 +23,7 @@ commands:
           paths:
             - ~/.cache/yarn
             - ~/AppData/Local/Yarn/Cache
+            - ~/Library/Caches/Yarn
   prepack:
     steps:
       - run:
@@ -174,3 +178,12 @@ workflows:
           prepack: false
           requires:
             - prepack
+      - test:
+          name: "test-cli-macos"
+          executor: macos
+          package: cli
+          driver: safari
+          pre-steps:
+            - run:
+                name: "Enable safaridriver"
+                command: defaults write com.apple.Safari AllowRemoteAutomation 1

--- a/packages/webdriver/src/local.ts
+++ b/packages/webdriver/src/local.ts
@@ -45,12 +45,17 @@ type DriverInfo = {
 }
 
 export function *getDriverPath(browserName: BrowserName): Operation<DriverInfo> {
-  if (browserName == 'edge') {
+  let path;
+  if (browserName === 'edge') {
     let { installDriver } = yield import('ms-chromium-edge-driver');
     let edgePaths = yield installDriver();
-    return edgePaths.driverPath.replace(/\\/g, '/');
-  } else {
-    let pkg = yield import(browserName === 'firefox' ? 'geckodriver' : `${browserName}driver`);
-    return pkg.path.replace(/\\/g, '/');
+    path = edgePaths.driverPath
+  } else if(browserName === 'firefox') {
+    path = (yield import('geckodriver')).path
+  } else if(browserName === 'chrome') {
+    path = (yield import('chromedriver')).path
+  } else if(browserName === 'safari') {
+    path = 'safaridriver'; // always installed in $PATH on macOS
   }
+  return path.replace(/\\/g, '/');
 }


### PR DESCRIPTION
Windows and MacOS are really our *main* platform, since most developers are not working on Linux desktops (sidenote, is 2021 the year of Linux on desktop? :trollface:). So we should run our tests on macOS in case there are any differences.