### PR TITLE
Update dependencies in integrations/cypress

### DIFF
--- a/integrations/cypress/cypress/integration/interactor.spec.ts
+++ b/integrations/cypress/cypress/integration/interactor.spec.ts
@@ -1,4 +1,4 @@
-import { Button } from '../../src';
+import { Button, including, matching } from '../../src';
 
 describe('Cypress with Interactors', () => {
   beforeEach(() => {
@@ -19,5 +19,12 @@ describe('Cypress with Interactors', () => {
         Button('SIGN IN').exists(),
         Button('LOG OUT').absent()
       ]);
-  })
+  });
+  it('interactors with matchers', () => {
+    cy
+      .expect([
+        Button(including('SIGN')).exists(),
+        Button(matching(/SI(.*)IN/)).exists()
+      ]);
+  });
 });

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -14,8 +14,8 @@
     "README.md"
   ],
   "dependencies": {
-    "@bigtest/globals": "^0.7.4",
-    "@bigtest/interactor": "^0.26.0",
+    "@bigtest/globals": "^0.7.5",
+    "@bigtest/interactor": "^0.28.2",
     "cypress": "^5.6.0"
   },
   "scripts": {

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/cypress",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Cypress Integration for BigTest Interactors",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/integrations/cypress/yarn.lock
+++ b/integrations/cypress/yarn.lock
@@ -23,20 +23,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@bigtest/globals@^0.7.3":
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/@bigtest/globals/-/globals-0.7.3.tgz#92653740142879e1da8123c1b049218cf34f357f"
-  integrity sha512-r9+M62SiRXUB4M1jKqzXj1u90/VtGlIUfmxPyq6J7Zh+Cr4lVyOSBnXbNXC5R2JF4tvHb+frNMt8TMz0Vge5Fg==
+"@bigtest/globals@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@bigtest/globals/-/globals-0.7.5.tgz#b958321276c5548b6e1fc20b20aa8c7b8cd28b1e"
+  integrity sha512-69Z6/eN1LyavydNDQhGD7jVPbNthPdyT6mVWNFu41yy2CtufMkATX+7TNBNm1jHtZ3Z6GKkFH8BKZMGq3o6HSQ==
   dependencies:
-    "@bigtest/suite" "^0.11.1"
-    effection "^0.7.0"
+    "@bigtest/suite" "^0.11.2"
+    effection "^0.8.0"
 
-"@bigtest/interactor@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.23.0.tgz#41a01c16e23a6ef0dfa5f76816f77654cd80e619"
-  integrity sha512-Q07Tc3gniyCwpvmOBxv+gk8ulzUBJPTH0p6AlNVtW3HUR7vdT6mZYYHNqqMx9xSZqWyDz7oxg51et8XvjpvaLg==
+"@bigtest/interactor@^0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.28.2.tgz#52fcfc15a95f798cff4494eeb81755c833058c37"
+  integrity sha512-fUlFI6c5uAhK29lBMCj0UQXxnjK+f/aeodHF0FhYbkA/2vPzSdvGvmtDt33mqoaCp8Lo/jhtaftbrd3pTK53oA==
   dependencies:
-    "@bigtest/globals" "^0.7.3"
+    "@bigtest/globals" "^0.7.5"
     "@bigtest/performance" "^0.5.0"
     change-case "^4.1.1"
     element-is-visible "^1.0.0"
@@ -47,10 +47,10 @@
   resolved "https://registry.yarnpkg.com/@bigtest/performance/-/performance-0.5.0.tgz#195f2c445cbe2ebe4357e08f7b39449240bf62d7"
   integrity sha512-5lmaul6UIdyEApxapYumCShEdKca7PjwYlcIHiu/5iI032DUQsq4dygYMX07cgevfCZSR2fss57uMGfdB22GbQ==
 
-"@bigtest/suite@^0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@bigtest/suite/-/suite-0.11.1.tgz#00cf3ebb9f50d0c68ebcd22c4179b4849f377159"
-  integrity sha512-//QRi5TKLGpR6hoRlbD6aUwmGPWcx7D/+yKXGicXjV8Bqs8tDJ+rocqmX+1CrnqulZBtGf5VkcC/KavJRstlcA==
+"@bigtest/suite@^0.11.2":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@bigtest/suite/-/suite-0.11.3.tgz#f6c915ad91c69567d8585f8f4efe479b1e1b1ba0"
+  integrity sha512-50M5zC0xjEE9maNayWNNUKatR6NSEPrwNOVjEZKVRL3n3DdNwBV5OIE2xuwVIaWz1Wgbdg/lsojLefRNzOIapA==
 
 "@cypress/listr-verbose-renderer@^0.4.1":
   version "0.4.1"
@@ -816,10 +816,10 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-effection@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-0.7.0.tgz#9cdb74d075021af0715c18124038d3b0dca01363"
-  integrity sha512-p9Y1YiFI/WH5L1DzGJg/RFPFQgpXyHd1xKvGpFkzR8ah/nUGdcDtXHavj9wJgPpuHtxM2ef5YPXA7ySMmuEa1w==
+effection@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-0.8.0.tgz#55426e611825af610ac31858496853319d757126"
+  integrity sha512-sohyRJ+StqWnPWbTe+0n9SdZUzXlCphHRVjAIEpJZ1UXGe/RyWX5HL1woxQYcfD6HngBEnpLh2Knx0II2IT0Iw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Motivation

The current `@bigtest/cypress` package does not include the latest features from interactor such as matchers.

## Approach

- `@bigtest/globals` from `0.7.4` to `0.7.5` to include the effection dependencies bump to `v1`
- `@bigtest/interactor` from `0.26.0` to `0.28.2`. The detailed changes can be seen in the [CHANGELOG](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/CHANGELOG.md), but basically it's to include matchers and other minor changes such as using `innerText` instead of `text` for default locators
- Added matchers tests for integrations
  - Not sure if it was necessary but I wanted to be extra sure that it works
- Manual bump of `@bigtest/cypress` to `0.0.4` because changeset doesn't support multiple workspaces