### PR TITLE
Fix template dependencies for sample app

### DIFF
--- a/sample/bin/create-sample-app.js
+++ b/sample/bin/create-sample-app.js
@@ -2,10 +2,9 @@
 
 const { main, MainError } = require('@effection/node');
 const rmrfsync = require('rimraf').sync;
-const fs = require('fs');
-const fsp = fs.promises;
+const fsp = require('fs').promises;
+const fse = require('fs-extra');
 const path = require('path');
-const ncp = require('ncp').ncp;
 
 const { messages, generateInstructions } = require('./messages');
 const { formatErr, formatSuccess, spin } = require('./console-helpers');
@@ -18,7 +17,7 @@ const TARGET_DIR = process.env.DEV_BUILD ? `${path.dirname(__dirname)}/build`: `
 let template;
 
 async function createDirectory(message) {
-  if (fs.existsSync(TARGET_DIR)) {
+  if (fse.existsSync(TARGET_DIR)) {
     if(!process.env.DEV_BUILD){
       throw new MainError({
         message: `${formatErr('directory \'bigtest-sample\' already exists')}\n${messages.abort}`
@@ -42,8 +41,8 @@ function migrate(messages) {
 
       yield fsp.readdir(SOURCE_DIR).then(sourceFiles => sourceFiles.forEach((file) => {
         if(files.includes(file)){
-          ncp(`${SOURCE_DIR}/${file}`, `${TARGET_DIR}/${file}`);
-        };
+          fse.copySync(`${SOURCE_DIR}/${file}`, `${TARGET_DIR}/${file}`);
+        }
       }));
 
       switch(templateName){

--- a/sample/bin/create-sample-app.js
+++ b/sample/bin/create-sample-app.js
@@ -48,16 +48,16 @@ function migrate(messages) {
 
       switch(templateName){
         case 'cypress':
-          rmrfsync(`${TARGET_DIR}/src/test/*bigtest*`);
-          rmrfsync(`${TARGET_DIR}/src/test/*jest*`);
+          rmrfsync(`${TARGET_DIR}/src/test/bigtest.test.js`);
+          rmrfsync(`${TARGET_DIR}/src/test/jest.test.js`);
           break;
         case 'jest':
-          rmrfsync(`${TARGET_DIR}/src/test/*bigtest*`);
-          rmrfsync(`${TARGET_DIR}/src/test/*cypress*`);
+          rmrfsync(`${TARGET_DIR}/src/test/bigtest.test.js`);
+          rmrfsync(`${TARGET_DIR}/src/test/cypress.spec.js`);
           break;
         case 'bigtest':
-          rmrfsync(`${TARGET_DIR}/src/test/*cypress*`);
-          rmrfsync(`${TARGET_DIR}/src/test/*jest*`);
+          rmrfsync(`${TARGET_DIR}/src/test/cypress.spec.js`);
+          rmrfsync(`${TARGET_DIR}/src/test/jest.test.js`);
           break;
       };
     });

--- a/sample/bin/templates/base.js
+++ b/sample/bin/templates/base.js
@@ -16,6 +16,7 @@ const baseTemplate = ({ dependencies }) => {
         "parcel": `${dependencies.parcel}`,
         "react": `${dependencies.react}`,
         "react-dom": `${dependencies['react-dom']}`,
+        "react-router-dom": `${dependencies['react-router-dom']}`,
         "typescript": `${dependencies.typescript}`,
         "eslint": `${dependencies.eslint}`
       },

--- a/sample/bin/templates/base.js
+++ b/sample/bin/templates/base.js
@@ -18,7 +18,8 @@ const baseTemplate = ({ dependencies }) => {
         "react-dom": `${dependencies['react-dom']}`,
         "react-router-dom": `${dependencies['react-router-dom']}`,
         "typescript": `${dependencies.typescript}`,
-        "eslint": `${dependencies.eslint}`
+        "eslint": `${dependencies.eslint}`,
+        "@babel/core": `${dependencies['@babel/core']}`,
       },
       "volta": {
         "node": "12.16.0",

--- a/sample/bin/templates/cypress.js
+++ b/sample/bin/templates/cypress.js
@@ -6,7 +6,6 @@ const cypressTemplate = ({ dependencies }) => {
         "test:cypress": "start-server-and-test 'npm run start -- -p 3000' http://localhost:3000 cypress:run",
       },
       "dependencies": {
-        "@babel/core": `${dependencies['@babel/core']}`,
         "@bigtest/cypress": `${dependencies['@bigtest/cypress']}`,
         "eslint-plugin-cypress": `${dependencies['eslint-plugin-cypress']}`,
         "start-server-and-test": `${dependencies['start-server-and-test']}`

--- a/sample/bin/templates/jest.js
+++ b/sample/bin/templates/jest.js
@@ -5,7 +5,6 @@ const jestTemplate = ({ dependencies, browserslist, babel, jest }) => {
         "test:jest": "jest 'src/test/jest.test.js'",
       },
       "dependencies": {
-        "@babel/core": `${dependencies['@babel/core']}`,
         "@babel/preset-env": `${dependencies['@babel/preset-env']}`,
         "@babel/preset-react": `${dependencies['@babel/preset-react']}`,
         "@testing-library/react": `${dependencies['@testing-library/react']}`,

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bigtest-sample",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -983,6 +983,16 @@
       "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
+    "fs-extra": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
     "fs-minipass": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
@@ -1093,6 +1103,11 @@
         "merge2": "^1.3.0",
         "slash": "^3.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -1270,6 +1285,15 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -1389,11 +1413,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "ncp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
     },
     "needle": {
       "version": "2.6.0",
@@ -2024,6 +2043,11 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.4.tgz",
       "integrity": "sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==",
       "optional": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/sample/package.json
+++ b/sample/package.json
@@ -25,8 +25,8 @@
     "@effection/subscription": "2.0.0-preview.6",
     "chalk": "^4.1.0",
     "effection": "2.0.0-preview.7",
+    "fs-extra": "^10.0.0",
     "lodash.merge": "^4.6.2",
-    "ncp": "^2.0.0",
     "rimraf": "^3.0.2"
   },
   "devDependencies": {

--- a/sample/package.json
+++ b/sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigtest-sample",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "BigTest Sample App",
   "repository": "https://github.com/thefrontside/bigtest.git",
   "author": "Frontside Engineering <engineering@frontside.com>",

--- a/sample/yarn.lock
+++ b/sample/yarn.lock
@@ -736,6 +736,15 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -811,6 +820,11 @@ globby@^11.0.1:
     ignore "^5.1.4"
     merge2 "^1.3.0"
     slash "^3.0.0"
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 handlebars@^4.7.6:
   version "4.7.6"
@@ -990,6 +1004,15 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -1096,11 +1119,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
-
-ncp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
-  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 needle@^2.5.0:
   version "2.6.0"
@@ -1681,6 +1699,11 @@ uglify-js@^3.1.4:
   version "3.12.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.4.tgz#93de48bb76bb3ec0fc36563f871ba46e2ee5c7ee"
   integrity sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.0"


### PR DESCRIPTION
## Motivation

There are some missing dependencies from the templates and some hoisting issues in the sample app.

## Approach

- `parcel` is bringing in a much older version of `@babel/core @ 7.3.4` (at the root of `node_modules`) and for some reason it's conflicting with `bigtest`'s dependencies on `@babel/core @ 7.14.2` (inside `node_modules/@bigtest/**/node_modules)` (_Both `jest` and `cypress` templates require a dependency of `@babel/core` in the sample app project so this issue only affects the sample app when using the `--only bigtest` template._)
  - This can be fixed by specifying `{ "resolutions": "@babel/core": "7.14.2" }` inside package.json. However, when running the `npx bigtest-sample` command without an `--only` flag, all templates are merged together and the `resolutions` property will be included too (even though `@babel/core` would also be in dependencies).
    - One approach would be to write the script to ditch the `resolutions` property when merging all templates... or a much more simpler solution would be to just include `@babel/core` as a base dependency for all templates.
- `react-router-dom` was also missing from all of the templates. Surprisingly this was not an issue for the `bigtest` and `cypress` templates because something(?) is detecting that `react-router-dom` is missing in `package.json` and actually adds and installs it. (The automatic-modifying of package.json happens when I run `yarn bigtest ci`. 🤷‍♂️). But it wasn't doing it for `jest` which is how I came across this oversight.
- I also replaced `ncp` with `fs-extra` because `ncp` was lacking a synchronous copy function and so this whole time there was a race condition in the script.