### PR TITLE
Remove dollar signs from all of the commands in docs

### DIFF
--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -24,7 +24,7 @@ By the end of this page you will be testing one of your own apps with Interactor
 Run the following command to install a sample project which includes a simple app with test suites implemented for Jest, Cypress, and BigTest:
 
 ```
-$ npx bigtest-sample
+npx bigtest-sample
 ```
 
 After you’ve installed the project, you’ll be able to run the test suite of your choice. For example, for running the Jest suite you can use `npm run test:jest`. More details are available in the welcome message for the project.
@@ -46,14 +46,14 @@ import TabItem from '@theme/TabItem';
   <TabItem value="npm">
 
   ```
-  $ npm install bigtest --save-dev
+  npm install bigtest --save-dev
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn add bigtest --dev
+  yarn add bigtest --dev
   ```
 
   </TabItem>
@@ -72,14 +72,14 @@ If you are using Cypress, you will only need to install `@bigtest/cypress`:
   <TabItem value="npm">
 
   ```
-  $ npm install @bigtest/cypress --save-dev
+  npm install @bigtest/cypress --save-dev
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn add @bigtest/cypress --dev
+  yarn add @bigtest/cypress --dev
   ```
 
   </TabItem>

--- a/website/docs/platform/1-installation.md
+++ b/website/docs/platform/1-installation.md
@@ -33,14 +33,14 @@ import TabItem from '@theme/TabItem';
   <TabItem value="npm">
 
   ```
-  $ npm install bigtest --save-dev
+  npm install bigtest --save-dev
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn add bigtest --dev
+  yarn add bigtest --dev
   ```
 
   </TabItem>
@@ -58,14 +58,14 @@ Once that's finished installing, you can run the following command to generate t
   <TabItem value="npm">
 
   ```
-  $ npx bigtest init
+  npx bigtest init
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn bigtest init
+  yarn bigtest init
   ```
 
   </TabItem>

--- a/website/docs/platform/3-running-tests.md
+++ b/website/docs/platform/3-running-tests.md
@@ -22,14 +22,14 @@ import TabItem from '@theme/TabItem';
   <TabItem value="npm">
 
   ```
-  $ npx bigtest ci
+  npx bigtest ci
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn bigtest ci
+  yarn bigtest ci
   ```
 
   </TabItem>
@@ -56,14 +56,14 @@ First, start the server with this command:
   <TabItem value="npm">
 
   ```
-  $ npx bigtest server --launch=chrome
+  npx bigtest server --launch=chrome
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn bigtest server --launch=chrome
+  yarn bigtest server --launch=chrome
   ```
 
   </TabItem>
@@ -81,14 +81,14 @@ Once the server is running, run this command in a separate terminal:
   <TabItem value="npm">
 
   ```
-  $ npx bigtest test
+  npx bigtest test
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  $ yarn bigtest test
+  yarn bigtest test
   ```
 
   </TabItem>


### PR DESCRIPTION
## Motivation

To resolve #883.

## Approach

Went through all of the pages in the website to remove `$` from the shell command instructions.