### PR TITLE
add a jsTSConfig to the rollup typescript plugin if no tsconfig is found

### DIFF
--- a/.changeset/unlucky-geckos-shop.md
+++ b/.changeset/unlucky-geckos-shop.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/bundler": minor
+---
+
+add a jsTSConfig to the rollup typescript plugin if no tsconfig is found

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -3,7 +3,7 @@ import { on } from '@effection/events';
 import { Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Channel } from '@effection/channel';
 import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
-import { defaultTSConfig } from '@bigtest/project';
+import { defaultTSConfig, jsTSConfig } from '@bigtest/project';
 import resolve, {
   DEFAULTS as RESOLVE_DEFAULTS,
 } from '@rollup/plugin-node-resolve';
@@ -23,6 +23,8 @@ interface BundleOptions {
 };
 
 function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMessage>): InputOptions {
+  let hasTsConfig = typeof bundle.tsconfig !== 'undefined'
+  
   return {
     input: bundle.entry,
     onwarn(warning){
@@ -36,7 +38,7 @@ function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMess
       commonjs(),
       typescript({
         tsconfig: bundle.tsconfig,
-        tsconfigDefaults: defaultTSConfig(),
+        tsconfigDefaults: hasTsConfig ? defaultTSConfig() : jsTSConfig(),
         tsconfigOverride: {
           compilerOptions: {
             module: "ESNext",

--- a/packages/bundler/src/bundler.ts
+++ b/packages/bundler/src/bundler.ts
@@ -2,7 +2,7 @@ import { Operation, resource, timeout } from 'effection';
 import { on } from '@effection/events';
 import { Subscribable, SymbolSubscribable, Subscription } from '@effection/subscription';
 import { Channel } from '@effection/channel';
-import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher } from 'rollup';
+import { watch, rollup, OutputOptions, InputOptions, RollupWatchOptions, RollupWatcherEvent, RollupWatcher, RollupBuild } from 'rollup';
 import { defaultTSConfig, jsTSConfig } from '@bigtest/project';
 import resolve, {
   DEFAULTS as RESOLVE_DEFAULTS,
@@ -23,7 +23,7 @@ interface BundleOptions {
 };
 
 function prepareInputOptions(bundle: BundleOptions, channel: Channel<BundlerMessage>): InputOptions {
-  let hasTsConfig = typeof bundle.tsconfig !== 'undefined'
+  let hasTsConfig = typeof bundle.tsconfig !== 'undefined';
   
   return {
     input: bundle.entry,
@@ -134,7 +134,7 @@ export class Bundler implements Subscribable<BundlerMessage, undefined> {
     yield timeout(0); // send start event asynchronously, so we have a chance to subscribe
     this.channel.send({ type: 'START' });
     try {
-      let result = yield rollup(prepareInputOptions(this.options, this.channel));
+      let result: RollupBuild = yield rollup(prepareInputOptions(this.options, this.channel));
       yield result.write(prepareOutputOptions(this.options));
 
       this.channel.send({ type: 'UPDATE' });

--- a/packages/project/src/index.ts
+++ b/packages/project/src/index.ts
@@ -161,7 +161,17 @@ export function defaultTSConfig(): {compilerOptions: Pick<CompilerOptions, 'skip
     compilerOptions: {
       skipLibCheck: true,
       target: "es6" as unknown as ScriptTarget,
-      lib: ["esnext", "dom"]
+      lib: ["esnext", "dom"],
+    }
+  }
+}
+
+export function jsTSConfig(): {compilerOptions: Pick<CompilerOptions, 'allowJs' | 'skipLibCheck' | 'target'>} {
+  return {
+    compilerOptions: {
+      allowJs: true,
+      skipLibCheck: true,
+      target: "es5" as unknown as ScriptTarget,
     }
   }
 }


### PR DESCRIPTION
## Motivation

Fix for #959 where an annoying warning is displayed if no tsconfig.json exists

## Approach

Add a `js` `tsconfig.json` if no `tsconfig.json` is found to the rollup typescript plugin.

This `js` `tsconfig` has the `"allowJs": true` compiler option set.