### PR TITLE
feat: add `specification` static prop for interactor

### DIFF
--- a/packages/interactor/src/builder.ts
+++ b/packages/interactor/src/builder.ts
@@ -3,22 +3,28 @@ import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification
 import { createConstructor } from './constructor';
 import { MergeObjects } from './merge-objects';
 
-export function makeBuilder<T, E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(base: T, name: string, specification: InteractorSpecification<E, any, any>): T & InteractorBuilder<E, FP, AM> {
+export function makeBuilder<
+  T,
+  E extends Element,
+  FP extends FilterParams<any, any>,
+  AM extends ActionMethods<any, any>,
+  IS extends InteractorSpecification<any, any, any>
+>(base: T, name: string, specification: IS): T & InteractorBuilder<E, FP, AM, IS> {
   return Object.assign(base, {
-    selector: (value: string): InteractorConstructor<E, FP, AM> => {
+    selector: (value: string): InteractorConstructor<E, FP, AM, MergeObjects<IS, { selector: string }>> => {
       return createConstructor(name, { ...specification, selector: value });
     },
-    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, AM> => {
+    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, AM, MergeObjects<IS, { locator: LocatorFn<E> }>> => {
       return createConstructor(name, { ...specification, locator: value });
     },
-    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM> => {
+    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM, MergeObjects<IS, { filters: IS['filters'] & FR }>> => {
       return createConstructor(name, { ...specification, filters: { ...specification.filters, ...filters } });
     },
-    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>> => {
+    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>, MergeObjects<IS, { actions: IS['actions'] & AR }>> => {
       return createConstructor(name, { ...specification, actions: Object.assign({}, specification.actions, actions) });
     },
-    extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, AM> => {
-      return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, AM>;
+    extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, AM, IS> => {
+      return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, AM, IS>;
     },
   });
 }

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -193,10 +193,15 @@ export function instantiateInteractor<E extends Element, F extends Filters<E>, A
   return interactor as Interactor<E, FilterParams<E, F>> & ActionMethods<E, A>;
 }
 
-export function createConstructor<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(
+export function createConstructor<
+  E extends Element,
+  FP extends FilterParams<any, any>,
+  AM extends ActionMethods<any, any>,
+  IS extends InteractorSpecification<any, any, any>
+>(
   name: string,
-  specification: InteractorSpecification<E, any, any>,
-): InteractorConstructor<E, FP, AM> {
+  specification: IS,
+): InteractorConstructor<E, FP, AM, IS> {
   function initInteractor(...args: any[]) {
     let locator, filter;
     if(typeof(args[0]) === 'string' || isMatcher(args[0])) {
@@ -207,6 +212,7 @@ export function createConstructor<E extends Element, FP extends FilterParams<any
     }
     return instantiateInteractor({ name, specification, filter, locator, ancestors: [] });
   }
+  initInteractor.specification = specification
 
-  return makeBuilder(initInteractor, name, specification) as unknown as InteractorConstructor<E, FP, AM>;
+  return makeBuilder(initInteractor, name, specification) as unknown as InteractorConstructor<E, FP, AM, IS>;
 }

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -21,7 +21,7 @@ import { makeBuilder } from './builder';
  * @returns You will need to call the returned builder to create an interactor.
  */
 export function createInteractor<E extends Element>(name: string): InteractorSpecificationBuilder<E> {
-  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>> {
+  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>, InteractorSpecification<E, F, A>> {
     return createConstructor(name, specification);
   }
   return makeBuilder(cons, name, {


### PR DESCRIPTION
## Motivation

Simplify getting interactor specification for composing/reuse actions/filters between interactors

## Approach

Add `specification` static prop for interactor's constructor

```ts
import { Button } from '@bigtest/interactor';

const HiddenButton = Button.filters({ visible: Button.specification.filters.visible.apply });
```