### PR TITLE
Remove anoying blue underline when hovering links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,9 @@
 </p>
 
 <p align="center">  
-  <a href="https://app.circleci.com/pipelines/github/thefrontside/bigtest?branch=v0">
-     <img alt="CircleCI" src="https://circleci.com/gh/thefrontside/bigtest.svg?style=shield"
-  </a>
-  <a href="https://discord.gg/r6AvtnU">
-    <img alt="Chat on Discord" src="https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/r6AvtnU" />
-  </a>
-  <a href="https://frontside.com">
-    <img alt="created by Frontside" src="https://img.shields.io/badge/created%20by-frontside-26abe8.svg" />
-  </a>
+  <a href="https://app.circleci.com/pipelines/github/thefrontside/bigtest?branch=v0"><img alt="CircleCI" src="https://circleci.com/gh/thefrontside/bigtest.svg?style=shield"/></a>
+  <a href="https://discord.gg/r6AvtnU"><img alt="Chat on Discord" src="https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/r6AvtnU"/></a>
+  <a href="https://frontside.com"><img alt="created by Frontside" src="https://img.shields.io/badge/created%20by-frontside-26abe8.svg"/></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The `<a>` tags extend out around the space, causing there to be a small blue underline between the badges when hovering them. This is obviously a very serious, high priority issue.

<img width="315" alt="Screenshot 2021-02-08 at 16 22 12" src="https://user-images.githubusercontent.com/134/107240365-1f3a0980-6a2a-11eb-8f45-f9e61c88eb59.png">

[Rendered](https://github.com/thefrontside/bigtest/blob/remove-blue-underline/README.md)
