### PR TITLE
Filter delegation

### DIFF
--- a/packages/interactor/src/builder.ts
+++ b/packages/interactor/src/builder.ts
@@ -1,24 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification, InteractorConstructor, FilterParams, ActionMethods } from './specification';
+import { Filters, Actions, LocatorFn, InteractorBuilder, InteractorSpecification, InteractorConstructor, FilterParams, FilterMethods, ActionMethods } from './specification';
 import { createConstructor } from './constructor';
 import { MergeObjects } from './merge-objects';
 
-export function makeBuilder<T, E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>>(base: T, name: string, specification: InteractorSpecification<E, any, any>): T & InteractorBuilder<E, FP, AM> {
+export function makeBuilder<T, E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any>>(base: T, name: string, specification: InteractorSpecification<E, any, any>): T & InteractorBuilder<E, FP, FM, AM> {
   return Object.assign(base, {
-    selector: (value: string): InteractorConstructor<E, FP, AM> => {
+    selector: (value: string): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, selector: value });
     },
-    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, AM> => {
+    locator: (value: LocatorFn<E>): InteractorConstructor<E, FP, FM, AM> => {
       return createConstructor(name, { ...specification, locator: value });
     },
-    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM> => {
+    filters: <FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM> => {
       return createConstructor(name, { ...specification, filters: { ...specification.filters, ...filters } });
     },
-    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>> => {
+    actions: <AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, FM, MergeObjects<AM, ActionMethods<E, AR>>> => {
       return createConstructor(name, { ...specification, actions: Object.assign({}, specification.actions, actions) });
     },
-    extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, AM> => {
-      return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, AM>;
+    extend: <ER extends Element = E>(newName: string): InteractorConstructor<ER, FP, FM, AM> => {
+      return createConstructor(newName, specification) as unknown as InteractorConstructor<ER, FP, FM, AM>;
     },
   });
 }

--- a/packages/interactor/src/create-interactor.ts
+++ b/packages/interactor/src/create-interactor.ts
@@ -1,4 +1,4 @@
-import { EmptyObject, InteractorSpecificationBuilder, InteractorSpecification, InteractorConstructor, Filters, Actions, FilterParams, ActionMethods } from './specification';
+import { EmptyObject, InteractorSpecificationBuilder, InteractorSpecification, InteractorConstructor, Filters, Actions, FilterParams, FilterMethods, ActionMethods } from './specification';
 import { createConstructor } from './constructor';
 import { makeBuilder } from './builder';
 
@@ -21,7 +21,7 @@ import { makeBuilder } from './builder';
  * @returns You will need to call the returned builder to create an interactor.
  */
 export function createInteractor<E extends Element>(name: string): InteractorSpecificationBuilder<E> {
-  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>> {
+  let cons = function<F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, FilterMethods<E, F>, ActionMethods<E, A>> {
     return createConstructor(name, specification);
   }
   return makeBuilder(cons, name, {

--- a/packages/interactor/src/inspector.ts
+++ b/packages/interactor/src/inspector.ts
@@ -3,23 +3,23 @@
 import { instantiateBaseInteractor, findElements, unsafeSyncResolveParent } from "./constructor";
 import { BaseInteractor, Filters, InteractorConstructor, FilterParams } from "./specification";
 
-type GetElement<I extends InteractorConstructor<any, any, any>> = I extends InteractorConstructor<infer E, any, any> ? E : never
-type GetFilters<I extends InteractorConstructor<any, any, any>> = I extends InteractorConstructor<any, infer F, any> ? F : never
-type GetActions<I extends InteractorConstructor<any, any, any>> = I extends InteractorConstructor<any, any, infer A> ? A : never
+type GetElement<I extends InteractorConstructor<any, any, any, any>> = I extends InteractorConstructor<infer E, any, any, any> ? E : never
+type GetFilters<I extends InteractorConstructor<any, any, any, any>> = I extends InteractorConstructor<any, infer F, any, any> ? F : never
+type GetActions<I extends InteractorConstructor<any, any, any, any>> = I extends InteractorConstructor<any, any, any, infer A> ? A : never
 
 export interface InteractorInspector<E extends Element, FP extends FilterParams<any, any>> extends BaseInteractor<E, FP> {
   element: E,
-  find<T extends InteractorConstructor<any, any, any>>(interactor: T): Inspector<T>
+  find<T extends InteractorConstructor<any, any, any, any>>(interactor: T): Inspector<T>
 }
 
-export interface Inspector<C extends InteractorConstructor<any, any, any>> {
+export interface Inspector<C extends InteractorConstructor<any, any, any, any>> {
   /**
    * Finds all matched by selector elements and wraps each of them to intreactor
    */
    all(): (InteractorInspector<GetElement<C>, GetFilters<C>> & GetActions<C>)[]
 }
 
-export function createInspector<IC extends InteractorConstructor<any, any, any>>(
+export function createInspector<IC extends InteractorConstructor<any, any, any, any>>(
   constructor: IC,
   parentElement?: Element
 ): Inspector<IC> {
@@ -32,7 +32,7 @@ export function createInspector<IC extends InteractorConstructor<any, any, any>>
         element => (Object.assign(
           instantiateBaseInteractor(options, () => element) as (BaseInteractor<GetElement<IC>, Filters<GetFilters<IC>>> & GetActions<IC>), {
           element,
-          find<T extends InteractorConstructor<any, any, any>>(constructor: T): Inspector<T> {
+          find<T extends InteractorConstructor<any, any, any, any>>(constructor: T): Inspector<T> {
             return createInspector(constructor, element)
           }
         }))

--- a/packages/interactor/src/interaction.ts
+++ b/packages/interactor/src/interaction.ts
@@ -1,3 +1,4 @@
+import type { ToFilter } from './specification';
 /**
  * An interaction represents some type of action or assertion that can be
  * taken on an {@link Interactor}.
@@ -55,4 +56,12 @@ export function interaction<T>(description: string, action: () => Promise<T>): I
 
 export function check<T>(description: string, check: () => Promise<T>): ReadonlyInteraction<T> {
   return { check, ...interaction(description, check) };
+}
+
+export function interactionFilter<T, Q>(description: string, action: () => Promise<T>, filter: (element: Element) => Q): Interaction<T> & ToFilter<Q> {
+  return { toFilter() { return filter }, ...interaction(description, action) };
+}
+
+export function checkFilter<T, Q>(description: string, action: () => Promise<T>, filter: (element: Element) => Q): ReadonlyInteraction<T> & ToFilter<Q> {
+  return { toFilter() { return filter } , ...check(description, action) };
 }

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -108,6 +108,7 @@ function isToFilter(definition: any): definition is ToFilter<any> {
   return definition != null && typeof(definition.toFilter) === 'function';
 }
 
+// NOTE Don't need toFilter
 export function applyFilter<T>(definition: FilterFn<T, any> | FilterObject<T, any> | ToFilter<T>, element: Element): T {
   if(typeof(definition) === 'function') {
     return definition(element) as T;

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -8,6 +8,10 @@ import { MaybeMatcher } from './matcher';
 
 export type EmptyObject = Record<never, never>;
 
+export interface ToFilter<T> {
+  toFilter(): (element: Element) => T
+}
+
 export interface ExistsAssertionsImplementation {
 
   /**
@@ -20,7 +24,7 @@ export interface ExistsAssertionsImplementation {
    * await Link('Next').exists();
    * ```
    */
-  exists(): ReadonlyInteraction<void>;
+  exists(): ReadonlyInteraction<void> & ToFilter<boolean>;
 
   /**
    * An assertion which checks that an element matching the interactor does not
@@ -32,7 +36,7 @@ export interface ExistsAssertionsImplementation {
    * await Link('Next').absent();
    * ```
    */
-  absent(): ReadonlyInteraction<void>;
+  absent(): ReadonlyInteraction<void> & ToFilter<boolean>;
 }
 
 export interface BaseInteractor<E extends Element, F extends FilterParams<any, any>> {
@@ -152,7 +156,7 @@ export type FilterObject<T, E extends Element> = {
   default?: T;
 }
 
-export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E>>
+export type Filters<E extends Element> = Record<string, FilterFn<unknown, E> | FilterObject<unknown, E> | ToFilter<unknown>>
 
 export type Actions<E extends Element> = Record<string, ActionFn<E>>;
 
@@ -178,25 +182,32 @@ export type ActionMethods<E extends Element, A extends Actions<E>> = {
     : never;
 }
 
+export type FilterMethods<E extends Element, F extends Filters<E>> = {
+  [P in keyof F]:
+    F[P] extends ToFilter<infer TReturn> ? (() => Interaction<TReturn> & ToFilter<TReturn>) :
+    F[P] extends FilterFn<infer TReturn, any> ? (() => Interaction<TReturn> & ToFilter<TReturn>) :
+    F[P] extends FilterObject<infer TReturn, any> ? (() => Interaction<TReturn> & ToFilter<TReturn>) :
+    never;
+}
+
 export type FilterReturn<F> = {
   [P in keyof F]?: F[P] extends MaybeMatcher<infer T> ? T : never;
 }
 
 export type FilterParams<E extends Element, F extends Filters<E>> = keyof F extends never ? never : {
   [P in keyof F]?:
-    F[P] extends FilterFn<infer TArg, E> ?
-    MaybeMatcher<TArg> :
-    F[P] extends FilterObject<infer TArg, E> ?
-    MaybeMatcher<TArg> :
+    F[P] extends ToFilter<infer TArg> ? MaybeMatcher<TArg> :
+    F[P] extends FilterFn<infer TArg, E> ? MaybeMatcher<TArg> :
+    F[P] extends FilterObject<infer TArg, E> ? MaybeMatcher<TArg> :
     never;
 }
 
-export interface InteractorBuilder<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> {
-  selector(value: string): InteractorConstructor<E, FP, AM>;
-  locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
-  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM>;
-  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>>;
-  extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, AM>;
+export interface InteractorBuilder<E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any>> {
+  selector(value: string): InteractorConstructor<E, FP, FM, AM>;
+  locator(value: LocatorFn<E>): InteractorConstructor<E, FP, FM, AM>;
+  filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, MergeObjects<FM, FilterMethods<E, FR>>, AM>;
+  actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, FM, MergeObjects<AM, ActionMethods<E, AR>>>;
+  extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, FM, AM>;
 }
 
 /**
@@ -211,7 +222,7 @@ export interface InteractorBuilder<E extends Element, FP extends FilterParams<an
  * @typeParam F the filters of this interactor, this is usually inferred from the specification
  * @typeParam A the actions of this interactor, this is usually inferred from the specification
  */
-export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> extends InteractorBuilder<E, FP, AM> {
+export interface InteractorConstructor<E extends Element, FP extends FilterParams<any, any>, FM extends FilterMethods<any, any>, AM extends ActionMethods<any, any>> extends InteractorBuilder<E, FP, FM, AM> {
   /**
    * The constructor can be called with filters only:
    *
@@ -227,7 +238,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
    *
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (filters?: FP): Interactor<E, FP> & AM;
+  (filters?: FP): Interactor<E, FP> & FM & AM;
   /**
    * The constructor can be called with a locator:
    *
@@ -244,7 +255,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
    * @param value The locator value, which should match the value of applying the locator function defined in the {@link InteractorSpecification} to the element.
    * @param filters An object describing a set of filters to apply, which should match the value of applying the filters defined in the {@link InteractorSpecification} to the element.
    */
-  (value: MaybeMatcher<string>, filters?: FP): Interactor<E, FP> & AM;
+  (value: MaybeMatcher<string>, filters?: FP): Interactor<E, FP> & FM & AM;
 }
 
 /**
@@ -254,7 +265,7 @@ export interface InteractorConstructor<E extends Element, FP extends FilterParam
  *
  * @typeParam E The type of DOM Element that this interactor operates on. By specifying the element type, actions and filters defined for the interactor can be type checked against the actual element type.
  */
-export interface InteractorSpecificationBuilder<E extends Element> extends InteractorBuilder<E, EmptyObject, EmptyObject> {
+export interface InteractorSpecificationBuilder<E extends Element> extends InteractorBuilder<E, EmptyObject, EmptyObject, EmptyObject> {
   /**
    * Calling the builder will create an interactor.
    *
@@ -263,7 +274,7 @@ export interface InteractorSpecificationBuilder<E extends Element> extends Inter
    * @typeParam A the actions of this interactor, this is usually inferred from the specification
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  <F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, ActionMethods<E, A>>;
+  <F extends Filters<E> = EmptyObject, A extends Actions<E> = EmptyObject>(specification: InteractorSpecification<E, F, A>): InteractorConstructor<E, FilterParams<E, F>, FilterMethods<E, F>, ActionMethods<E, A>>;
 }
 
 export type InteractorOptions<E extends Element, F extends Filters<E>, A extends Actions<E>> = {

--- a/packages/interactor/test.ts
+++ b/packages/interactor/test.ts
@@ -1,0 +1,5 @@
+import { createInteractor } from './src/index';
+
+let Foo = createInteractor('foo').filters({
+  text: (element) => element.textContent || ""
+});

--- a/packages/interactor/test/filter-delegate.test.ts
+++ b/packages/interactor/test/filter-delegate.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from 'mocha';
+import expect from 'expect';
+import { dom } from './helpers';
+
+import { HTML } from '../src/index';
+
+
+
+const Header = HTML.extend('header')
+  .selector('h1,h2,h3,h4,h5,h6')
+
+const Label = HTML.extend<HTMLLabelElement>("label")
+  .selector("label")
+
+const Calendar = HTML.extend<HTMLElement>("calendar")
+  .selector("div.calendar")
+
+const TextField = HTML.extend<HTMLInputElement>('text field')
+  .selector('input')
+  .filters({
+    placeholder: element => element.placeholder,
+  })
+
+const Datepicker = HTML.extend<HTMLDivElement>("datepicker")
+  .selector("div.datepicker")
+  .locator(element => element.querySelector("label")?.textContent || "")
+  .filters({
+    open: Calendar().exists(),
+    month: Calendar().find(Header()).text(),
+  })
+  .actions({
+    toggle: async interactor => {
+      await interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
+    }
+  });
+
+describe('@bigtest/interactor', () => {
+  it('can use interactors within actions', async () => {
+    dom(`
+      <div class="datepicker">
+        <label for="start-date">Start Date</label>
+        <input type="text" id="start-date" placeholder="YYYY-MM-DD" />
+      </div>
+      <script>
+        let startDateInput = document.getElementById("start-date");
+        let datepicker = document.querySelector(".datepicker");
+        startDateInput.onclick = () => {
+          let calendar = document.createElement("div");
+          let calendarMonth = document.createElement("h4");
+          calendarMonth.appendChild(document.createTextNode("January"));
+          calendar.classList.add("calendar");
+          calendar.appendChild(calendarMonth);
+          datepicker.appendChild(calendar);
+        };
+      </script>
+    `);
+
+    await expect(Datepicker("Start Date").has({ open: false })).resolves.toBeUndefined();
+    await Datepicker("Start Date").toggle();
+    await expect(Datepicker("Start Date").has({ open: true })).resolves.toBeUndefined();
+    await expect(Datepicker("Start Date").has({ month: "January" })).resolves.toBeUndefined();
+  });
+});

--- a/packages/interactor/test/filter-delegate.test.ts
+++ b/packages/interactor/test/filter-delegate.test.ts
@@ -5,6 +5,10 @@ import { dom } from './helpers';
 import { HTML } from '../src/index';
 
 
+// TODO I need to fix types, but the idea is to pass filter as a plain property without calling it
+// TODO by using getter under the hood
+// TODO And as an side-effect that prop could be used to read a value in other actions or steps
+// TODO See note in tests
 
 const Header = HTML.extend('header')
   .selector('h1,h2,h3,h4,h5,h6')
@@ -26,7 +30,7 @@ const Datepicker = HTML.extend<HTMLDivElement>("datepicker")
   .locator(element => element.querySelector("label")?.textContent || "")
   .filters({
     open: Calendar().exists(),
-    month: Calendar().find(Header()).text(),
+    month: Calendar().find(Header()).text,
   })
   .actions({
     toggle: async interactor => {
@@ -59,5 +63,6 @@ describe('@bigtest/interactor', () => {
     await Datepicker("Start Date").toggle();
     await expect(Datepicker("Start Date").has({ open: true })).resolves.toBeUndefined();
     await expect(Datepicker("Start Date").has({ month: "January" })).resolves.toBeUndefined();
+    await expect(Datepicker("Start Date").month).resolves.toEqual('January') // NOTE Like this
   });
 });


### PR DESCRIPTION
This is a proof of concept for a way to implement filter delegation.

The API looks like this:

``` typescript
const Calendar = HTML.extend<HTMLElement>("calendar")
  .selector("div.calendar")

const Datepicker = HTML.extend<HTMLDivElement>("datepicker")
  .selector("div.datepicker")
  .locator(element => element.querySelector("label")?.textContent || "")
  .filters({
    open: Calendar().exists(),
    month: Calendar().find(Header()).text(),
  })
  .actions({
    toggle: async interactor => {
      await interactor.find(TextField({ placeholder: "YYYY-MM-DD" })).click();
    }
  });
```

There are a lot of open questions and inconsistencies with this implementation, but it does kinda-sorta work!