### PR TITLE
✨Allow for interactions that span documents

### DIFF
--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/cypress",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "Cypress Integration for BigTest Interactors",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/integrations/cypress/src/cypress.ts
+++ b/integrations/cypress/src/cypress.ts
@@ -12,13 +12,16 @@ declare global {
   }
 }
 
+Object.defineProperty(bigtestGlobals, 'document', {
+  get: () => cy.$$('body')[0].ownerDocument
+});
+
 function interact(
   interaction: Interaction<void> | ReadonlyInteraction<void>,
   runnerState: RunnerState
 ) {
   bigtestGlobals.runnerState = runnerState;
-  return cy.document({ log: false }).then((doc: Document) => {
-    bigtestGlobals.document = doc;
+  return cy.then(() => {
     return interaction;
   }).then(() => {
     Cypress.log({
@@ -38,7 +41,7 @@ if (typeof Cypress !== 'undefined' ) {
       interact(interaction, 'step');
     }
   });
-  
+
   Cypress.Commands.add('expect', (
     interaction: ReadonlyInteraction<void> | ReadonlyInteraction<void>[]
   ) => {


### PR DESCRIPTION
## Motivation

We were setting the interactor document only once at the beginning of when an interaction started running. However, this proved to be a problem when you have an interaction that might start out looking at one document, but actually finish on another. Take for instance the case where you are redirecting from an application page to a log in page.

You might write something like:

```js
cy.do([
  Link("Sign in").click(),
  // goes to Auth0 page
  TextField("username").fillIn("boberton"),
  TextField("password").fillIn("secret"),
  Button("Continue").click()
]);
```

Each interaction attempts to converge upon a matching element. As such, there could be hundreds if not thousands of attempts to match for a single iteraction depending on the timeout period. As it stood though, the bigtest interactor document was being set _before_ the first attempt and never again. This is fine if the document never changes, but if the document changes between attempts, then this breaks.

## Approach
The solution is to make the `bigtestglobals.document` a dynamic getter that re-computes the active document with every attempt. This way, the convergence can span any number of redirects and page loads.
