### PR TITLE
add support to define an array of locators

### DIFF
--- a/.changeset/multiple-locators.md
+++ b/.changeset/multiple-locators.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/interactor": minor
+---
+
+Allow to define multiple locator functions for interactors

--- a/packages/interactor/src/constructor.ts
+++ b/packages/interactor/src/constructor.ts
@@ -25,7 +25,7 @@ import { Match } from './match';
 import { NoSuchElementError, NotAbsentError, AmbiguousElementError } from './errors';
 import { isMatcher } from './matcher';
 
-const defaultLocator: LocatorFn<Element> = (element) => element.textContent || "";
+const defaultLocator: LocatorFn<Element> = (element) => element.textContent ?? "";
 const defaultSelector = 'div';
 
 export function findElements<E extends Element>(parentElement: Element, interactor: InteractorOptions<any, any, any>): E[] {

--- a/packages/interactor/src/locator.ts
+++ b/packages/interactor/src/locator.ts
@@ -2,7 +2,10 @@ import { LocatorFn } from './specification';
 import { matcherDescription, MaybeMatcher } from './matcher';
 
 export class Locator<E extends Element> {
-  constructor(public locatorFn: LocatorFn<E>, public value: MaybeMatcher<string>) {}
+  public locatorFn: LocatorFn<E>[];
+  constructor(locatorFn: LocatorFn<E> | LocatorFn<E>[], public value: MaybeMatcher<string>) {
+    this.locatorFn = Array.isArray(locatorFn) ? locatorFn : [locatorFn]
+  }
 
   get description(): string {
     return matcherDescription(this.value);

--- a/packages/interactor/src/match.ts
+++ b/packages/interactor/src/match.ts
@@ -52,20 +52,20 @@ export class Match<E extends Element, F extends Filters<E>> {
 
 export class MatchLocator<E extends Element> {
   public matches: boolean;
-  public expected: MaybeMatcher<string> | null;
-  public actual: string | null;
+  public expected: MaybeMatcher<string>;
+  public actual: string[];
 
   constructor(
     public element: E,
     public locator: Locator<E>,
   ) {
     this.expected = locator.value;
-    this.actual = locator.locatorFn(element);
-    this.matches = applyMatcher(this.expected, this.actual);
+    this.actual = locator.locatorFn.map(fn => fn(element));
+    this.matches = this.actual.some(actual => applyMatcher(this.expected, actual));
   }
 
   formatActual(): string {
-    return JSON.stringify(this.actual);
+    return this.actual.filter(Boolean).map(actual => JSON.stringify(actual)).join(' or ');
   }
 
   description(): string {

--- a/packages/interactor/src/specification.ts
+++ b/packages/interactor/src/specification.ts
@@ -164,12 +164,12 @@ export type InteractorSpecification<E extends Element, F extends Filters<E>, A e
   actions?: A;
   filters?: F;
   /**
-   * A function which returns a string value for a matched element, which can
+   * A function(s) which return(s) a string value for a matched element, which can
    * be used to locate a specific instance of this interactor. The `value`
    * parameter of an {@link InteractorConstructor} must match the value
    * returned from the locator function.
    */
-  locator?: LocatorFn<E>;
+  locator?: LocatorFn<E> | LocatorFn<E>[];
 }
 
 export type ActionMethods<E extends Element, A extends Actions<E>> = {
@@ -193,7 +193,7 @@ export type FilterParams<E extends Element, F extends Filters<E>> = keyof F exte
 
 export interface InteractorBuilder<E extends Element, FP extends FilterParams<any, any>, AM extends ActionMethods<any, any>> {
   selector(value: string): InteractorConstructor<E, FP, AM>;
-  locator(value: LocatorFn<E>): InteractorConstructor<E, FP, AM>;
+  locator(value: LocatorFn<E> | LocatorFn<E>[]): InteractorConstructor<E, FP, AM>;
   filters<FR extends Filters<E>>(filters: FR): InteractorConstructor<E, MergeObjects<FP, FilterParams<E, FR>>, AM>;
   actions<AR extends Actions<E>>(actions: AR): InteractorConstructor<E, FP, MergeObjects<AM, ActionMethods<E, AR>>>;
   extend<ER extends E = E>(name: string): InteractorConstructor<ER, FP, AM>;

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -59,6 +59,14 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")
 const MainNav = createInteractor('main nav')
   .selector('nav')
 
+const ListItem = createInteractor<HTMLLIElement>('list item')
+  .selector('li')
+  .locator([
+    element => element.getAttribute('aria-label') ?? '',
+    element => element.textContent ?? ''
+  ])
+  .filters({ text: element => element.textContent });
+
 describe('@bigtest/interactor', () => {
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
@@ -74,6 +82,34 @@ describe('@bigtest/interactor', () => {
         '┣━━━━━━━━━━━━━┫',
         '┃ ⨯ "Foo Bar" ┃',
         '┃ ⨯ "Quox"    ┃',
+      ].join('\n'));
+    });
+
+    it('can use multiple locators', async () => {
+      dom(`
+        <ul>
+          <li><p>foo</p></li>
+          <li aria-label="bar"><p>text</p></li>
+          <li aria-label="baz"><p>text</p></li>
+          <li><p>baz</p></li>
+        </ul>
+      `);
+
+      await expect(ListItem('foo').exists()).resolves.toBeUndefined();
+      await expect(ListItem('bar').exists()).resolves.toBeUndefined();
+      await expect(ListItem('baz').has({ text: 'image' })).rejects.toHaveProperty('message', [
+        'list item "baz" matches multiple elements:', '',
+        '- <li aria-label="baz">',
+        '- <li>'
+      ].join('\n'));
+      await expect(ListItem('spam').exists()).rejects.toHaveProperty('message', [
+        'did not find list item "spam", did you mean one of:', '',
+        '┃ list item         ┃',
+        '┣━━━━━━━━━━━━━━━━━━━┫',
+        '┃ ⨯ "foo"           ┃',
+        '┃ ⨯ "bar" or "text" ┃',
+        '┃ ⨯ "baz" or "text" ┃',
+        '┃ ⨯ "baz"           ┃',
       ].join('\n'));
     });
 


### PR DESCRIPTION
## Motivation

For some Material UI interactors would be nice to find an element by more than one source, for example, `Button` might have a text and can be located by `innerText` value, and also Button might have an icon as content, in that case, it should be located by `aria-label` attribute. The current implementation has a limitation where the result depends on order how locator sources are used.

## Approach

Adding the ability to pass an array to the locator helps us use more than one source.

```js
const MuiButton = Button
  .extends('Mui Button')
  .locator([
    element => element.innerText,
    element => element.getAttribute('aria-label') ?? ''
  ])

// If user has a component `<Button aria-label="upload">Upload a new image</Button>`
// It can be found by both parameters

MuiButton('upload').exists()
MuiButton('Upload a new image').exists()
```