### PR TITLE
Update docs to replace `createInteractor` in favor of `extends`

### DIFF
--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -315,7 +315,7 @@ As you can see, Interactors not only make it simple to use DOM elements like Rad
 
 ### Continue learning about Interactors
 
-Try using more of the [Built-in Interactors](/docs/interactors/built-in-dom) within your tests such as `Link`, `Checkbox`, `TextField`, and more.
+Try using more of the [Built-in Interactors](/docs/interactors/built-in-dom) within your tests such as `Link`, `CheckBox`, `TextField`, and more.
 
 You’ll quickly realize how much more powerful Interactors are when combined with [Locators, Filters, and Actions](/docs/interactors/locators-filters-actions).
 

--- a/website/docs/interactors/2-built-in-dom.md
+++ b/website/docs/interactors/2-built-in-dom.md
@@ -30,6 +30,7 @@ Follow the links above to get more information on how to use these interactors t
 If your app has unique interfaces that are not covered by these built-in tools, you are encouraged to [write your own interactors](/docs/interactors/write-your-own).
 
 ### Page
+
 The `Page` interactor is unique. Unlike Big Test’s other built-in interactors, it's not designed to target one specific element but rather the whole page. It is useful for asserting for the url or title in your test environment:
 
 ```js
@@ -51,9 +52,13 @@ export default test('BigTest Runner')
   .assertion(Page.has({ title: 'BigTest Example App'}));
 ```
 
-<!-- 
 ### HTML
-todo -->
+
+The `HTML` interactor is not meant to be used directly in your tests but for _composing_ other interactors. How this interactor is used will make much more sense once you read the `Write Your Own Matchers` page. But for now you can think of the `HTML` interactor as the basic building block for all other interactors.
+
+We took many of the common HTML properties and interactions, such as `className` and `click`, and added them into the `HTML` interactor. This provides the convenience of not having to respecify these properties over and over again for each of your interactors.
+
+Take a look at the [source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts) for the `HTML` interactor to see which filters and actions were added.
 
 ## Up Next
 

--- a/website/docs/interactors/2-built-in-dom.md
+++ b/website/docs/interactors/2-built-in-dom.md
@@ -11,7 +11,6 @@ These are the default interactors that are offered out-of-the-box with BigTest:
 - [CheckBox](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/check-box.ts)
 - [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts)
 - [Heading](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/heading.ts)
-- [HTML](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts)
 - [Link](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/link.ts)
 - [MultiSelect](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/multi-select.ts)
 - [Page](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/page.ts)
@@ -24,8 +23,6 @@ As you might have seen on the [Quick Start](/docs/interactors/) page, you can im
 ```js
 import { Button, TextField } from 'bigtest';
 ```
-
-Follow the links above to get more information on how to use these interactors to test your app.
 
 If your app has unique interfaces that are not covered by these built-in tools, you are encouraged to [write your own interactors](/docs/interactors/write-your-own).
 
@@ -42,7 +39,7 @@ _The `Page` interactor is instantiated differently than the other built-in inter
 We introduced `.exists()` and `.absent()` in the [Quick Start](/docs/interactors/) section but there are also `.has()` and `.is()` Interactor assertion methods. We will discuss their details on the [Assertions](/docs/interactors/assertions) page.
 :::
 
-And when using BigTest runner, the Page interactor can be used to navigate between routes:
+And when using the BigTest runner, the Page interactor can be used to navigate between routes:
 
 ```js
 import { Page, test } from 'bigtest';
@@ -51,14 +48,6 @@ export default test('BigTest Runner')
   .step(Page.visit('/contact'))
   .assertion(Page.has({ title: 'BigTest Example App'}));
 ```
-
-### HTML
-
-You can think of the `HTML` interactor as the basic building block for all other interactors. The `HTML` interactor is not meant to be used directly in your tests but for _composing_ other interactors. How this interactor is used will make much more sense once you read the `Write Your Own Matchers` page.
-
-Many common HTML properties and interactions, such as `className` and `click`, are included in the `HTML` interactor. This provides the convenience of not having to re-specify these properties over and over again for each of your interactors.
-
-Take a look at the [source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts) for the `HTML` interactor to see which filters and actions were added.
 
 ## Up Next
 

