### PR TITLE
Change matcher format() to description()

### DIFF
--- a/.changeset/interactor-format-bye.md
+++ b/.changeset/interactor-format-bye.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Deprecate matchers' format() for description()

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -154,7 +154,7 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
           let element = resolver(options);
           let match = new MatchFilter(element, filter);
           if(!match.matches) {
-            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.formatAsExpectations()}`);
+            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.descriptionAsExpectations()}`);
           }
         });
       });

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -154,7 +154,7 @@ export function instantiateBaseInteractor<E extends Element, F extends Filters<E
           let element = resolver(options);
           let match = new MatchFilter(element, filter);
           if(!match.matches) {
-            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.descriptionAsExpectations()}`);
+            throw new FilterNotMatchingError(`${description(options)} does not match filters:\n\n${match.formatAsExpectations()}`);
           }
         });
       });

--- a/packages/interactor/src/filter.ts
+++ b/packages/interactor/src/filter.ts
@@ -1,6 +1,6 @@
 import { Filters, FilterFn, FilterObject, FilterParams, InteractorSpecification } from './specification';
 import { noCase } from 'change-case';
-import { formatMatcher } from './matcher';
+import { matcherDescription } from './matcher';
 
 export class Filter<E extends Element, F extends Filters<E>> {
   constructor(
@@ -22,7 +22,7 @@ export class Filter<E extends Element, F extends Filters<E>> {
             return `which is not ${noCase(key)}`;
           }
         } else {
-          return `with ${noCase(key)} ${formatMatcher(value)}`
+          return `with ${noCase(key)} ${matcherDescription(value)}`
         }
       }).join(' and ');
     }
@@ -40,6 +40,6 @@ export class Filter<E extends Element, F extends Filters<E>> {
   }
 
   asTableHeader(): string[] {
-    return Object.entries(this.all).map(([key, value]) => `${key}: ${formatMatcher(value)}`);
+    return Object.entries(this.all).map(([key, value]) => `${key}: ${matcherDescription(value)}`);
   }
 }

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -1,10 +1,10 @@
 import { LocatorFn } from './specification';
-import { formatMatcher, MaybeMatcher } from './matcher';
+import { matcherDescription, MaybeMatcher } from './matcher';
 
 export class Locator<E extends Element> {
   constructor(public locatorFn: LocatorFn<E>, public value: MaybeMatcher<string>) {}
 
   get description(): string {
-    return formatMatcher(this.value);
+    return matcherDescription(this.value);
   }
 }

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -2,7 +2,7 @@ import { Locator } from './locator';
 import { Filter } from './filter';
 import { Filters } from './specification';
 import { escapeHtml } from './escape-html';
-import { MaybeMatcher, applyMatcher, formatMatcher } from './matcher';
+import { MaybeMatcher, applyMatcher, matcherDescription } from './matcher';
 
 const check = (value: unknown): string => value ? "✓" : "⨯";
 
@@ -31,7 +31,7 @@ export class Match<E extends Element, F extends Filters<E>> {
 
   asTableRow(): string[] {
     if(this.matchLocator) {
-      return [this.matchLocator.format(), ...this.matchFilter.asTableRow()]
+      return [this.matchLocator.description(), ...this.matchFilter.asTableRow()]
     } else {
       return this.matchFilter.asTableRow();
     }
@@ -64,12 +64,12 @@ export class MatchLocator<E extends Element> {
     this.matches = applyMatcher(this.expected, this.actual);
   }
 
-  formatActual(): string {
+  descriptionActual(): string {
     return JSON.stringify(this.actual);
   }
 
-  format(): string {
-    return `${check(this.matches)} ${this.formatActual()}`;
+  description(): string {
+    return `${check(this.matches)} ${this.descriptionActual()}`;
   }
 
   get sortWeight(): number {
@@ -92,15 +92,15 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
   }
 
   asTableRow(): string[] {
-    return this.items.map((f) => f.format());
+    return this.items.map((f) => f.description());
   }
 
   get sortWeight(): number {
     return this.items.reduce((agg, i) => agg + i.sortWeight, 0);
   }
 
-  formatAsExpectations(): string {
-    return this.items.filter((i) => !i.matches).map((i) => i.formatAsExpectation()).join('\n\n');
+  descriptionAsExpectations(): string {
+    return this.items.filter((i) => !i.matches).map((i) => i.descriptionAsExpectation()).join('\n\n');
   }
 }
 
@@ -127,23 +127,23 @@ export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
     }
   }
 
-  formatActual(): string {
+  descriptionActual(): string {
     return JSON.stringify(this.actual);
   }
 
-  formatExpected(): string {
-    return formatMatcher(this.expected);
+  descriptionExpected(): string {
+    return matcherDescription(this.expected);
   }
 
-  format(): string {
-    return `${check(this.matches)} ${this.formatActual()}`;
+  description(): string {
+    return `${check(this.matches)} ${this.descriptionActual()}`;
   }
 
-  formatAsExpectation(): string {
+  descriptionAsExpectation(): string {
     return [
       `╒═ Filter:   ${this.key}`,
-      `├─ Expected: ${this.formatExpected()}`,
-      `└─ Received: ${this.formatActual()}`,
+      `├─ Expected: ${this.descriptionExpected()}`,
+      `└─ Received: ${this.descriptionActual()}`,
     ].join('\n')
   }
 

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -64,12 +64,12 @@ export class MatchLocator<E extends Element> {
     this.matches = applyMatcher(this.expected, this.actual);
   }
 
-  descriptionActual(): string {
+  formatActual(): string {
     return JSON.stringify(this.actual);
   }
 
   description(): string {
-    return `${check(this.matches)} ${this.descriptionActual()}`;
+    return `${check(this.matches)} ${this.formatActual()}`;
   }
 
   get sortWeight(): number {
@@ -99,8 +99,8 @@ export class MatchFilter<E extends Element, F extends Filters<E>> {
     return this.items.reduce((agg, i) => agg + i.sortWeight, 0);
   }
 
-  descriptionAsExpectations(): string {
-    return this.items.filter((i) => !i.matches).map((i) => i.descriptionAsExpectation()).join('\n\n');
+  formatAsExpectations(): string {
+    return this.items.filter((i) => !i.matches).map((i) => i.formatAsExpectation()).join('\n\n');
   }
 }
 
@@ -127,23 +127,23 @@ export class MatchFilterItem<T, E extends Element, F extends Filters<E>> {
     }
   }
 
-  descriptionActual(): string {
+  formatActual(): string {
     return JSON.stringify(this.actual);
   }
 
-  descriptionExpected(): string {
+  formatExpected(): string {
     return matcherDescription(this.expected);
   }
 
   description(): string {
-    return `${check(this.matches)} ${this.descriptionActual()}`;
+    return `${check(this.matches)} ${this.formatActual()}`;
   }
 
-  descriptionAsExpectation(): string {
+  formatAsExpectation(): string {
     return [
       `╒═ Filter:   ${this.key}`,
-      `├─ Expected: ${this.descriptionExpected()}`,
-      `└─ Received: ${this.descriptionActual()}`,
+      `├─ Expected: ${this.formatExpected()}`,
+      `└─ Received: ${this.formatActual()}`,
     ].join('\n')
   }
 

--- a/packages/interactor/src/matcher.ts
+++ b/packages/interactor/src/matcher.ts
@@ -2,18 +2,18 @@ import isEqual from 'lodash.isequal';
 
 export interface Matcher<T> {
   match(actual: T): boolean;
-  format(): string;
+  description(): string;
 }
 
 export type MaybeMatcher<T> = Matcher<T> | T;
 
 export function isMatcher<T>(value: MaybeMatcher<T>): value is Matcher<T> {
-  return value && typeof (value as Matcher<T>).match === 'function' && typeof (value as Matcher<T>).format === 'function';
+  return value && typeof (value as Matcher<T>).match === 'function' && typeof (value as Matcher<T>).description === 'function';
 }
 
-export function formatMatcher<T>(value: MaybeMatcher<T>): string {
+export function matcherDescription<T>(value: MaybeMatcher<T>): string {
   if(isMatcher(value)) {
-    return value.format();
+    return value.description();
   } else {
     return JSON.stringify(value);
   }

--- a/packages/interactor/src/matcher.ts
+++ b/packages/interactor/src/matcher.ts
@@ -1,26 +1,42 @@
 import isEqual from 'lodash.isequal';
 
-export interface Matcher<T> {
+export type Matcher<T> = NewMatcher<T> | OldMatcher<T>;
+
+export interface NewMatcher<T> {
   match(actual: T): boolean;
   description(): string;
+  format?(): never;
+}
+
+export interface OldMatcher<T> {
+  match(actual: T): boolean;
+  format(): string;
+  description?(): never;
 }
 
 export type MaybeMatcher<T> = Matcher<T> | T;
 
-export function isMatcher<T>(value: MaybeMatcher<T>): value is Matcher<T> {
-  return value && typeof (value as Matcher<T>).match === 'function' && typeof (value as Matcher<T>).description === 'function';
+export function isMatcher<T>(value: MaybeMatcher<T>): value is NewMatcher<T> {
+  return value && typeof (value as NewMatcher<T>).match === 'function' && typeof (value as NewMatcher<T>).description === 'function';
+}
+
+export function isDeprecatedMatcher<T>(value: MaybeMatcher<T>): value is OldMatcher<T> {
+  return value && typeof (value as OldMatcher<T>).match === 'function' && typeof (value as OldMatcher<T>).format === 'function';
 }
 
 export function matcherDescription<T>(value: MaybeMatcher<T>): string {
   if(isMatcher(value)) {
     return value.description();
+  } else if (isDeprecatedMatcher(value)) {
+    console.warn('DEPRECATION: format() is deprecated, use description() instead')
+    return value.format();
   } else {
     return JSON.stringify(value);
   }
 }
 
 export function applyMatcher<T>(value: MaybeMatcher<T>, actual: T): boolean {
-  if(isMatcher(value)) {
+  if(isMatcher(value) || isDeprecatedMatcher(value)) {
     return value.match(actual);
   } else {
     return isEqual(value, actual);

--- a/packages/interactor/src/matchers/and.ts
+++ b/packages/interactor/src/matchers/and.ts
@@ -1,12 +1,12 @@
-import { Matcher, MaybeMatcher, formatMatcher, applyMatcher } from '../matcher';
+import { Matcher, MaybeMatcher, matcherDescription, applyMatcher } from '../matcher';
 
 export function and<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
   return {
     match(actual: T): boolean {
       return args.every((matcher) => applyMatcher(matcher, actual));
     },
-    format(): string {
-      return args.map(formatMatcher).join(' and ');
+    description(): string {
+      return args.map(matcherDescription).join(' and ');
     },
   }
 }

--- a/packages/interactor/src/matchers/every.ts
+++ b/packages/interactor/src/matchers/every.ts
@@ -1,12 +1,12 @@
-import { Matcher, MaybeMatcher, applyMatcher, formatMatcher } from '../matcher';
+import { Matcher, MaybeMatcher, applyMatcher, matcherDescription } from '../matcher';
 
 export function every<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
   return {
     match(actual: Iterable<T>): boolean {
       return Array.from(actual).every((value) => applyMatcher(expected, value));
     },
-    format(): string {
-      return `every item ${formatMatcher(expected)}`;
+    description(): string {
+      return `every item ${matcherDescription(expected)}`;
     },
   }
 }

--- a/packages/interactor/src/matchers/including.ts
+++ b/packages/interactor/src/matchers/including.ts
@@ -5,7 +5,7 @@ export function including(subString: string): Matcher<string> {
     match(actual: string): boolean {
       return actual.includes(subString);
     },
-    format(): string {
+    description(): string {
       return `including ${JSON.stringify(subString)}`;
     },
   }

--- a/packages/interactor/src/matchers/matching.ts
+++ b/packages/interactor/src/matchers/matching.ts
@@ -5,7 +5,7 @@ export function matching(regexp: RegExp): Matcher<string> {
     match(actual: string): boolean {
       return actual.match(regexp) != null;
     },
-    format(): string {
+    description(): string {
       return `matching ${regexp}`;
     },
   }

--- a/packages/interactor/src/matchers/not.ts
+++ b/packages/interactor/src/matchers/not.ts
@@ -1,12 +1,12 @@
-import { Matcher, MaybeMatcher, formatMatcher, applyMatcher } from '../matcher';
+import { Matcher, MaybeMatcher, matcherDescription, applyMatcher } from '../matcher';
 
 export function not<T>(matcher: MaybeMatcher<T>): Matcher<T> {
   return {
     match(actual: T): boolean {
       return !applyMatcher(matcher, actual);
     },
-    format(): string {
-      return `not ${formatMatcher(matcher)}`;
+    description(): string {
+      return `not ${matcherDescription(matcher)}`;
     },
   }
 }

--- a/packages/interactor/src/matchers/or.ts
+++ b/packages/interactor/src/matchers/or.ts
@@ -1,12 +1,12 @@
-import { Matcher, MaybeMatcher, formatMatcher, applyMatcher } from '../matcher';
+import { Matcher, MaybeMatcher, matcherDescription, applyMatcher } from '../matcher';
 
 export function or<T>(...args: MaybeMatcher<T>[]): Matcher<T> {
   return {
     match(actual: T): boolean {
       return args.some((matcher) => applyMatcher(matcher, actual));
     },
-    format(): string {
-      return args.map(formatMatcher).join(' or ');
+    description(): string {
+      return args.map(matcherDescription).join(' or ');
     },
   }
 }

--- a/packages/interactor/src/matchers/some.ts
+++ b/packages/interactor/src/matchers/some.ts
@@ -1,12 +1,12 @@
-import { Matcher, MaybeMatcher, applyMatcher, formatMatcher } from '../matcher';
+import { Matcher, MaybeMatcher, applyMatcher, matcherDescription } from '../matcher';
 
 export function some<T>(expected: MaybeMatcher<T>): Matcher<Iterable<T>> {
   return {
     match(actual: Iterable<T>): boolean {
       return Array.from(actual).some((value) => applyMatcher(expected, value));
     },
-    format(): string {
-      return `some item ${formatMatcher(expected)}`;
+    description(): string {
+      return `some item ${matcherDescription(expected)}`;
     },
   }
 }

--- a/packages/interactor/test/matcher.test.ts
+++ b/packages/interactor/test/matcher.test.ts
@@ -15,7 +15,7 @@ function shouted(value: string): Matcher<string> {
     match(actual: string): boolean {
       return actual === value.toUpperCase();
     },
-    format(): string {
+    description(): string {
       return `uppercase ${JSON.stringify(value.toUpperCase())}`;
     },
   }

--- a/packages/interactor/test/matchers/and.test.ts
+++ b/packages/interactor/test/matchers/and.test.ts
@@ -6,10 +6,6 @@ import { HTML, and, including } from '../../src/index';
 
 describe('@bigtest/interactor', () => {
   describe('and', () => {
-    it('can provide description', () => {
-      expect(and('foo', including('bar')).description()).toEqual('"foo" and including "bar"');
-    });
-
     it('can check whether the given value matches all of the given matchers', async () => {
       dom(`
         <div title="hello cruel world"></div>

