### PR TITLE
Deprecated focus/blur/focused helpers

### DIFF
--- a/.changeset/forty-masks-teach.md
+++ b/.changeset/forty-masks-teach.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Deprecate focus, blur and focused helpers

--- a/packages/interactor/src/definitions/html.ts
+++ b/packages/interactor/src/definitions/html.ts
@@ -1,4 +1,4 @@
-import { createInteractor, focused, focus, blur } from '../index';
+import { createInteractor } from '../index';
 import { isVisible } from 'element-is-visible';
 
 const HTMLInteractor = createInteractor<HTMLElement>('element')
@@ -10,12 +10,12 @@ const HTMLInteractor = createInteractor<HTMLElement>('element')
     visible: { apply: isVisible, default: true },
     className: (element) => element.className,
     classList: (element) => Array.from(element.classList),
-    focused
+    focused: (element) => element.ownerDocument.activeElement === element
   })
   .actions({
     click: ({ perform }) => perform((element) => { element.click(); }),
-    focus,
-    blur
+    focus: ({ perform }) => perform((element) => { element.focus(); }),
+    blur: ({ perform }) => perform((element) => { element.blur(); }),
   })
 
 /**

--- a/packages/interactor/src/focused.ts
+++ b/packages/interactor/src/focused.ts
@@ -6,6 +6,7 @@ import { Interactor } from './specification';
  * Helper function for focused filters, returns whether the given element is focused.
  */
 export function focused(element: Element): boolean {
+  console.warn("usage of the focused() helper is deprecated, and will be removed from the public API. Instead, switch your interactor to extend the `HTML` interactor to inherit the `focused` filter");
   return element.ownerDocument.activeElement === element;
 }
 
@@ -21,6 +22,7 @@ export function focused(element: Element): boolean {
  * ```
  */
 export async function focus<E extends HTMLElement>(interactor: Interactor<E, any>): Promise<void> {
+  console.warn("usage of the focus() helper is deprecated, and will be removed from the public API. Instead, switch your interactor to extend the `HTML` interactor to inherit the `focus()` action");
   await interactor.perform((element) => element.focus())
 };
 
@@ -36,5 +38,6 @@ export async function focus<E extends HTMLElement>(interactor: Interactor<E, any
  * ```
  */
 export async function blur<E extends HTMLElement>(interactor: Interactor<E, any>): Promise<void> {
+  console.warn("usage of the blur() helper is deprecated, and will be removed from the public API. Instead, switch your interactor to extend the `HTML` interactor to inherit the `blur()` action");
   await interactor.perform((element) => element.blur())
 };


### PR DESCRIPTION
Just a little cleanup. It doesn't feel necessary to export these anymore, imo. Inline them into the HTML interactor instead. They can be reused by extending this interactor instead.