### PR TITLE
Change format of filter not matching error

### DIFF
--- a/.changeset/fresh-bears-boil.md
+++ b/.changeset/fresh-bears-boil.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": patch
+"bigtest": patch
+---
+
+Improved format for filter not matching error

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -163,8 +163,7 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
           let element = unsafeSyncResolveUnique(options);
           let match = new MatchFilter(element, filter);
           if(!match.matches) {
-            let table = formatTable({ headers: filter.asTableHeader(), rows: [match.asTableRow()] });
-            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${table}`);
+            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.formatAsExpectations()}`);
           }
         });
       });

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -2,7 +2,7 @@ import { Locator } from './locator';
 import { Filter } from './filter';
 import { Filters } from './specification';
 import { escapeHtml } from './escape-html';
-import { MaybeMatcher, applyMatcher } from './matcher';
+import { MaybeMatcher, applyMatcher, formatMatcher } from './matcher';
 
 const check = (value: unknown): string => value ? "✓" : "⨯";
 
@@ -98,6 +98,10 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
   get sortWeight(): number {
     return this.items.reduce((agg, i) => agg + i.sortWeight, 0);
   }
+
+  formatAsExpectations(): string {
+    return this.items.filter((i) => !i.matches).map((i) => i.formatAsExpectation()).join('\n\n');
+  }
 }
 
 export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
@@ -127,8 +131,20 @@ export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
     return JSON.stringify(this.actual);
   }
 
+  formatExpected(): string {
+    return formatMatcher(this.expected);
+  }
+
   format(): string {
     return `${check(this.matches)} ${this.formatActual()}`;
+  }
+
+  formatAsExpectation(): string {
+    return [
+      `╒═ Filter:   ${this.key}`,
+      `├─ Expected: ${this.formatExpected()}`,
+      `└─ Received: ${this.formatActual()}`,
+    ].join('\n')
   }
 
   get sortWeight(): number {

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -296,9 +296,9 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Email').is({ value: 'jonas@example.com' })).resolves.toBeUndefined();
       await expect(TextField('Email').is({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', [
         'text field "Email" does not match filters:', '',
-        '┃ value: "incorrect@example.com" ┃ enabled: true ┃',
-        '┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
-        '┃ ⨯ "jonas@example.com"          ┃ ✓ true        ┃',
+        '╒═ Filter:   value',
+        '├─ Expected: "incorrect@example.com"',
+        '└─ Received: "jonas@example.com"',
       ].join('\n'))
     });
   });
@@ -312,9 +312,9 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Email').has({ value: 'jonas@example.com' })).resolves.toBeUndefined();
       await expect(TextField('Email').has({ value: 'incorrect@example.com' })).rejects.toHaveProperty('message', [
         'text field "Email" does not match filters:', '',
-        '┃ value: "incorrect@example.com" ┃ enabled: true ┃',
-        '┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━━━━━━━━━━━━┫',
-        '┃ ⨯ "jonas@example.com"          ┃ ✓ true        ┃',
+        '╒═ Filter:   value',
+        '├─ Expected: "incorrect@example.com"',
+        '└─ Received: "jonas@example.com"',
       ].join('\n'))
     });
   });

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -47,9 +47,9 @@ describe('@bigtest/interactor', () => {
       await expect(Link('Foo Bar').has({ title: "Foo" })).resolves.toBeUndefined();
       await expect(Link('Foo Bar').has({ title: "Quox" })).rejects.toHaveProperty('message', [
         'link "Foo Bar" does not match filters:', '',
-        '┃ title: "Quox" ┃',
-        '┣━━━━━━━━━━━━━━━┫',
-        '┃ ⨯ "Foo"       ┃',
+        '╒═ Filter:   title',
+        '├─ Expected: "Quox"',
+        '└─ Received: "Foo"',
       ].join('\n'));
     });
 
@@ -61,9 +61,9 @@ describe('@bigtest/interactor', () => {
       await expect(Link('Foo Bar').has({ href: "/foobar" })).resolves.toBeUndefined();
       await expect(Link('Foo Bar').has({ href: "/quox" })).rejects.toHaveProperty('message', [
         'link "Foo Bar" does not match filters:', '',
-        '┃ href: "/quox" ┃',
-        '┣━━━━━━━━━━━━━━━┫',
-        '┃ ⨯ "/foobar"   ┃',
+        '╒═ Filter:   href',
+        '├─ Expected: "/quox"',
+        '└─ Received: "/foobar"',
       ].join('\n'));
     });
 

--- a/packages/interactor/test/matcher.test.ts
+++ b/packages/interactor/test/matcher.test.ts
@@ -64,9 +64,9 @@ describe('@bigtest/interactor', () => {
       await expect(Link('Foo Bar').has({ title: shouted('foo') })).resolves.toBeUndefined();
       await expect(Link('Foo Bar').has({ title: shouted('bar') })).rejects.toHaveProperty('message', [
         'link "Foo Bar" does not match filters:', '',
-        '┃ title: uppercase "BAR" ┃',
-        '┣━━━━━━━━━━━━━━━━━━━━━━━━┫',
-        '┃ ⨯ "FOO"                ┃',
+        '╒═ Filter:   title',
+        '├─ Expected: uppercase "BAR"',
+        '└─ Received: "FOO"',
       ].join('\n'));
     });
   });

--- a/packages/interactor/test/page.test.ts
+++ b/packages/interactor/test/page.test.ts
@@ -81,11 +81,10 @@ describe('@bigtest/interactor', function() {
         await expect(Page.has({ title: 'Hello World' })).resolves.toBeUndefined();
         await expect(Page.has({ title: 'Does Not Exist' })).rejects.toHaveProperty('message', [
           'page does not match filters:', '',
-          '┃ title: "Does Not Exist" ┃',
-          '┣━━━━━━━━━━━━━━━━━━━━━━━━━┫',
-          '┃ ⨯ "Hello World"         ┃',
+          '╒═ Filter:   title',
+          '├─ Expected: "Does Not Exist"',
+          '└─ Received: "Hello World"',
         ].join('\n'))
-
       });
     });
 
@@ -96,9 +95,9 @@ describe('@bigtest/interactor', function() {
         await expect(Page.has({ url: 'about:blank' })).resolves.toBeUndefined();
         await expect(Page.has({ url: 'does-not-exist' })).rejects.toHaveProperty('message', [
           'page does not match filters:', '',
-          '┃ url: "does-not-exist" ┃',
-          '┣━━━━━━━━━━━━━━━━━━━━━━━┫',
-          '┃ ⨯ "about:blank"       ┃',
+          '╒═ Filter:   url',
+          '├─ Expected: "does-not-exist"',
+          '└─ Received: "about:blank"',
         ].join('\n'))
       });
     });


### PR DESCRIPTION
This changes the format of the `FilterNotMatchingError`. The table format has been pointed out as confusing by users. Also, both `ElementNotFoundError` and `FilterNorMatchingError` currently look visually similar, but serve different purposes. By making them more visually distinct, we make it easier to see these as separate errors with different failure modes.

Before:

<img width="833" alt="Screenshot 2021-02-16 at 16 42 12" src="https://user-images.githubusercontent.com/134/108085908-1d012c00-7076-11eb-951e-97264c5aa04c.png">

After:

<img width="833" alt="Screenshot 2021-02-16 at 16 41 53" src="https://user-images.githubusercontent.com/134/108085938-25f1fd80-7076-11eb-97ec-30072d44ad72.png">

In this PR, colorizing the output is not included, since it requires more substantive changes, and this way we can split up this complex change into smaller chunks.