### PR TITLE
Refactor sample app scripts to effection v2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+sample/**/yarn.lock binary
+sample/**/package-lock.json binary

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -19,7 +19,7 @@
     "cypress": "^5.6.0"
   },
   "scripts": {
-    "start": "cd ../../sample/ && npm run start -- -p 3000",
+    "start": "cd ../../sample/ && npm install && npm run start -- -p 3000",
     "cypress:run": "npx cypress run --spec 'cypress/integration/*.spec.ts'",
     "test": "start-server-and-test 'npm run start' http://localhost:3000 cypress:run",
     "prepack": "tsc --build",

--- a/sample/app/package-lock.json
+++ b/sample/app/package-lock.json
@@ -1202,12 +1202,12 @@
       }
     },
     "@bigtest/cypress": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@bigtest/cypress/-/cypress-0.0.2.tgz",
-      "integrity": "sha512-hu953aeEUx91xNNClVuhXlPLCxLDWtVm9rgviQK8GiM9JWM6+NDSLoVX18T44x5he6otn1wI/o+n0nx+cI2k2Q==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@bigtest/cypress/-/cypress-0.0.4.tgz",
+      "integrity": "sha512-JP/6skkBNOd1yh1P1L+q4i9IFf3XP6CT9AqQ4FnTD1SyJvR6BDVrrXCN/4GJoX/fV1zHiNjEBvKvT1LN1KVB/g==",
       "requires": {
-        "@bigtest/globals": "^0.7.3",
-        "@bigtest/interactor": "^0.23.0",
+        "@bigtest/globals": "^0.7.5",
+        "@bigtest/interactor": "^0.28.2",
         "cypress": "^5.6.0"
       }
     },
@@ -1268,11 +1268,11 @@
       }
     },
     "@bigtest/interactor": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@bigtest/interactor/-/interactor-0.23.0.tgz",
