### PR TITLE
Prevent race condition on app start

### DIFF
--- a/.changeset/quiet-brooms-learn.md
+++ b/.changeset/quiet-brooms-learn.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/server": patch
+"bigtest": patch
+---
+
+Prevent race condition if app server becomes available too early

--- a/packages/server/src/orchestrator.ts
+++ b/packages/server/src/orchestrator.ts
@@ -125,7 +125,7 @@ export function* createOrchestrator(options: OrchestratorOptions): Operation {
     });
     yield fork(function*() {
       let status = yield options.atom.slice('appServer').once((status) => {
-        return status.type === 'started' || status.type === 'exited';
+        return status.type === 'started' || status.type === 'available' || status.type === 'exited';
       });
       console.debug(`[orchestrator] app server ${status.type}`);
     });


### PR DESCRIPTION
If app becomes `available` before entering the watcher here, then the orchestrator will fail to become ready.