--- a/website/docs/interactors/2-built-in-dom.md
+++ b/website/docs/interactors/2-built-in-dom.md
@@ -9,7 +9,9 @@ These are the default interactors that are offered out-of-the-box with BigTest:
 
 - [Button](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/button.ts)
 - [CheckBox](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/check-box.ts)
+- [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts)
 - [Heading](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/heading.ts)
+- [HTML](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts)
 - [Link](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/link.ts)
 - [MultiSelect](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/multi-select.ts)
 - [Page](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/page.ts)
@@ -48,6 +50,10 @@ export default test('BigTest Runner')
   .step(Page.visit('/contact'))
   .assertion(Page.has({ title: 'BigTest Example App'}));
 ```
+
+<!-- 
+### HTML
+todo -->
 
 ## Up Next
 

--- a/website/docs/interactors/2-built-in-dom.md
+++ b/website/docs/interactors/2-built-in-dom.md
@@ -54,9 +54,9 @@ export default test('BigTest Runner')
 
 ### HTML
 
-The `HTML` interactor is not meant to be used directly in your tests but for _composing_ other interactors. How this interactor is used will make much more sense once you read the `Write Your Own Matchers` page. But for now you can think of the `HTML` interactor as the basic building block for all other interactors.
+You can think of the `HTML` interactor as the basic building block for all other interactors. The `HTML` interactor is not meant to be used directly in your tests but for _composing_ other interactors. How this interactor is used will make much more sense once you read the `Write Your Own Matchers` page.
 
-We took many of the common HTML properties and interactions, such as `className` and `click`, and added them into the `HTML` interactor. This provides the convenience of not having to respecify these properties over and over again for each of your interactors.
+Many common HTML properties and interactions, such as `className` and `click`, are included in the `HTML` interactor. This provides the convenience of not having to re-specify these properties over and over again for each of your interactors.
 
 Take a look at the [source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts) for the `HTML` interactor to see which filters and actions were added.
 

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -49,7 +49,7 @@ The locator of the `TextField` interactor is the `innerText` of its associated l
 </label>
 ```
 
-_See the source code for the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor which is from where it inherits the locator function._
+_See the source code for the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor, so it has a locator function._
 :::
 
 You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why BigTest offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.
