### PR TITLE
feat: website sync up code blocks

### DIFF
--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -37,6 +37,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},
@@ -62,6 +63,7 @@ import TabItem from '@theme/TabItem';
 If you are using Cypress, you will only need to install `@bigtest/cypress`:
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},
@@ -91,6 +93,7 @@ Interactors can do a lot, but let's keep things simple for now and begin testing
 Interactors have methods like `click` that mimic user actions. If you are using your own app, in your codebase find a test that already has a button click in it. In that test, import the `Button` interactor from `bigtest` and use it to replace the click interaction as exemplified below (make sure to substitute "Sign In" with your own button text):
 
 <Tabs
+  groupId="runner"
   defaultValue="jest"
   values={[
     {label: 'Jest', value: 'jest'},
@@ -167,6 +170,7 @@ Let’s build on top of the example you used in the last section. When a user cl
 In the sample project, when you click the “Sign In” button it disappears and a “Sign out” button appears in its place. If you’re following along your own test suite, find a test that asserts whether an element exists. Writing this kind of assertion would look like this with Interactors:
 
 <Tabs
+  groupId="runner"
   defaultValue="jest"
   values={[
     {label: 'Jest', value: 'jest'},
@@ -231,6 +235,7 @@ What if testing a more complex UI was as straightforward as using that button in
 Here are examples of what a test for an airline datepicker interface could look like that use interactors:
 
 <Tabs
+  groupId="runner"
   defaultValue="jest"
   values={[
     {label: 'Jest', value: 'jest'},

--- a/website/docs/interactors/4-write-your-own.md
+++ b/website/docs/interactors/4-write-your-own.md
@@ -23,6 +23,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
+  groupId="language"
   defaultValue="javascript"
   values={[
     {label: 'Javascript', value: 'javascript'},
@@ -106,6 +107,7 @@ createInteractor('my interactor')
 The former syntax is necessary if you want to write an action that delegates to the actions of other interactors. For example, imagine that you want to create a form interactor that has a submit action. You could take this approach:
 
 <Tabs
+  groupId="language"
   defaultValue="javascript"
   values={[
     {label: 'Javascript', value: 'javascript'},
@@ -160,6 +162,7 @@ Form().submit();
 Let's get back to our example and add the new TextField interactor to a test. In this example we are testing an email subscription form by first filling in the email text field, clicking the `Subscribe` button, and then asserting for the success header.
 
 <Tabs
+  groupId="runner"
   defaultValue="jest"
   values={[
     {label: 'Jest', value: 'jest'},
@@ -309,6 +312,7 @@ TableCell({ columnTitle: 'Name', rowNumber: 2 }).has({ value: 'Marge Simpson' })
 Now that we have the TableCell Interactor ready, let’s put it in action to test a Jeopardy chart where we have multiple tablecells with similar values. We want to make sure that the $600 cell under ‘Politics’ of our Jeopardy table disappears when we click it. The following example shows how our new TableCell interactor makes that task trivial:
 
 <Tabs
+  groupId="runner"
   defaultValue="jest"
   values={[
     {label: 'Jest', value: 'jest'},

--- a/website/docs/platform/1-installation.md
+++ b/website/docs/platform/1-installation.md
@@ -24,6 +24,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},
@@ -48,6 +49,7 @@ import TabItem from '@theme/TabItem';
 Once that's finished installing, you can run the following command to generate the essential files:
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},

--- a/website/docs/platform/3-running-tests.md
+++ b/website/docs/platform/3-running-tests.md
@@ -13,6 +13,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},
@@ -46,6 +47,7 @@ The browser also stays open after tests are running so that you can inspect and 
 First, start the server with this command:
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},
@@ -70,6 +72,7 @@ First, start the server with this command:
 Once the server is running, run this command in a separate terminal:
 
 <Tabs
+  groupId="package-manager"
   defaultValue="npm"
   values={[
     {label: 'NPM', value: 'npm'},


### PR DESCRIPTION
## Motivation

This change will sync up all code blocks. If someone is using, say `yarn`, they will likely prefer to see all of the code blocks using yarn instead of npm. This change allows selecting it once, and every other instance will also be changed as well (that matches the `groupId`).

## Approach

Add `groupId="text"` to any `Tabs`, this will sync up tabs that have that same `groupId`.
