### PR TITLE
Add `read` function to get values by using filter functions

### DIFF
--- a/.changeset/interactor-getters.md
+++ b/.changeset/interactor-getters.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Add `read` function to simplify getting values from element by using filter functions

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -109,7 +109,7 @@ export function unsafeSyncResolveParent(options: InteractorOptions<any, any, any
   return options.ancestors.reduce(resolveUnique, bigtestGlobals.document.documentElement);
 }
 
-function unsafeSyncResolveUnique<E extends Element>(options: InteractorOptions<E, any, any>): E {
+export function unsafeSyncResolveUnique<E extends Element>(options: InteractorOptions<E, any, any>): E {
   return resolveUnique(unsafeSyncResolveParent(options), options) as E;
 }
 

--- a/packages/interactor/src/index.ts
+++ b/packages/interactor/src/index.ts
@@ -4,6 +4,7 @@ export { createInteractor } from './create-interactor';
 export { createInspector } from './inspector'
 export { Page } from './page';
 export { App } from './app';
+export { read } from './read';
 export { perform } from './perform';
 export { fillIn } from './fill-in';
 export { focused, focus, blur } from './focused';

--- a/packages/interactor/src/read.ts
+++ b/packages/interactor/src/read.ts
@@ -1,0 +1,16 @@
+import { bigtestGlobals } from "@bigtest/globals";
+import { converge } from "./converge";
+import { interaction } from "./interaction";
+import { unsafeSyncResolveUnique } from './constructor'
+import { EmptyObject, FilterReturn, Interactor } from "./specification";
+
+export const read = <E extends Element, F extends EmptyObject>(interactor: Interactor<E, F>, field: keyof F): Promise<FilterReturn<F>> => {
+  let filter = interactor.options.specification.filters?.[field]
+  return interaction(`get ${field} from ${interactor.description}`, async () => {
+    if(bigtestGlobals.runnerState === 'assertion') {
+      throw new Error(`tried to get ${field} from ${interactor.description} in an assertion, getters should only be used in steps`);
+    }
+    let filterFn = typeof(filter) === 'function' ? filter : filter.apply
+    return await converge(() => filterFn(unsafeSyncResolveUnique(interactor.options)));
+  });
+}

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -178,6 +178,10 @@ export type ActionMethods<E extends Element, A extends Actions<E>> = {
     : never;
 }
 
+export type FilterReturn<F> = {
+  [P in keyof F]?: F[P] extends MaybeMatcher<infer T> ? T : never;
+}
+
 export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {
   [P in keyof F]?:
     F[P] extends FilterFn<infer TArg, E> ?

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { dom } from './helpers';
 import { bigtestGlobals } from '@bigtest/globals';
 
-import { createInteractor } from '../src/index';
+import { createInteractor, read } from '../src/index';
 
 const Link = createInteractor<HTMLLinkElement>('link')
   .selector('a')
@@ -30,6 +30,7 @@ const TextField = createInteractor<HTMLInputElement>('text field')
   .selector('input')
   .locator((element) => element.id)
   .filters({
+    id: element => element.id,
     placeholder: element => element.placeholder,
     enabled: {
       apply: (element) => !element.disabled,
@@ -496,4 +497,16 @@ describe('@bigtest/interactor', () => {
       await expect(TextField('Password', { enabled: false, value: 'test1234' }).exists()).resolves.toBeUndefined();
     });
   });
+
+  describe('getters', () => {
+    it('can return value by using filter function', async () => {
+      dom(`
+        <input id="Email" value='jonas@example.com'/>
+        <input id="Password" value='test1234'/>
+      `);
+
+      await expect(read(TextField('Password'), 'value')).resolves.toEqual('test1234')
+      await expect(read(TextField({ value: 'jonas@example.com' }), 'id')).resolves.toEqual('Email')
+    })
+  })
 });


### PR DESCRIPTION
## Motivation

There is a way to get a value out by using the `perform` method https://github.com/thefrontside/bigtest/pull/925. But we already have a few predefined getter functions that used in filters. So instead of forcing the user to copy-pasted those filters to use them in `perform`, I think there is a better approach is provide a simple way to re-use them.

## Approach

Added `read` function, that takes an interactor and filter name as arguments and returns interaction that resolves to a value.
```ts
const value = await read(TextField('locator'), 'value')
```

### Alternate Designs

I thought about another design that is to compose getters as that had done for actions. So a user could use them like this:
```ts
const value = await TextField('locator').value;
```
