### PR TITLE
Use medium size windows executor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
       - test:
           executor:
             name: "win/default"
-            size: "large"
+            size: "medium"
           name: "test-cli-windows"
           pre-steps:
             - run:


### PR DESCRIPTION

## Motivation
We're paying $500 a month for our large windows executors.

## Approach
Switch to a medium VM since the pricing is half of the large and see what difference it makes in build time.
