### PR TITLE
fix: add types restrition for test builder

### DIFF
--- a/packages/suite/test/dsl.test.ts
+++ b/packages/suite/test/dsl.test.ts
@@ -40,16 +40,25 @@ describe('dsl', () => {
 
   it('prevents adding steps after adding assertions', () => {
     let base = test('an assertion').assertion("hello", noop)
-    expect(() => base.step('foo', noop)).toThrowError()
+    expect(
+      //@ts-expect-error test runtime exception
+      () => base.step('foo', noop)
+    ).toThrowError()
   });
 
   it('prevents adding steps after adding child', () => {
     let base = test('an assertion').child('foo', (test) => test)
-    expect(() => base.step('foo', noop)).toThrowError()
+    expect(
+      //@ts-expect-error test runtime exception
+      () => base.step('foo', noop)
+    ).toThrowError()
   });
 
   it('prevents adding assertions after adding child', () => {
     let base = test('an assertion').child('foo', (test) => test)
-    expect(() => base.assertion('foo', noop)).toThrowError()
+    expect(
+      //@ts-expect-error test runtime exception
+      () => base.assertion('foo', noop)
+    ).toThrowError()
   });
 })


### PR DESCRIPTION
## Motivation

if you are trying to write an invalid sequence in tests, it will nice to get the feedback earlier than get an exception on runtime

## Approach

Solution pretty simple, add `Omit` for methods' return type

### Possible Drawbacks or Risks

It's still possible to run these methods in runtime, but we throw an understandable error. So I think everything is ok.