--- a/packages/interactor/test/matchers/and.test.ts
+++ b/packages/interactor/test/matchers/and.test.ts
@@ -7,7 +7,7 @@ import { HTML, and, including } from '../../src/index';
 describe('@bigtest/interactor', () => {
   describe('and', () => {
     it('can provide description', () => {
-      expect(and('foo', including('bar')).format()).toEqual('"foo" and including "bar"');
+      expect(and('foo', including('bar')).description()).toEqual('"foo" and including "bar"');
     });
 
     it('can check whether the given value matches all of the given matchers', async () => {

--- a/packages/interactor/test/matchers/including.test.ts
+++ b/packages/interactor/test/matchers/including.test.ts
@@ -6,10 +6,6 @@ import { HTML, including } from '../../src/index';
 
 describe('@bigtest/interactor', () => {
   describe('including', () => {
-    it('can provide description', () => {
-      expect(including('hello').description()).toEqual('including "hello"');
-    });
-
     it('can check whether the given string is contained', async () => {
       dom(`
         <div title="hello world"></div>

--- a/packages/interactor/test/matchers/including.test.ts
+++ b/packages/interactor/test/matchers/including.test.ts
@@ -7,7 +7,7 @@ import { HTML, including } from '../../src/index';
 describe('@bigtest/interactor', () => {
   describe('including', () => {
     it('can provide description', () => {
-      expect(including('hello').format()).toEqual('including "hello"');
+      expect(including('hello').description()).toEqual('including "hello"');
     });
 
     it('can check whether the given string is contained', async () => {

--- a/packages/interactor/test/matchers/matching.test.ts
+++ b/packages/interactor/test/matchers/matching.test.ts
@@ -3,21 +3,38 @@ import expect from 'expect';
 import { dom } from '../helpers';
 
 import { HTML, matching } from '../../src/index';
+import { Matcher } from '../../src/matcher';
+
+function matchingWithDeprecatedFormat(regexp: RegExp): Matcher<string> {
+  return {
+    match(actual: string): boolean {
+      return actual.match(regexp) != null;
+    },
+    format(): string {
+      return `matching ${regexp}`;
+    },
+  }
+}
 
 describe('@bigtest/interactor', () => {
+  beforeEach(() => {
+    dom(`
+      <div title="hello world"></div>
+      <div title="what the heck"></div>
+    `);
+  });
+  
   describe('matching', () => {
-    it('can provide description', () => {
-      expect(matching(/hello/).description()).toEqual('matching /hello/');
-    });
-
     it('can check whether the given string matching', async () => {
-      dom(`
-        <div title="hello world"></div>
-        <div title="what the heck"></div>
-      `);
-
       await HTML({ title: matching(/he(llo|ck)/) }).exists();
       await expect(HTML({ title: matching(/blah/) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
     });
   });
+
+  describe('matching with deprecated format() API', () => {
+    it('can check whether the given string matching', async () => {
+      await HTML({ title: matchingWithDeprecatedFormat(/he(llo|ck)/) }).exists();
+      await expect(HTML({ title: matchingWithDeprecatedFormat(/blah/) }).exists()).rejects.toHaveProperty('name', 'NoSuchElementError')
+    });
+  })
 });

--- a/packages/interactor/test/matchers/matching.test.ts
+++ b/packages/interactor/test/matchers/matching.test.ts
@@ -7,7 +7,7 @@ import { HTML, matching } from '../../src/index';
 describe('@bigtest/interactor', () => {
   describe('matching', () => {
     it('can provide description', () => {
-      expect(matching(/hello/).format()).toEqual('matching /hello/');
+      expect(matching(/hello/).description()).toEqual('matching /hello/');
     });
 
     it('can check whether the given string matching', async () => {

--- a/packages/interactor/test/matchers/not.test.ts
+++ b/packages/interactor/test/matchers/not.test.ts
@@ -10,11 +10,6 @@ const div = HTML({ id: "test-div" });
 describe('@bigtest/interactor', () => {
 
   describe('not', () => {
-    it('can provide description', () => {
-      expect(not(including('bar')).description()).toEqual('not including "bar"');
-      expect(not('bar').description()).toEqual('not "bar"');
-    });
-
     it('can check whether the filter does not match the given matcher', async () => {
       dom(`
         <div id="test-div" title="hello cruel world"></div>

--- a/packages/interactor/test/matchers/not.test.ts
+++ b/packages/interactor/test/matchers/not.test.ts
@@ -11,8 +11,8 @@ describe('@bigtest/interactor', () => {
 
   describe('not', () => {
     it('can provide description', () => {
-      expect(not(including('bar')).format()).toEqual('not including "bar"');
-      expect(not('bar').format()).toEqual('not "bar"');
+      expect(not(including('bar')).description()).toEqual('not including "bar"');
+      expect(not('bar').description()).toEqual('not "bar"');
     });
 
     it('can check whether the filter does not match the given matcher', async () => {

--- a/packages/interactor/test/matchers/or.test.ts
+++ b/packages/interactor/test/matchers/or.test.ts
@@ -7,7 +7,7 @@ import { HTML, or, including } from '../../src/index';
 describe('@bigtest/interactor', () => {
   describe('or', () => {
     it('can provide description', () => {
-      expect(or('foo', including('bar')).format()).toEqual('"foo" or including "bar"');
+      expect(or('foo', including('bar')).description()).toEqual('"foo" or including "bar"');
     });
 
     it('can check whether the given value matches any of the given matchers', async () => {

--- a/packages/interactor/test/matchers/or.test.ts
+++ b/packages/interactor/test/matchers/or.test.ts
@@ -6,10 +6,6 @@ import { HTML, or, including } from '../../src/index';
 
 describe('@bigtest/interactor', () => {
   describe('or', () => {
-    it('can provide description', () => {
-      expect(or('foo', including('bar')).description()).toEqual('"foo" or including "bar"');
-    });
-
     it('can check whether the given value matches any of the given matchers', async () => {
       dom(`
         <div title="hello cruel world"></div>

--- a/packages/interactor/types/matcher.ts
+++ b/packages/interactor/types/matcher.ts
@@ -5,7 +5,7 @@ function shouted(value: string): Matcher<string> {
     match(actual: string): boolean {
       return actual === value.toUpperCase();
     },
-    format(): string {
+    description(): string {
       return value.toUpperCase();
     }
   }
@@ -15,7 +15,7 @@ let isEven: Matcher<number> = {
   match(actual: number): boolean {
     return actual % 2 === 0;
   },
-  format(): string {
+  description(): string {
     return "is even";
   }
 }

--- a/website/docs/interactors/5-matchers.md
+++ b/website/docs/interactors/5-matchers.md
@@ -150,7 +150,7 @@ MultiSelect().has({ values: every(blueOrGreen) });
 
 ## Creating matchers from scratch
 
-To create your own matcher without the use of any of the preexisting ones, you will need to create a function that returns a `{ match(), format() }` object.
+To create your own matcher without the use of any of the preexisting ones, you will need to create a function that returns a `{ match(), description() }` object.
 
 The `match()` function is where you place all of the matcher logic. It takes one argument, `actual`, which represents the values from the interactors. Here's how the `including()` matcher is implemented:
 
@@ -160,7 +160,7 @@ export function including(subString) {
     match(actual) {
       return actual.includes(subString);
     },
-    format() {
+    description() {
       return `including ${JSON.stringify(subString)}`;
     }
   };
@@ -169,7 +169,7 @@ export function including(subString) {
 
 _You can find the source code for the `including()` matcher [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/matchers/including.ts)._
 
-And the return value from the `format()` function is to display an error message for when no interactors are found:
+And the return value from the `description()` function is to display an error message for when no interactors are found:
 
 ```
 ERROR did not find heading with id including "foo" ...
@@ -193,7 +193,7 @@ export function greaterThan(number) {
     match(actual) {
       return actual > number
     },
-    format() {
+    description() {
       return `greater than ${number}`
     }
   };


### PR DESCRIPTION
## Motivation

Currently if someone wants to construct their own matcher, they have to pass in an object that looks like this:
```js
{
  match(): { /* ... */ },
  format(): { /* ... */ }
}
```

But with this new refactor, we're renaming `format` to `description`:
```js
{
  match(): { /* ... */ },
  description(): { /* ... */ }
}
```

This will resolve #906.

## Approach

- Instead of changing `formatMatcher` to `descriptionMatcher`, I flipped it to say `matcherDescription` as that seems more descriptive in my opinion.
- Added changeset for minor bump since we're still on v0.
- Removed tests for built-in matchers that called `matcher().description()` as that's not something a user would be invoking themselves.
- Added test for the `matching` matcher with the old `format` API to ensure it still works (but will output a deprecation message in the console).
- Updated documentation.

## TODOs

- [x] ~I should probably keep `format()` in to output a message to say it's deprecated...?~ Did.