### PR TITLE
Track orchestrator status in state

### DIFF
--- a/.changeset/tasty-cheetahs-shout.md
+++ b/.changeset/tasty-cheetahs-shout.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/server": minor
+"@bigtest/cli": patch
+---
+
+Track orchstrator status in state, remove delegate

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { fork, Operation, spawn } from 'effection';
-import { Mailbox } from '@bigtest/effection';
 import { AgentServerConfig } from '@bigtest/agent';
 import { Slice } from '@bigtest/atom';
 import { ProjectOptions } from '@bigtest/project';
@@ -19,12 +18,13 @@ import { AgentRunner } from './runner';
 
 type OrchestratorOptions = {
   atom: Slice<OrchestratorState>;
-  delegate?: Mailbox;
   project: ProjectOptions;
 }
 
 export function* createOrchestrator(options: OrchestratorOptions): Operation {
   console.log('[orchestrator] starting');
+
+  let status = options.atom.slice('status');
 
   let agentServerConfig = new AgentServerConfig(options.project.proxy);
 
@@ -147,7 +147,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
   console.log(`[orchestrator] launch agents via: ${connectURL}`);
   console.log(`[orchestrator] show GraphQL dashboard via: ${commandUrl}`);
 
-  options.delegate && options.delegate.send({ status: 'ready' });
+  status.set({ type: 'ready' });
 
   try {
     yield;

--- a/packages/server/src/orchestrator/atom.ts
+++ b/packages/server/src/orchestrator/atom.ts
@@ -36,6 +36,9 @@ export function createOrchestratorAtom(overrides?: DeepPartial<OrchestratorState
     manifestServer: {
       type: 'unstarted',
     },
+    status: {
+      type: 'pending',
+    }
   };
   return createAtom<OrchestratorState>(merge(options, overrides || {}));
 }

--- a/packages/server/src/orchestrator/state.ts
+++ b/packages/server/src/orchestrator/state.ts
@@ -100,6 +100,10 @@ export type CommandServerStatus = {
   type: 'unstarted' | 'starting' | 'started';
 }
 
+export type OrchestratorStatus = {
+  type: 'pending' | 'ready';
+}
+
 export type OrchestratorState = {
   agents: Record<string, AgentState>;
   manifest: Manifest;
@@ -111,4 +115,5 @@ export type OrchestratorState = {
   proxyServer: ProxyServerStatus;
   connectionServer: ConnectionServerStatus;
   commandServer: CommandServerStatus;
+  status: OrchestratorStatus;
 }

--- a/packages/server/test/helpers.ts
+++ b/packages/server/test/helpers.ts
@@ -43,8 +43,6 @@ export const actions = {
   async startOrchestrator(overrides?: DeepPartial<ProjectOptions>): Promise<any> {
     this.atom = createOrchestratorAtom();
 
-    let delegate = new Mailbox();
-
     let options: ProjectOptions = {
       port: 24102,
       testFiles: ["test/fixtures/*.t.js"],
@@ -69,12 +67,11 @@ export const actions = {
     };
 
     this.fork(createOrchestrator({
-      delegate,
       atom: this.atom,
       project: merge(options, overrides || {}),
     }));
 
-    await this.receive(delegate, { status: 'ready' });
+    await this.fork(this.atom.slice('status', 'type').once(type => type === 'ready'));
   }
 }
 


### PR DESCRIPTION
Tracks the orchestrator status in the state instead of via a delegate. Removes the last of the delegates.