### PR TITLE
Clear CLI options override

### DIFF
--- a/.changeset/new-pianos-hide.md
+++ b/.changeset/new-pianos-hide.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/cli": minor
+"bigtest": minor
+---
+
+Allow options to be cleared by providing an empty string

--- a/packages/cli/src/project-options.ts
+++ b/packages/cli/src/project-options.ts
@@ -34,13 +34,13 @@ export function applyStartArgs(options: ProjectOptions, args: StartArgs): void {
   if(args.testFiles) {
     options.testFiles = args.testFiles;
   }
-  if(args.appCommand) {
+  if(args.appCommand != null) {
     options.app.command = args.appCommand;
   }
-  if(args.appUrl) {
+  if(args.appUrl != null) {
     options.app.url = args.appUrl;
   }
-  if(args.tsconfig) {
+  if(args.tsconfig != null) {
     options.tsconfig = args.tsconfig;
   }
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, beforeEach } from 'mocha';
-import { daemon, exec, ExitStatus } from '@effection/node';
+import { exec, ExitStatus } from '@effection/node';
 import { defaultTSConfig } from '@bigtest/project';
 
 import expect from 'expect';
@@ -53,8 +53,7 @@ describe('@bigtest/cli', function() {
       let child: TestProcess;
 
       beforeEach(async () => {
-        await World.spawn(daemon('yarn test:app:start 36001'));
-        child = await run('server', '--app.url', 'http://localhost:36001', '--no-app.command');
+        child = await run('server', '--app-url', 'http://localhost:36001', '--app-command', '');
       });
 
       it('outputs that the server was started successfully', async () => {
@@ -66,7 +65,7 @@ describe('@bigtest/cli', function() {
       let child: TestProcess;
 
       beforeEach(async () => {
-        child = await run('server', '--app.url', 'http://localhost:36001', '--app.command', '"yarn test:app:start 36001"');
+        child = await run('server', '--app-url', 'http://localhost:36001', '--app-command', '"yarn test:app:start 36001"');
       });
 
       it('outputs that the server was started successfully', async () => {

--- a/packages/server/src/app-server.ts
+++ b/packages/server/src/app-server.ts
@@ -18,6 +18,7 @@ export function* appServer(options: AppServerOptions): Operation<void> {
   assert(!!options.url, 'no app url given');
 
   if (options.command) {
+    console.debug('[app] starting app with command:', options.command);
     let child: Process = yield exec(options.command as string, {
       cwd: options.dir,
       env: Object.assign({}, process.env, options.env),


### PR DESCRIPTION
This allows CLI options like `--app-command` to take an empty string to override and "clear" the original option, which feels more correct to me. This way you can start bigtest with `--app-comand ''` and it will not start an app server.