### PR TITLE
Use innerText over textContent where appropriate

### DIFF
--- a/.changeset/big-donkeys-eat.md
+++ b/.changeset/big-donkeys-eat.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": minor
+"bigtest": minor
+---
+
+Use innerText for html interactors instead of textContent

--- a/packages/interactor/src/definitions/button.ts
+++ b/packages/interactor/src/definitions/button.ts
@@ -8,7 +8,7 @@ const ButtonInteractor = HTML.extend<HTMLInputElement | HTMLButtonElement>('butt
   .selector('button,input[type=button],input[type=submit],input[type=reset],input[type=image]')
   .locator((element) => {
     if(isButtonElement(element)) {
-      return element.textContent || '';
+      return element.innerText || '';
     } else if(element.type === 'image') {
       return element.alt;
     } else {

--- a/packages/interactor/src/definitions/form-field.ts
+++ b/packages/interactor/src/definitions/form-field.ts
@@ -3,7 +3,7 @@ import { HTML } from './html';
 type FieldTypes = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLSelectElement
 
 const FormFieldInteractor = HTML.extend<FieldTypes>('form field')
-  .locator((element) => element.labels ? (Array.from(element.labels)[0]?.textContent || '') : '')
+  .locator((element) => element.labels ? (Array.from(element.labels)[0]?.innerText || '') : '')
   .filters({
     valid: (element) => element.validity.valid,
     disabled: {

--- a/packages/interactor/src/definitions/html.ts
+++ b/packages/interactor/src/definitions/html.ts
@@ -3,8 +3,9 @@ import { isVisible } from 'element-is-visible';
 
 const HTMLInteractor = createInteractor<HTMLElement>('element')
   .selector('*')
+  .locator((element) => element.innerText)
   .filters({
-    text: (element) => element.textContent,
+    text: (element) => element.innerText,
     title: (element) => element.title,
     id: (element) => element.id,
     visible: { apply: isVisible, default: true },

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -24,7 +24,7 @@ const Div = createInteractor('div')
 
 const Details = createInteractor<HTMLDetailsElement>('details')
   .selector('details')
-  .locator((element) => element.querySelector('summary')?.textContent || '')
+  .locator((element) => element.querySelector('summary')?.innerText || '')
 
 const TextField = createInteractor<HTMLInputElement>('text field')
   .selector('input')
@@ -44,10 +44,10 @@ const TextField = createInteractor<HTMLInputElement>('text field')
 
 const Datepicker = createInteractor<HTMLDivElement>("datepicker")
   .selector("div.datepicker")
-  .locator(element => element.querySelector("label")?.textContent || "")
+  .locator(element => element.querySelector("label")?.innerText || "")
   .filters({
     open: element => !!element.querySelector("div.calendar"),
-    month: element => element.querySelector("div.calendar h4")?.textContent
+    month: element => element.querySelector("div.calendar h4")?.innerText
   })
   .actions({
     toggle: async interactor => {

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -47,7 +47,7 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")
   .locator(element => element.querySelector("label")?.innerText || "")
   .filters({
     open: element => !!element.querySelector("div.calendar"),
-    month: element => element.querySelector("div.calendar h4")?.innerText
+    month: element => element.querySelector<HTMLElement>("div.calendar h4")?.innerText
   })
   .actions({
     toggle: async interactor => {

--- a/packages/interactor/test/helpers.ts
+++ b/packages/interactor/test/helpers.ts
@@ -6,7 +6,21 @@ let jsdom: JSDOM;
 
 export function dom(html: string): DOMWindow {
   jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
+
+  // Because JSDOM does not have any concept of flow or layout, it cannot actually implement
+  // `innerText` correctly, so they have opted not to implement it at all. So, to make things
+  // work we just alias `.innerText` to `.textContent` for all `HTMLElement` subtypes.
+  // Long term, the solution is to have interactors actually run inside the bigtest runner
+  // against multiple browsers.
+  //
+  // See details: https://github.com/jsdom/jsdom/issues/1245
+  Object.defineProperty(jsdom.window.HTMLElement.prototype, 'innerText', {
+    get() {
+      return this.textContent || '';
+    }
+  });
   bigtestGlobals.document = jsdom.window.document;
+
   return jsdom.window;
 }
 

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -17,7 +17,7 @@ Button('Submit').exists();
 
 A typical user identifies a button by the words printed across it, so in this example they would consider a button with the word 'Submit' on it as the "Submit" button. Interactors use locators to make that connection.
 
-What is going on behind the scenes? Just like the user, the built-in Button interactor provided by BigTest looks for a button with "Submit" on it. It uses [element.textContent](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/button.ts#L11-L12) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.textContent` is equal to `Submit`.
+What is going on behind the scenes? Just like the user, the built-in Button interactor provided by BigTest looks for a button with "Submit" on it. It uses [element.innerText](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/button.ts#L11-L12) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.innerText` is equal to `Submit`.
 
 ### The locator is optional
 
@@ -40,7 +40,7 @@ TextField('Username:', { id: 'username-id' }).exists();
 ```
 
 :::note How is the textfield located?
- The locator of the `TextField` interactor is the textContent of its associated label:
+ The locator of the `TextField` interactor is the `innerText` of its associated label:
  ```html
 <label>
   Username:

--- a/website/docs/interactors/4-write-your-own.md
+++ b/website/docs/interactors/4-write-your-own.md
@@ -81,7 +81,7 @@ NoSuchElementError: did not find my-textfield-interactor "USERNAME"
 ```
 _An example of the console output when a test is unable to locate the interactor_
 
-Locators, filters, and actions are optional when creating your own interactor. While the locator for the `TextField` interactor offered by BigTest uses the `textContent` of the associated label (as we explained on the [Locators, Filters, and Actions page](/docs/interactors/locators-filters-actions#filters)), the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of Locators to anything that suits your needs. If you create an interactor without a locator, it will default to `locator: element => element.textContent`.
+Locators, filters, and actions are optional when creating your own interactor. While the locator for the `TextField` interactor offered by BigTest uses the `innerText` of the associated label (as we explained on the [Locators, Filters, and Actions page](/docs/interactors/locators-filters-actions#filters)), the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of Locators to anything that suits your needs. If you create an interactor without a locator, it will default to `locator: element => element.textContent`.
 
 You might be wondering what `interactor.perform()` does: it is a method on the interactor which ensures that there are no race conditions when working directly with elements. You can use it like this:
 


### PR DESCRIPTION
Uses `innerText` for built in HTML interactors. Still default to `textContent` for other elements.

Closes #853 