-      "integrity": "sha512-Q07Tc3gniyCwpvmOBxv+gk8ulzUBJPTH0p6AlNVtW3HUR7vdT6mZYYHNqqMx9xSZqWyDz7oxg51et8XvjpvaLg==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@bigtest/interactor/-/interactor-0.28.2.tgz",
+      "integrity": "sha512-fUlFI6c5uAhK29lBMCj0UQXxnjK+f/aeodHF0FhYbkA/2vPzSdvGvmtDt33mqoaCp8Lo/jhtaftbrd3pTK53oA==",
       "requires": {
-        "@bigtest/globals": "^0.7.3",
+        "@bigtest/globals": "^0.7.5",
         "@bigtest/performance": "^0.5.0",
         "change-case": "^4.1.1",
         "element-is-visible": "^1.0.0",
@@ -7101,19 +7101,6 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7122,21 +7109,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "hosted-git-info": {
@@ -8030,6 +8002,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "is-url": {
       "version": "1.2.4",
@@ -9655,11 +9632,12 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "log-symbols": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
-      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
       "requires": {
-        "chalk": "^4.0.0"
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9935,15 +9913,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
-    },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -12677,23 +12646,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -12932,57 +12884,6 @@
       "version": "17.0.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
-    },
-    "react-router": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
-      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
-      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      }
     },
     "react-shallow-renderer": {
       "version": "16.14.1",
@@ -13320,11 +13221,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14980,16 +14876,6 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
-    "tiny-invariant": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
-      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -15796,11 +15682,6 @@
       "requires": {
         "builtins": "^1.0.3"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/sample/app/yarn.lock
+++ b/sample/app/yarn.lock
@@ -1041,7 +1041,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.8.4":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -1202,13 +1202,13 @@
     effection "^0.8.0"
     websocket "^1.0.31"
 
-"@bigtest/cypress@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@bigtest/cypress/-/cypress-0.0.2.tgz#bc24cf17de0b68ca203f2b9edff587b4ea890cf6"
-  integrity sha512-hu953aeEUx91xNNClVuhXlPLCxLDWtVm9rgviQK8GiM9JWM6+NDSLoVX18T44x5he6otn1wI/o+n0nx+cI2k2Q==
+"@bigtest/cypress@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@bigtest/cypress/-/cypress-0.0.4.tgz#df3c6f43efc49a72da04ee922b791010617bb096"
+  integrity sha512-JP/6skkBNOd1yh1P1L+q4i9IFf3XP6CT9AqQ4FnTD1SyJvR6BDVrrXCN/4GJoX/fV1zHiNjEBvKvT1LN1KVB/g==
   dependencies:
-    "@bigtest/globals" "^0.7.3"
-    "@bigtest/interactor" "^0.23.0"
+    "@bigtest/globals" "^0.7.5"
+    "@bigtest/interactor" "^0.28.2"
     cypress "^5.6.0"
 
 "@bigtest/driver@^0.5.6":
@@ -1241,7 +1241,7 @@
     "@types/node" "^13.13.4"
     effection "^0.8.0"
 
-"@bigtest/globals@^0.7.3", "@bigtest/globals@^0.7.5":
+"@bigtest/globals@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@bigtest/globals/-/globals-0.7.5.tgz#b958321276c5548b6e1fc20b20aa8c7b8cd28b1e"
   integrity sha512-69Z6/eN1LyavydNDQhGD7jVPbNthPdyT6mVWNFu41yy2CtufMkATX+7TNBNm1jHtZ3Z6GKkFH8BKZMGq3o6HSQ==
@@ -1249,23 +1249,12 @@
     "@bigtest/suite" "^0.11.2"
     effection "^0.8.0"
 
-"@bigtest/interactor@0.28.2":
+"@bigtest/interactor@0.28.2", "@bigtest/interactor@^0.28.2":
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.28.2.tgz#52fcfc15a95f798cff4494eeb81755c833058c37"
   integrity sha512-fUlFI6c5uAhK29lBMCj0UQXxnjK+f/aeodHF0FhYbkA/2vPzSdvGvmtDt33mqoaCp8Lo/jhtaftbrd3pTK53oA==
   dependencies:
     "@bigtest/globals" "^0.7.5"
-    "@bigtest/performance" "^0.5.0"
-    change-case "^4.1.1"
-    element-is-visible "^1.0.0"
-    lodash.isequal "^4.5.0"
-
-"@bigtest/interactor@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.23.0.tgz#41a01c16e23a6ef0dfa5f76816f77654cd80e619"
-  integrity sha512-Q07Tc3gniyCwpvmOBxv+gk8ulzUBJPTH0p6AlNVtW3HUR7vdT6mZYYHNqqMx9xSZqWyDz7oxg51et8XvjpvaLg==
-  dependencies:
-    "@bigtest/globals" "^0.7.3"
     "@bigtest/performance" "^0.5.0"
     change-case "^4.1.1"
     element-is-visible "^1.0.0"
@@ -5505,18 +5494,6 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
-history@^4.9.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
-  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    loose-envify "^1.2.0"
-    resolve-pathname "^3.0.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-    value-equal "^1.0.1"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5525,13 +5502,6 @@ hmac-drbg@^1.0.1:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^3.1.0:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
-  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
-  dependencies:
-    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.8.8"
@@ -7140,7 +7110,7 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7361,14 +7331,6 @@ mimic-response@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
-
-mini-create-react-context@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
-  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
-  dependencies:
-    "@babel/runtime" "^7.12.1"
-    tiny-warning "^1.0.3"
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -8233,13 +8195,6 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^1.7.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
@@ -8780,15 +8735,6 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2:
-  version "15.7.2"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
-  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
-  dependencies:
-    loose-envify "^1.4.0"
-    object-assign "^4.1.1"
-    react-is "^16.8.1"
-
 proto-list@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
@@ -8988,40 +8934,6 @@ react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
-
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
-  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-router-dom@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
-  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    loose-envify "^1.3.1"
-    prop-types "^15.6.2"
-    react-router "5.2.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
-
-react-router@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
-  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    history "^4.9.0"
-    hoist-non-react-statics "^3.1.0"
-    loose-envify "^1.3.1"
-    mini-create-react-context "^0.4.0"
-    path-to-regexp "^1.7.0"
-    prop-types "^15.6.2"
-    react-is "^16.6.0"
-    tiny-invariant "^1.0.2"
-    tiny-warning "^1.0.0"
 
 react-shallow-renderer@^16.13.1:
   version "16.14.1"
@@ -9342,11 +9254,6 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
-
-resolve-pathname@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
-  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -10377,16 +10284,6 @@ tiny-inflate@^1.0.0:
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
-tiny-invariant@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
-  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
-
-tiny-warning@^1.0.0, tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -10916,11 +10813,6 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
-
-value-equal@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
-  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"

--- a/sample/bin/console-helpers.js
+++ b/sample/bin/console-helpers.js
@@ -1,21 +1,23 @@
 const chalk = require('chalk');
-const { spawn, timeout } = require('effection');
+const { sleep } = require('effection');
 
-function* spin(message, operation){
-  yield spawn(function* () {
-    const spinner = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
-    let frameNumber = 0;
-    try {
-      while(true) {
-        let spinnerGlyph = chalk`{yellow ${spinner[frameNumber++ % spinner.length]}}`;
-        process.stdout.write('\u001b[0G' + spinnerGlyph + ' ' + message + '\u001b[0m');
-        yield timeout(30);
+function spin(message, operation){
+  return function*(task){
+    yield task.spawn(function* () {
+      const spinner = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
+      let frameNumber = 0;
+      try {
+        while(true) {
+          let spinnerGlyph = chalk`{yellow ${spinner[frameNumber++ % spinner.length]}}`;
+          process.stdout.write('\u001b[0G' + spinnerGlyph + ' ' + message + '\u001b[0m');
+          yield sleep(30);
+        };
+      } finally {
+        process.stdout.write('\u001b[0G\u001b[2K');
       };
-    } finally {
-      process.stdout.write('\u001b[0G\u001b[2K');
-    };
-  });
-  return yield operation;
+    });
+    return yield operation;
+  };
 };
 
 const formatErr = (err) => {

--- a/sample/bin/console-helpers.js
+++ b/sample/bin/console-helpers.js
@@ -3,7 +3,7 @@ const { sleep } = require('effection');
 
 function spin(message, operation){
   return function*(task){
-    yield task.spawn(function* () {
+    task.spawn(function* () {
       const spinner = ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'];
       let frameNumber = 0;
       try {

--- a/sample/bin/create-sample-app.js
+++ b/sample/bin/create-sample-app.js
@@ -26,7 +26,7 @@ async function createDirectory(message) {
 
 function migrate(messages) {
   return function*(){
-    yield spin(messages.before, function* () {  
+     yield spin(messages.before, function* () {
       yield fsp.readdir(SOURCE_DIR).then(files => files.forEach((file) => {
         if(file === 'app-pkg.json'){
           fs.renameSync(`${SOURCE_DIR}/app-pkg.json`, `${TARGET_DIR}/package.json`);

--- a/sample/bin/create-sample-app.js
+++ b/sample/bin/create-sample-app.js
@@ -24,22 +24,26 @@ async function createDirectory(message) {
   };
 };
 
-function* migrate(messages) {
-  yield spin(messages.before, function* () {  
-    yield fsp.readdir(SOURCE_DIR).then(files => files.forEach((file) => {
-      if(file === 'app-pkg.json'){
-        fs.renameSync(`${SOURCE_DIR}/app-pkg.json`, `${TARGET_DIR}/package.json`);
-      } else {
-        fs.renameSync(`${SOURCE_DIR}/${file}`, `${TARGET_DIR}/${file}`);
-      };
-    }));
-  });
-  console.log(formatSuccess(messages.after));
+function migrate(messages) {
+  return function*(){
+    yield spin(messages.before, function* () {  
+      yield fsp.readdir(SOURCE_DIR).then(files => files.forEach((file) => {
+        if(file === 'app-pkg.json'){
+          fs.renameSync(`${SOURCE_DIR}/app-pkg.json`, `${TARGET_DIR}/package.json`);
+        } else {
+          fs.renameSync(`${SOURCE_DIR}/${file}`, `${TARGET_DIR}/${file}`);
+        };
+      }));
+    });
+    console.log(formatSuccess(messages.after));
+  }
 };
 
-function* installDependencies(messages) {
-  yield spin(messages.before, install({ cwd: TARGET_DIR }));
-  console.log(formatSuccess(messages.after));
+function installDependencies(messages) {
+  return function*() {
+    yield spin(messages.before, install({ cwd: TARGET_DIR }));
+    console.log(formatSuccess(messages.after));
+  }
 };
 
 function* run() {

--- a/sample/bin/install.js
+++ b/sample/bin/install.js
@@ -5,10 +5,10 @@ function install({ cwd, stdio }) {
     let command = process.argv.includes('-Y') || process.argv.includes('-yarn') ? 'yarn' : 'npm';
     let install = exec(`${command} install`, { cwd }).run(task);
     if(stdio === 'inherit'){
-      yield task.spawn(install.stdout.forEach((data) => {
+      task.spawn(install.stdout.forEach((data) => {
         process.stdout.write(data);
       }));
-      yield task.spawn(install.stderr.forEach((data) => {
+      task.spawn(install.stderr.forEach((data) => {
         process.stderr.write(data);
       }));
     };

--- a/sample/bin/install.js
+++ b/sample/bin/install.js
@@ -1,21 +1,19 @@
 const { exec } = require('@effection/node');
-const { subscribe } = require('@effection/subscription');
-const { spawn } = require('effection');
 
-function* install({ cwd, stdio }) {  
-  let command = process.argv.includes('-Y') || process.argv.includes('-yarn') ? 'yarn' : 'npm';
-  let install = yield exec(`${command} install`, { cwd });
-  if(stdio === 'inherit'){
-    yield spawn(subscribe(install.stdout).forEach((data) => {
-      process.stdout.write(data);
-      return Promise.resolve();
-    }));
-    yield spawn(subscribe(install.stderr).forEach((data) => {
-      process.stderr.write(data);
-      return Promise.resolve();
-    }));
-  };
-  yield install.expect();
+function install({ cwd, stdio }) {  
+  return function*(task){
+    let command = process.argv.includes('-Y') || process.argv.includes('-yarn') ? 'yarn' : 'npm';
+    let install = exec(`${command} install`, { cwd }).run(task);
+    if(stdio === 'inherit'){
+      yield task.spawn(install.stdout.forEach((data) => {
+        process.stdout.write(data);
+      }));
+      yield task.spawn(install.stderr.forEach((data) => {
+        process.stderr.write(data);
+      }));
+    };
+    yield install.expect();
+  }
 };
 
 module.exports = {

--- a/sample/bin/start-dev.js
+++ b/sample/bin/start-dev.js
@@ -22,11 +22,11 @@ function* dev(task) {
 
   let { stdout, stderr } = daemon(`${command} ${args.join(' ')}`).run(task);
 
-  yield task.spawn(stdout.forEach((data) => {
+  task.spawn(stdout.forEach((data) => {
     process.stdout.write(data);
   }));
   
-  yield task.spawn(stderr.forEach((data) => {
+  task.spawn(stderr.forEach((data) => {
     process.stderr.write(data);
   }));
 

--- a/sample/bin/start-dev.js
+++ b/sample/bin/start-dev.js
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
 const { daemon, main } = require('@effection/node');
-const { spawn } = require('effection');
-const { subscribe } = require('@effection/subscription');
 const fs = require('fs');
 const fsp = fs.promises;
 const { install } = require('./install');
 
-function* dev() {
+function* dev(task) {
   let command = process.argv.includes('-Y') || process.argv.includes('-yarn') ? 'yarn' : 'npx';
 
   let appStartScript = JSON.parse(fs.readFileSync('./app-pkg.json')).scripts.start;
@@ -22,16 +20,14 @@ function* dev() {
   yield fsp.copyFile('app-pkg.json', 'package.json');
   yield install({ stdio: 'inherit' });
 
-  let { stdout, stderr } = yield daemon(`${command} ${args.join(' ')}`);
+  let { stdout, stderr } = daemon(`${command} ${args.join(' ')}`).run(task);
 
-  yield spawn(subscribe(stdout).forEach((data) => {
+  yield task.spawn(stdout.forEach((data) => {
     process.stdout.write(data);
-    return Promise.resolve();
   }));
   
-  yield spawn(subscribe(stderr).forEach((data) => {
+  yield task.spawn(stderr.forEach((data) => {
     process.stderr.write(data);
-    return Promise.resolve();
   }));
 
   yield;

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigtest-sample",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "BigTest Sample App",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.com>",

--- a/sample/package.json
+++ b/sample/package.json
@@ -16,11 +16,11 @@
     "sample": "./bin/create-sample-app.js"
   },
   "dependencies": {
-    "@effection/events": "^1.0.0",
-    "@effection/node": "^1.0.1",
-    "@effection/subscription": "^1.0.0",
+    "@effection/events": "2.0.0-preview.5",
+    "@effection/node": "2.0.0-preview.7",
+    "@effection/subscription": "2.0.0-preview.6",
     "chalk": "^4.1.0",
-    "effection": "^1.0.0",
+    "effection": "2.0.0-preview.7",
     "rimraf": "^3.0.2"
   },
   "devDependencies": {

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -23,42 +23,47 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@effection/channel@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@effection/channel/-/channel-1.0.0.tgz#6f41e210d3bf88298784f6716a074d834246e381"
-  integrity sha512-uMzvWqGxWu9pBMEHKk/NqPuL4sg1Fg4W2nsdv14yn+y7JXl1lTAFMk0t8prwnZCLMGEew1NxwwdnFiD9Q6Mrhw==
+"@effection/channel@2.0.0-preview.6":
+  version "2.0.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@effection/channel/-/channel-2.0.0-preview.6.tgz#526859964f599377c1a0ffa9e2c1c613d7ecc121"
+  integrity sha512-8H/+YXl3JaTCic+9sSYK4HTcH4TU7fSZd4xHwY/GmA7f525CZQ960eR1mGfuosYtLYyNJ68rhUIbDnR5R6Vf4Q==
   dependencies:
-    "@effection/events" "^1.0.0"
-    "@effection/subscription" "^1.0.0"
-    effection "^1.0.0"
+    "@effection/core" "2.0.0-preview.6"
+    "@effection/events" "2.0.0-preview.5"
+    "@effection/subscription" "2.0.0-preview.6"
 
-"@effection/events@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@effection/events/-/events-1.0.0.tgz#4430ed538377bf04a5efd7c3b6d40a7b4e2b0607"
-  integrity sha512-IiQLoGktVBucpCGqWInhT35a7oMeeelIK7XmWTm/35D8ViL2KBLNH700gGcXe6pAQAR0NZghbTQf1s25nt/I4w==
-  dependencies:
-    "@effection/subscription" "^1.0.0"
-    effection "^1.0.0"
+"@effection/core@2.0.0-preview.6":
+  version "2.0.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@effection/core/-/core-2.0.0-preview.6.tgz#73097a9d307b08ff7ed1b8b22cbabe515a2491f2"
+  integrity sha512-7zTTky6iw/iovzpxbiAcJ7PYudZUZO7wXYK74ajqx+N25eanj4FtjlYeQeR93bXoUNl+GtqlP0RzlsiSY1/39g==
 
-"@effection/node@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@effection/node/-/node-1.0.1.tgz#ea37041046a592b1f02ca397810c6c811806948e"
-  integrity sha512-mbgpMeLhyLYcVFgInOWnXNb1DPC3ZnijIVdA+VFfa9tnzUuUP0ZpeAVMgdMcaclx1pD4f/WPmCCV93w37O/66Q==
+"@effection/events@2.0.0-preview.5":
+  version "2.0.0-preview.5"
+  resolved "https://registry.yarnpkg.com/@effection/events/-/events-2.0.0-preview.5.tgz#11edf939712c062865b0bded2565d7327370ac4b"
+  integrity sha512-hJiYZ2po19aitkFHtHL1UhbqCtt6IV2mH5sJrLcoDi26EZesILW3KTtTz5hTeUERWeAMBjrSE2zSnbHPFD7SQw==
   dependencies:
-    "@effection/channel" "^1.0.0"
-    "@effection/events" "^1.0.0"
-    "@effection/subscription" "^1.0.0"
+    "@effection/core" "2.0.0-preview.6"
+    "@effection/subscription" "2.0.0-preview.6"
+
+"@effection/node@2.0.0-preview.7":
+  version "2.0.0-preview.7"
+  resolved "https://registry.yarnpkg.com/@effection/node/-/node-2.0.0-preview.7.tgz#594518d225ac8d2ba3f913f3f7b9bcb23ef155e9"
+  integrity sha512-ZBDN8VpY+jJ2W3L3NadMah8pY8mG8qdp5dSTucnhW7B8l5wEe+Hy1pR9a+o75WUdnnAurbpY9Q7uvmpqOs1OqQ==
+  dependencies:
+    "@effection/channel" "2.0.0-preview.6"
+    "@effection/core" "2.0.0-preview.6"
+    "@effection/events" "2.0.0-preview.5"
+    "@effection/subscription" "2.0.0-preview.6"
     cross-spawn "^7.0.3"
     ctrlc-windows "^1.0.3"
-    effection "^1.0.0"
     shellwords "^0.1.1"
 
-"@effection/subscription@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@effection/subscription/-/subscription-1.0.0.tgz#331cc08f8ebc5a09be705532d93d4d308e31ff44"
-  integrity sha512-Uldp70Yv/i8vbP+f7vr7U14YMT7iZUm8yrsWKcNUCGOypM8kCPXX3ihtvJ+P3ZpFShecfFQQpjblIVaBEkx37g==
+"@effection/subscription@2.0.0-preview.6":
+  version "2.0.0-preview.6"
+  resolved "https://registry.yarnpkg.com/@effection/subscription/-/subscription-2.0.0-preview.6.tgz#0a026491e4ea6fd1a0f3074fc206eac1ccc36611"
+  integrity sha512-LGt+36j1PcTDlcOOvmziGlKKAGWlPK5w5qSGnYlUXURZOc5iGKHK+h0KN1c0ihjl8M8Ma8ICYWZs6nlhU5+reA==
   dependencies:
-    effection "^1.0.0"
+    "@effection/core" "2.0.0-preview.6"
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -502,10 +507,15 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-effection@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-1.0.0.tgz#7c20ee4ea6e63fddb5a51461dda8009b649b4195"
-  integrity sha512-ITAAnuI7sJqKhjvYlnm66NHaW7zrXzqgsGsjVaaqFHYDWPN8WylVj46xASfkrtwq5wmklbzy6tvRYaj2C4rDHw==
+effection@2.0.0-preview.7:
+  version "2.0.0-preview.7"
+  resolved "https://registry.yarnpkg.com/effection/-/effection-2.0.0-preview.7.tgz#0b648c3b798f07ff25d16bbf486377dc34a154d2"
+  integrity sha512-XI655DxwC7cQaq6jYf5IDX2nxGf5q90w4It5cjkOh0JzzPJzaEa/PFwMMBC50xMv2o3KJgsSjEKHGDRvN7nc/w==
+  dependencies:
+    "@effection/channel" "2.0.0-preview.6"
+    "@effection/core" "2.0.0-preview.6"
+    "@effection/events" "2.0.0-preview.5"
+    "@effection/subscription" "2.0.0-preview.6"
 
 emoji-regex@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
## Motivation

To refactor `effection` in the sample app scripts from `v1` to `v2-preview`.

## Approach
- Updated the effection dependencies to the latest preview packages:
![Screen Shot 2021-04-07 at 9 59 59 AM](https://user-images.githubusercontent.com/29791650/113878946-0e86e500-9788-11eb-8028-5c946e0e88bd.png)
- Had to add `npm install` in the app-start script for `integrations/`. I believe it was working previously because the monorepo already had dependencies on effection?
![Screen Shot 2021-04-07 at 10 01 33 AM](https://user-images.githubusercontent.com/29791650/113879165-3f671a00-9788-11eb-9166-b8a461064585.png)

- To manually confirm that these new changes are working, there are two entry points to the sample app scripts:
  1. `start-dev.js` - for building and starting the app from the bigtest monorepo
      - run `yarn --cwd sample start` from the monorepo
  2. `create-sample-app.js` - for consuming by running `npx bigtest-sample`
      - `npx bigtest-sample@0.0.10-696f050b`