### PR TITLE
Update cypress integration package dependencies

### DIFF
--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -14,8 +14,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@bigtest/globals": "^0.7.3",
-    "@bigtest/interactor": "^0.23.0",
+    "@bigtest/globals": "^0.7.4",
+    "@bigtest/interactor": "^0.26.0",
     "cypress": "^5.6.0"
   },
   "scripts": {

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/cypress",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Cypress Integration for BigTest Interactors",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Motivation

Update cypress integration package to include the latest changes to interactors

## Approach

- Bumped `@bigtest/interactor` from `0.23.0` to `0.26.0`
- Bumped `@bigtest/globals` from `0.7.3` to `0.7.4`
- Manual bump of cypress integration package to `0.0.3` so that the release workflow can publish