@@ -78,10 +78,10 @@ The filter object can take as many properties as you want it to:
 TextField({ id: 'username-id', placeholder: 'USERNAME', visible: true }).exists();
 ```
 
-The filters available are defined by each interactor, so look at the source code for the built-in interactors or the code for your own interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters.
+The filters available are defined by each interactor, so look at the source code for the built-in interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters.
 
 :::note
-Since the TextField interactor extends on the [FormField interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts) which extends from the [HTML interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts), the TextField interactor inherits all of the FormField and HTML interactor properties. So in total there are actually eleven filters available for the TextField interactor. 
+There are many filters available for the TextField interactor. The TextField interactor inherits all of the [FormField interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts) and [HTML interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts) properties.
 
 We will be exploring this concept more in-depth on the [Writing Interactors](/docs/interactors/write-your-own) page.
 :::

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -17,7 +17,7 @@ Button('Submit').exists();
 
 A typical user identifies a button by the words printed across it, so in this example they would consider a button with the word 'Submit' on it as the "Submit" button. Interactors use locators to make that connection.
 
-What is going on behind the scenes? Just like the user, the built-in Button interactor provided by BigTest looks for a button with "Submit" on it. It uses [element.innerText](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/button.ts#L11-L12) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.innerText` is equal to `Submit`.
+What is going on behind the scenes? Just like the user, the built-in Button interactor provided by BigTest looks for a button with "Submit" on it. It uses [element.innerText](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/button.ts#L11) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.innerText` is equal to `Submit`.
 
 ### The locator is optional
 
@@ -49,7 +49,7 @@ The locator of the `TextField` interactor is the `innerText` of its associated l
 </label>
 ```
 
-_See the source code of the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts)_.
+_See the source code of the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor which is where it inherits the locator function from._
 :::
 
 You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why BigTest offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.
@@ -78,9 +78,13 @@ The filter object can take as many properties as you want it to:
 TextField({ id: 'username-id', placeholder: 'USERNAME', visible: true }).exists();
 ```
 
-The filters available are defined by each interactor, so look at the API docs for the built-in interactors or the code for your own interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides eight different filters.
+The filters available are defined by each interactor, so look at the source code for the built-in interactors or the code for your own interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters.
 
-The [Assertions](/docs/interactors/assertions) page will cover how you can use filters to assert against Interactors in your tests. And later on the [Writing Interactors](/docs/interactors/write-your-own) page you will learn how to add your own filters to Interactors.
+:::note
+Since the TextField interactor extends on the [FormField interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts) which extends from the [HTML interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts), the TextField interactor inherits all of the FormField and HTML interactor properties. So in total there are actually eleven filters available for the TextField interactor. 
+
+We will be exploring this concept more in-depth on the [Writing Interactors](/docs/interactors/write-your-own) page.
+:::
 
 ## Actions
 

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -49,7 +49,7 @@ The locator of the `TextField` interactor is the `innerText` of its associated l
 </label>
 ```
 
-_See the source code of the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor which is where it inherits the locator function from._
+_See the source code for the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor which is from where it inherits the locator function._
 :::
 
 You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why BigTest offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -49,7 +49,7 @@ The locator of the `TextField` interactor is the `innerText` of its associated l
 </label>
 ```
 
-_See the source code for the TextField interactor [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts). The TextField interactor extends the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor, so it has a locator function._
+_This is just the way the built-in TextField interactor is configured. It is possible to modify pre-existing interactors such as this TextField interactor or create your own interactors from scratch to suit your needs. We will be going over how you can do all of this on the [Writing Interactors](/docs/interactors/write-your-own) page._
 :::
 
 You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why BigTest offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.
@@ -78,13 +78,7 @@ The filter object can take as many properties as you want it to:
 TextField({ id: 'username-id', placeholder: 'USERNAME', visible: true }).exists();
 ```
 
-The filters available are defined by each interactor, so look at the source code for the built-in interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters.
-
-:::note
-There are many filters available for the TextField interactor. The TextField interactor inherits all of the [FormField interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts) and [HTML interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts) properties.
-
-We will be exploring this concept more in-depth on the [Writing Interactors](/docs/interactors/write-your-own) page.
-:::
+The filters available are defined by each interactor, so look at the source code for the built-in interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters. In addition, TextField inherits all of the properties of the [FormField interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts) and [HTML interactor](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts).
 
 ## Actions
 
@@ -97,8 +91,6 @@ Button('Submit').click();
 ```
 
 It’s that simple! Because Interactors can only match one element, there’s no ambiguity over which submit button you clicked. Additionally, the action will not occur if the Interactor is not there, so you don’t have to worry about checking if the button exists before issuing a click action.
-
-On the [Writing Interactors](/docs/interactors/write-your-own) page we'll also explain how you can construct your own actions to suit your needs when you create your own Interactors.
 
 ## Up Next
 

--- a/website/docs/interactors/5-matchers.md
+++ b/website/docs/interactors/5-matchers.md
@@ -90,6 +90,7 @@ Heading().has({ or(id: 'foo', id: 'bar') }); // bad
 :::
 
 ### Iterable matchers
+
 For when you need to assert against iterables, you will find the `some()` and `every()` matchers very helpful. We will use the [`MultiSelect`](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/multi-select.ts#L48) interactor for the next example because its `values` filter returns an array based on its options' label:
 
 ```js
@@ -119,6 +120,7 @@ In the two tests above we are passing in the `including()` and `matching()` matc
 Though the matchers are already ergonomic, you can make your tests even tidier and easier to read by creating your own matchers. There are two ways you can write your own matcher: by piggybacking on preexisting matchers or you can create your own from scratch. We will cover both methods next.
 
 ## Composing matchers
+
 We will first go over how you can compose matchers using preexisting matchers. Let us start by creating a matcher called `hasFoo`:
 
 ```js

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -69,9 +69,9 @@ import TabItem from '@theme/TabItem';
 `fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts#L63-L76). You can use any of the functions defined by BigTest or implement your own.
 :::
 
-In the example above we're extending from the `HTML` interactor to compose the MyTextField interactor. If you take a look at the implementation of the built-in [TextField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts) interactor, you'll see that the `value` filter and `fillIn` action is already available.
+In the example above, we're extending from the `HTML` interactor to compose the MyTextField interactor. If you take a look at the implementation of the built-in [TextField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts) interactor, you'll see that the `value` filter and `fillIn` action are already available.
 
-In a more realistic scenario, if you want a TextField interactor that uses its placeholder value as its locator, you would just extend from the pre-existing TextField interactor like so:
+In a more realistic scenario, if you want a TextField interactor that uses its placeholder value as its locator, you should extend from the pre-existing TextField interactor:
 
 ```js
 import { TextField } from 'bigtest';
@@ -80,7 +80,7 @@ export const MyTextField = TextField.extend('my-textfield-interactor')
   .locator((element) => element.placeholder)
 ```
 
-This approach would allow your interactor to inherit the selector, locator, filters, and actions from the interactor it is extending from. Extending from another interactor provides the convenience of not having to rewrite common filters and actions. You can overwrite any of the inherited properties to suit your needs which is what we are doing with the locator in the example.
+This approach would allow your interactor to inherit the selector, locator, filters, and actions from the interactor it is extending from. Extending from another interactor provides the convenience of not having to rewrite common filters and actions. You can overwrite any of the inherited properties to suit your needs, which is what we are doing with the locator in the example.
 
 If we didn't provide the placeholder value as the locator, it would inherit the locator from BigTest's built-in TextField interactor which itself is inheriting its locator from the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor.
 

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -17,7 +17,7 @@ There are four things to decide when creating an interactor:
 3. The locator and filters, which helps users be able to narrow down the element they want to reference
 4. The action or actions that a test should `perform` when using the interactor (like `click`)
 
-In this case, let's call our Interactor ‘MyTextField’, and we’ll label it as ‘my-textfield-interactor’ to distinguish it from the built-in one. Let’s say that MyTextField will target a regular input with a custom class `.my-input`, which means its HTML selector would be `input[type=text].my-input`. For locator we’ll use the input’s placeholder, and we’ll define a value filter. Finally, we’ll define a `fillIn` action for MyTextField interactor. Putting this together, we get the following definition of an Interactor:
+Putting this together, let's create a new Interactor called 'MyTextField' with a label of 'my-textfield-interactor'. We'll specify the selector as `input[type=text]` so that it targets all the text input elements, define a `value` filter, and provide a `fillIn` action. And to differentiate from the built-in TextField interactor, we'll configure the placeholder value as its locator:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -32,9 +32,9 @@ import TabItem from '@theme/TabItem';
   <TabItem value="javascript">
 
   ```js
-  import { createInteractor, fillIn } from 'bigtest';
+  import { fillIn, HTML } from 'bigtest';
 
-  export const TextField = createInteractor('my-textfield-interactor')
+  export const MyTextField = HTML.extend('my-textfield-interactor')
     .selector('input[type=text]')
     .locator((element) => element.placeholder)
     .filters({
@@ -49,9 +49,9 @@ import TabItem from '@theme/TabItem';
   <TabItem value="typescript">
 
   ```ts
-  import { createInteractor, fillIn } from 'bigtest';
+  import { fillIn, HTML } from 'bigtest';
 
-  export const TextField = createInteractor<HTMLInputElement>('my-textfield-interactor')
+  export const MyTextField = HTML.extend<HTMLInputElement>('my-textfield-interactor')
     .selector('input[type=text]')
     .locator((element) => element.placeholder)
     .filters({
@@ -66,16 +66,29 @@ import TabItem from '@theme/TabItem';
 </Tabs>
 
 :::note
-`fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts). You can use any of the functions defined by BigTest or implement your own.
+`fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/fill-in.ts#L63-L76). You can use any of the functions defined by BigTest or implement your own.
 :::
+
+In the example above we're extending from the `HTML` interactor to compose the MyTextField interactor. If you take a look at the implementation of the built-in [TextField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts) interactor, you'll see that the `value` filter and `fillIn` action is already available.
+
+In a more realistic scenario, if you want a TextField interactor that uses its placeholder value as its locator, you would just extend from the pre-existing TextField interactor like so:
+
+```js
+import { TextField } from 'bigtest';
+
+export const MyTextField = TextField.extend('my-textfield-interactor')
+  .locator((element) => element.placeholder)
+```
+
+This approach would allow your interactor to inherit the selector, locator, filters, and actions from the interactor it is extending from. Extending from another interactor provides the convenience of not having to rewrite common filters and actions. You can overwrite any of the inherited properties to suit your needs which is what we are doing with the locator in the example.
+
+If we didn't provide the placeholder value as the locator, it would inherit the locator from BigTest's built-in TextField interactor which itself is inheriting its locator from the [FormField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/form-field.ts#L6) interactor.
 
 :::note Cypress
 If you're using Cypress, all of the built-in Interactors and Interactor functions will need to be imported from `@bigtest/cypress` and not `bigtest`.
 :::
 
-In this example, we've configured the selector as `input[type=text].my-input` which will search for all `<input type=‘text' class=“my-input”>` elements in your testing environment. Filters and locators are then used to narrow down the list of results.
-
-The string argument, the label, to `createInteractor()` is the name of the interactor your console will print if there's a failing test:
+The string argument to `extend()`, which we referred to as the "label" earlier, is the name of the interactor your console will print if there's a failing test:
 
 ```
 NoSuchElementError: did not find my-textfield-interactor "USERNAME"
@@ -83,12 +96,12 @@ NoSuchElementError: did not find my-textfield-interactor "USERNAME"
 
 _An example of the console output when a test is unable to locate the interactor_
 
-Locators, filters, and actions are optional when creating your own interactor. While the locator for the `TextField` interactor offered by BigTest uses the `innerText` of the associated label (as we explained on the [Locators, Filters, and Actions page](/docs/interactors/locators-filters-actions#filters)), the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of Locators to anything that suits your needs. If you create an interactor without a locator, it will default to `locator: element => element.textContent`.
+Locators, filters, and actions are optional when creating your own interactor. While the locator for the `TextField` interactor offered by BigTest uses the `innerText` of the associated label (as we explained on the [Locators, Filters, and Actions](/docs/interactors/locators-filters-actions#filters) page), the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of locators to anything that suits your needs. If you create an interactor without a locator, it would by default use the `innerText` value for its locator.
 
-You might be wondering what `interactor.perform()` does: it is a method on the interactor which ensures that there are no race conditions when working directly with elements. You can use it like this:
+You might also be wondering what `interactor.perform()` does: it is a method on the interactor which ensures that there are no race conditions when working directly with elements. You can use it like this:
 
 ```js
-createInteractor('my interactor')
+HTML.extend('my interactor')
   .actions({
     async click(interactor){
       await interactor.perform(element => element.click());
@@ -99,7 +112,7 @@ createInteractor('my interactor')
 Or you could use destructuring to make it a bit shorter:
 
 ```js
-createInteractor('my interactor')
+HTML.extend('my interactor')
   .actions({
     click: ({ perform }) => perform(element => element.click())
   });
@@ -117,9 +130,9 @@ The former syntax is necessary if you want to write an action that delegates to 
   <TabItem value="javascript">
 
   ```js
-  import { Button, createInteractor } from 'bigtest';
+  import { Button, HTML } from 'bigtest';
 
-  export const Form = createInteractor('form')
+  export const Form = HTML.extend('my-form-interactor')
     .selector('form')
     .actions({
       async submit(interactor){
@@ -132,9 +145,9 @@ The former syntax is necessary if you want to write an action that delegates to 
   <TabItem value="typescript">
 
   ```ts
-  import { Button, createInteractor } from 'bigtest';
+  import { Button, HTML } from 'bigtest';
 
-  export const Form = createInteractor<HTMLFormElement>('form')
+  export const Form = HTML.extend<HTMLFormElement>('my-form-interactor')
     .selector('form')
     .actions({
       async submit(interactor){
@@ -146,7 +159,7 @@ The former syntax is necessary if you want to write an action that delegates to 
   </TabItem>
 </Tabs>
 
-There’s two peculiarities about this example. First, notice we’re not using `perform` which means that we’re not performing an action on any element directly. Secondly, within the submit action definition you’ll notice that we’re using `find` to access another Interactor and calling its action. That’s what we mean with ‘delegating’ an action.
+There are two peculiarities about this example. First, notice we’re not using `perform` which means that we’re not performing an action on the interactors' element directly. Secondly, within the submit action definition you’ll notice that we’re using `find` to access another Interactor and calling its action. That’s what we mean with ‘delegating’ an action.
 
 Why would you want to delegate actions within an Interactor action definition? Well, it can help you avoid repeating yourself and to keep Interactors as black boxes. For example, let’s say we wanted to test that a user submits a form, without delegation we can reach in in the Form Interactor and issue a click action:
 
@@ -160,7 +173,7 @@ But if the Form component changes and now the button that submits is no longer `
 Form().submit();
 ```
 
-Let's get back to our example and add the new TextField interactor to a test. In this example we are testing an email subscription form by first filling in the email text field, clicking the `Subscribe` button, and then asserting for the success header.
+Let's get back to our example and add the new MyTextField interactor to a test. In this example we are testing an email subscription form by first filling in the email text field, clicking the `Subscribe` button, and then asserting for the success header:
 
 <Tabs
   groupId="runner"
@@ -178,13 +191,13 @@ Let's get back to our example and add the new TextField interactor to a test. In
   import App from './App';
 
   import { Button, Heading } from 'bigtest';
-  import { TextField } from './MyTextField';
+  import { MyTextField } from './MyTextField';
 
   describe('email subscription form', () => {
     beforeEach(() => render(<App />));
 
     it('fill and submit email address', async () => {
-      await TextField('EMAIL').fillIn('batman@gmail.com');
+      await MyTextField('EMAIL').fillIn('batman@gmail.com');
       await Button('Subscribe').click();
       await Heading('Success!').exists();
     });
@@ -196,14 +209,14 @@ Let's get back to our example and add the new TextField interactor to a test. In
 
   ```js
   import { Button, Heading } from '@bigtest/cypress';
-  import { TextField } from './MyTextField';
+  import { MyTextField } from './MyTextField';
 
   describe('email subscription form', () => {
     beforeEach(() => cy.visit('/'));
 
     it('fill and submit email address', () => {
       cy.do([
-        TextField('EMAIL').fillIn('batman@gmail.com');
+        MyTextField('EMAIL').fillIn('batman@gmail.com');
         Button('Subscribe').click();
       ]);
       cy.expect(Heading('Success'))
@@ -216,13 +229,13 @@ Let's get back to our example and add the new TextField interactor to a test. In
 
   ```js
   import { Button, Heading, Page, test } from 'bigtest';
-  import { TextField } from './MyTextField';
+  import { MyTextField } from './MyTextField';
 
   export default test('email subscription form')
     .step(Page.visit('/'))
     .child('fill and submit email address', test => test
       .step(
-        TextField('EMAIL').fillIn('batman@gmail.com'),
+        MyTextField('EMAIL').fillIn('batman@gmail.com'),
         Button('Subscribe').click())
       .assertion(Heading('Success!').exists()));
   ```
@@ -230,9 +243,14 @@ Let's get back to our example and add the new TextField interactor to a test. In
   </TabItem>
 </Tabs>
 
-The [TextField](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/text-field.ts) interactor from BigTest can do a lot more than this, but the example we just wrote is a good place to start when it comes to understanding how to use `createInteractor`.
+By composing our own text field interactor, we are able to use it with its new locator value without which we would have needed to use a filter for each instance:
 
-Check out the source code of [createInteractor()](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/create-interactor.ts) for more details.
+```js
+TextField({ placeholder: 'email' }).fillIn('batman@gmail.com');
+MyTextField('email').fillIn('batman@gmail.com');
+```
+
+Although the built-in interactors may cover most use cases, the composability of interactors means there is no limit to how much you can optimize and tailor them to your needs.
 
 ## Writing a more complex interactor
 
@@ -268,9 +286,9 @@ First, consider some table markup defined as follows:
 Here is one way to create the `TableCell` interactor:
 
 ```js
-import { createInteractor } from 'bigtest';
+import { HTML } from 'bigtest';
 
-export const TableCell = createInteractor('table cell')
+export const TableCell = HTML.extend('table cell')
   .selector('[role=gridcell]')
   .filters({
     columnTitle: element => {
@@ -304,7 +322,9 @@ export const TableCell = createInteractor('table cell')
 This example uses [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which is available in Node >=14.
 :::
 
-You'll notice we created `columnTitle` and `rowNumber` filters that will access its parent elements to get the appropriate value we're looking for. The locator was not specified, so it will default to `element.textContent`. We can now effectively use the TableCell interactor as we stated in the beginning of this page:
+Once again, by extending from the `HTML` interactor, our new TableCell interactor inherits all of the pre-defined filters and actions of the `HTML` interactor as defined [here](https://github.com/thefrontside/bigtest/blob/v0/packages/interactor/src/definitions/html.ts). If we needed to access a table cell's `id` property in our tests, we would not need to create a separate filter for it as it inherits it from the `HTML` interactor.
+
+Inside the TableCell interactor we created `columnTitle` and `rowNumber` filters that will access its parent elements to get the appropriate value we're looking for. The locator was not specified, so it will default to `element.innerText || element.textContent`. We can now effectively use the TableCell interactor as we stated at the beginning of this page:
 
 ```js
 TableCell({ columnTitle: 'Name', rowNumber: 2 }).has({ value: 'Marge Simpson' });
@@ -385,7 +405,7 @@ One more building block available to you is the `find` method, which helps you c
 Take for example the following DatePicker Interactor, in which we define an `open` action. We use `find` to target a button within `DatePicker`:
 
 ```js
-createInteractor('DatePicker')
+HTML.extend('DatePicker')
   .actions({
     open: (interactor) => interactor.find(Button).click()
   });


### PR DESCRIPTION
## Motivation

To resolve #844 and resolve #845. 

![Screen Shot 2021-04-30 at 12 23 53 PM](https://user-images.githubusercontent.com/29791650/116724683-f3864a00-a9ae-11eb-916e-9743067766c4.png)

## Approach

- Added `HTML` and `FormField` to [`Built-In Interactors`](https://deploy-preview-921--bigtest.netlify.app/bigtest/docs/interactors/built-in-dom) page and gave a brief description on what the `HTML` interactor is for
- Small updates to the [`Locators, Filters, and Actions`](https://deploy-preview-921--bigtest.netlify.app/bigtest/docs/interactors/locators-filters-actions) page to explain how filters are inherited from other interactors
- ❗Big updates to the [`Writing Interactors`](https://deploy-preview-921--bigtest.netlify.app/bigtest/docs/interactors/write-your-own) page to replace all instances of `createInteractor()` to `extends()`