### PR TITLE
Throw an error if an interactor has no label

### DIFF
--- a/.changeset/moody-cheetahs-melt.md
+++ b/.changeset/moody-cheetahs-melt.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Throw error if interactor is not given a label

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -38,6 +38,9 @@ export function findElements<E extends Element>(parentElement: Element, interact
 }
 
 function findMatches(parentElement: Element, interactor: InteractorOptions<any, any, any>): Match<Element, any>[] {
+  if (!interactor.name) {
+    throw new Error('The interactor used for this test was not given a label. Please provide a name for your interactor:\n\tHTML.extend(\'my interactor\') || createInteractor(\'my interactor\')');
+  }
   return findElements(parentElement, interactor).map((e) => new Match(e, interactor.filter, interactor.locator));
 }
 

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -39,7 +39,7 @@ export function findElements<E extends Element>(parentElement: Element, interact
 
 function findMatches(parentElement: Element, interactor: InteractorOptions<any, any, any>): Match<Element, any>[] {
   if (!interactor.name) {
-    throw new Error('The interactor used for this test was not given a label. Please provide a name for your interactor:\n\tHTML.extend(\'my interactor\') || createInteractor(\'my interactor\')');
+    throw new Error('One of your interactors was created without a name. Please provide a label for your interactor:\n\tHTML.extend(\'my interactor\') || createInteractor(\'my interactor\')');
   }
   return findElements(parentElement, interactor).map((e) => new Match(e, interactor.filter, interactor.locator));
 }

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -37,6 +37,10 @@ const Thing = HTML.extend<HTMLLinkElement>('div')
 const Header = createInteractor('header')
   .selector('h1,h2,h3,h4,h5,h6')
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+//@ts-ignore
+const HTMLWithNoLabel = HTML.extend()
+
 describe('@bigtest/interactor', () => {
   describe('.extend', () => {
     it('can use filters from base interactor', async () => {
@@ -98,6 +102,14 @@ describe('@bigtest/interactor', () => {
 
       await Thing().click(4);
       await Thing().has({ title: 4 });
+    });
+
+    it('throws error if interactor has no label', async () => {
+      dom(`<p>Foo Bar</p>`);
+      await expect(HTMLWithNoLabel('Foo Bar').exists()).rejects.toHaveProperty('message', [
+        "The interactor used for this test was not given a label. Please provide a name for your interactor:",
+        "\tHTML.extend('my interactor') || createInteractor('my interactor')"
+      ].join('\n'));
     });
   });
 });

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -107,7 +107,7 @@ describe('@bigtest/interactor', () => {
     it('throws error if interactor has no label', async () => {
       dom(`<p>Foo Bar</p>`);
       await expect(HTMLWithNoLabel('Foo Bar').exists()).rejects.toHaveProperty('message', [
-        "The interactor used for this test was not given a label. Please provide a name for your interactor:",
+        "One of your interactors was created without a name. Please provide a label for your interactor:",
         "\tHTML.extend('my interactor') || createInteractor('my interactor')"
       ].join('\n'));
     });


### PR DESCRIPTION
## Motivation
To resolve #820

## Approach
![Screen Shot 2021-05-18 at 7 41 02 AM](https://user-images.githubusercontent.com/29791650/118645074-7af3fb80-b7ac-11eb-9e03-b001f4842db8.png)

- Continuing from the discussion in issue #820, we needed to decide between either throwing an error and display a warning but I went with the former for two reasons:
  - 1). It formats for us. Especially for Jest (and most likely cypress and bigtest too), the error message is formatted _below_ the failing test and is color coded. If you take a look at this screenshot, where we throw a warning, the console log hits before the test completes so it almost looks like the warning is related to the previous test:
      ![118645043-6dd70c80-b7ac-11eb-92e5-dbb316a43823](https://user-images.githubusercontent.com/29791650/119058943-56ab4100-b99d-11eb-8963-cf242b61ba3a.png)
  - 2). We should force people to use interactors properly. Otherwise, they'll be getting unhelpful error messages in their test suites and I'm afraid people might place the blame on BigTest.

### TODOs
- [x] ~Are we okay with the wording? Should it be "An interactor used in this test..."?~ Changed to "An interactor..."
- [x] Once a preview package is published, I want to run it inside Cypress and BigTest runner to double check the error format
  - Bigtest:
    ![Screen Shot 2021-05-21 at 6 24 03 AM](https://user-images.githubusercontent.com/29791650/119124991-45931c00-b9ff-11eb-9b4c-8d40867d32c7.png)
  - Cypress:
    ![Screen Shot 2021-05-21 at 6 21 36 AM](https://user-images.githubusercontent.com/29791650/119124946-390ec380-b9ff-11eb-803a-d7c96aedd742.png)