### PR TITLE
Moves analytics to Plausible instead of GA

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -111,9 +111,6 @@ module.exports = {
       ],
       copyright: `Copyright © ${new Date().getFullYear()} The Frontside Software, Inc.`,
     },
-    googleAnalytics: {
-      trackingID: 'UA-44597640-4'
-    },
     image: 'images/meta-image.png'
   },
   presets: [
@@ -132,4 +129,12 @@ module.exports = {
   stylesheets: [
     'https://use.typekit.net/gyc5wys.css'
   ],
+  scripts: [
+    {
+      src: 'https://plausible.io/js/plausible.js',
+      async: true,
+      defer: true,
+      'data-domain': 'frontside.com/bigtest'
+    }
+  ]
 };


### PR DESCRIPTION
## Motivation

As an Open Source project, I think Google Analytics is the wrong choice for analytics. We're commodifying our users and feeding adtech, plus we're getting _nothing_ in return. Also, It is technically not legal for us to use Google Analytics without having the annoying cookie prompt.

## Approach

Early on the year, I made some research on the tracking tools available that were privacy mindful. I tried about three, and found [Plausible](https://plausible.io/) to be the best. I also moved OpenMic to use this tracking system. 