### PR TITLE
Make interactors work out of the box in JSDOM

### DIFF
--- a/.changeset/jsdom-interactors.md
+++ b/.changeset/jsdom-interactors.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/interactor": patch
+"bigtest": patch
+---
+Fix the `text` filter and `innerText` based locators so that they work
+out of the box with JSDOM

--- a/packages/interactor/src/definitions/button.ts
+++ b/packages/interactor/src/definitions/button.ts
@@ -1,4 +1,4 @@
-import { HTML } from './html';
+import { HTML, innerText } from './html';
 
 function isButtonElement(element: HTMLInputElement | HTMLButtonElement): element is HTMLButtonElement {
   return element.tagName === 'BUTTON';
@@ -8,7 +8,7 @@ const ButtonInteractor = HTML.extend<HTMLInputElement | HTMLButtonElement>('butt
   .selector('button,input[type=button],input[type=submit],input[type=reset],input[type=image]')
   .locator((element) => {
     if(isButtonElement(element)) {
-      return element.innerText || '';
+      return innerText(element);
     } else if(element.type === 'image') {
       return element.alt;
     } else {

--- a/packages/interactor/src/definitions/form-field.ts
+++ b/packages/interactor/src/definitions/form-field.ts
@@ -1,9 +1,9 @@
-import { HTML } from './html';
+import { HTML, innerText } from './html';
 
 type FieldTypes = HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | HTMLSelectElement
 
 const FormFieldInteractor = HTML.extend<FieldTypes>('form field')
-  .locator((element) => element.labels ? (Array.from(element.labels)[0]?.innerText || '') : '')
+  .locator((element) => element.labels ? innerText(Array.from(element.labels)[0]) : '')
   .filters({
     valid: (element) => element.validity.valid,
     disabled: {

--- a/packages/interactor/src/definitions/html.ts
+++ b/packages/interactor/src/definitions/html.ts
@@ -3,9 +3,9 @@ import { isVisible } from 'element-is-visible';
 
 const HTMLInteractor = createInteractor<HTMLElement>('element')
   .selector('*')
-  .locator((element) => element.innerText)
+  .locator(innerText)
   .filters({
-    text: (element) => element.innerText,
+    text: innerText,
     title: (element) => element.title,
     id: (element) => element.id,
     visible: { apply: isVisible, default: true },
@@ -18,6 +18,16 @@ const HTMLInteractor = createInteractor<HTMLElement>('element')
     focus: ({ perform }) => perform((element) => { element.focus(); }),
     blur: ({ perform }) => perform((element) => { element.blur(); }),
   })
+
+// Because JSDOM does not have any concept of flow or layout, it cannot actually implement
+// `innerText` correctly, so they have opted not to implement it at all. So, to make things
+// work use `textContent` as a backup for all `HTMLElement` subtypes if `innerText` is
+// undefined
+//
+// See details: https://github.com/jsdom/jsdom/issues/1245
+export function innerText(element?: HTMLElement): string {
+  return (element?.innerText != null ? element?.innerText :  element?.textContent) || '';
+}
 
 /**
  * Use this {@link InteractorConstructor} as a base for creating interactors which

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -24,7 +24,7 @@ const Div = createInteractor('div')
 
 const Details = createInteractor<HTMLDetailsElement>('details')
   .selector('details')
-  .locator((element) => element.querySelector('summary')?.innerText || '')
+  .locator((element) => element.querySelector('summary')?.textContent || '')
 
 const TextField = createInteractor<HTMLInputElement>('text field')
   .selector('input')
@@ -44,10 +44,10 @@ const TextField = createInteractor<HTMLInputElement>('text field')
 
 const Datepicker = createInteractor<HTMLDivElement>("datepicker")
   .selector("div.datepicker")
-  .locator(element => element.querySelector("label")?.innerText || "")
+  .locator(element => element.querySelector("label")?.textContent || "")
   .filters({
     open: element => !!element.querySelector("div.calendar"),
-    month: element => element.querySelector<HTMLElement>("div.calendar h4")?.innerText
+    month: element => element.querySelector<HTMLElement>("div.calendar h4")?.textContent
   })
   .actions({
     toggle: async interactor => {

--- a/packages/interactor/test/helpers.ts
+++ b/packages/interactor/test/helpers.ts
@@ -7,18 +7,6 @@ let jsdom: JSDOM;
 export function dom(html: string): DOMWindow {
   jsdom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, { runScripts: "dangerously" });
 
-  // Because JSDOM does not have any concept of flow or layout, it cannot actually implement
-  // `innerText` correctly, so they have opted not to implement it at all. So, to make things
-  // work we just alias `.innerText` to `.textContent` for all `HTMLElement` subtypes.
-  // Long term, the solution is to have interactors actually run inside the bigtest runner
-  // against multiple browsers.
-  //
-  // See details: https://github.com/jsdom/jsdom/issues/1245
-  Object.defineProperty(jsdom.window.HTMLElement.prototype, 'innerText', {
-    get() {
-      return this.textContent || '';
-    }
-  });
   bigtestGlobals.document = jsdom.window.document;
 
   return jsdom.window;


### PR DESCRIPTION
Motivation
--------------
When we switched to `innerText` as the default locator, we actually broke the test suite because JSDOM does not actually implement `innerText` at all. To make up for this, we monkey-patched `innerText` in our test suite to fallback to `textContent`. However, this had one serious drawback. We want interactors to work out of the box with JSDOM, so every test suite using JSDOM as the document ended up breaking. So while we fixed our own test suite, we broke everybody else's that uses JSDOM🤦🏻‍♂️


Approach
----------
This change makes the `text` filter and locators that rely on `innerText` handle gracefully the case where the `innerText` property does not actually exist, using `textContent` and finally the empty string as a fallback. In practice this should be very rare with the only known exception being JSDOM.
