### PR TITLE
Rename interactor package

### DIFF
--- a/.changeset/tough-bees-brake.md
+++ b/.changeset/tough-bees-brake.md
@@ -1,0 +1,5 @@
+---
+"@interactors/html": patch
+---
+
+Rename @bigtest/interactor package to @interactors/html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           at: .
       - run:
           name: Running tests
-          command: yarn workspace <<parameters.package>> test
+          command: yarn workspace @<<parameters.package>> test
   lint:
     executor: <<parameters.executor>>
     parameters:
@@ -134,23 +134,23 @@ workflows:
           matrix:
             parameters:
               package:
-                - '@bigtest/agent'
-                - '@bigtest/atom'
-                - '@bigtest/bundler'
-                - '@bigtest/cli'
-                - '@bigtest/client'
-                - '@bigtest/driver'
-                - '@bigtest/effection'
-                - '@bigtest/effection-express'
-                - '@bigtest/eslint-plugin'
-                - '@bigtest/globals'
-                - '@bigtest/logging'
-                - '@bigtest/performance'
-                - '@bigtest/project'
-                - '@bigtest/server'
-                - '@bigtest/suite'
-                - '@bigtest/webdriver'
-                - '@interactors/html'
+                - "bigtest/agent"
+                - "bigtest/atom"
+                - "bigtest/bundler"
+                - "bigtest/cli"
+                - "bigtest/client"
+                - "bigtest/driver"
+                - "bigtest/effection"
+                - "bigtest/effection-express"
+                - "bigtest/eslint-plugin"
+                - "bigtest/globals"
+                - "bigtest/logging"
+                - "bigtest/performance"
+                - "bigtest/project"
+                - "bigtest/server"
+                - "bigtest/suite"
+                - "bigtest/webdriver"
+                - "interactors/html"
           requires:
             - prepack
       - integrations:
@@ -170,18 +170,18 @@ workflows:
             - run:
                 name: "Install Microsoft Edge"
                 command: choco install microsoft-edge
-          package: '@bigtest/cli'
+          package: "bigtest/cli"
       - test:
           name: "test-cli-firefox"
           driver: "firefox.headless"
-          package: '@bigtest/cli'
+          package: "bigtest/cli"
           prepack: false
           requires:
             - prepack
       - test:
           name: "test-cli-macos"
           executor: macos
-          package: '@bigtest/cli'
+          package: "bigtest/cli"
           driver: safari
           pre-steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ jobs:
   test:
     executor: <<parameters.executor>>
     parameters:
+      scope:
+        type: string
+        default: "bigtest"
       package:
         type: string
       driver:
@@ -102,7 +105,7 @@ jobs:
           at: .
       - run:
           name: Running tests
-          command: yarn workspace @<<parameters.package>> test
+          command: yarn workspace @<<parameters.scope>>/<<parameters.package>> test
   lint:
     executor: <<parameters.executor>>
     parameters:
@@ -134,23 +137,29 @@ workflows:
           matrix:
             parameters:
               package:
-                - "bigtest/agent"
-                - "bigtest/atom"
-                - "bigtest/bundler"
-                - "bigtest/cli"
-                - "bigtest/client"
-                - "bigtest/driver"
-                - "bigtest/effection"
-                - "bigtest/effection-express"
-                - "bigtest/eslint-plugin"
-                - "bigtest/globals"
-                - "bigtest/logging"
-                - "bigtest/performance"
-                - "bigtest/project"
-                - "bigtest/server"
-                - "bigtest/suite"
-                - "bigtest/webdriver"
-                - "interactors/html"
+                - atom
+                - agent
+                - bundler
+                - cli
+                - client
+                - driver
+                - effection
+                - effection-express
+                - eslint-plugin
+                - globals
+                - logging
+                - performance
+                - project
+                - server
+                - suite
+                - webdriver
+          requires:
+            - prepack
+      - test:
+          name: "test-interactor"
+          scope: interactors
+          package: html
+          prepack: false
           requires:
             - prepack
       - integrations:
@@ -170,18 +179,18 @@ workflows:
             - run:
                 name: "Install Microsoft Edge"
                 command: choco install microsoft-edge
-          package: "bigtest/cli"
+          package: cli
       - test:
           name: "test-cli-firefox"
           driver: "firefox.headless"
-          package: "bigtest/cli"
+          package: cli
           prepack: false
           requires:
             - prepack
       - test:
           name: "test-cli-macos"
           executor: macos
-          package: "bigtest/cli"
+          package: cli
           driver: safari
           pre-steps:
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ workflows:
           matrix:
             parameters:
               package:
-                - atom
                 - agent
+                - atom
                 - bundler
                 - cli
                 - client

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
           at: .
       - run:
           name: Running tests
-          command: yarn workspace @bigtest/<<parameters.package>> test
+          command: yarn workspace <<parameters.package>> test
   lint:
     executor: <<parameters.executor>>
     parameters:
@@ -134,23 +134,23 @@ workflows:
           matrix:
             parameters:
               package:
-                - agent
-                - atom
-                - bundler
-                - cli
-                - client
-                - driver
-                - effection
-                - effection-express
-                - eslint-plugin
-                - globals
-                - interactor
-                - logging
-                - performance
-                - project
-                - server
-                - suite
-                - webdriver
+                - '@bigtest/agent'
+                - '@bigtest/atom'
+                - '@bigtest/bundler'
+                - '@bigtest/cli'
+                - '@bigtest/client'
+                - '@bigtest/driver'
+                - '@bigtest/effection'
+                - '@bigtest/effection-express'
+                - '@bigtest/eslint-plugin'
+                - '@bigtest/globals'
+                - '@bigtest/logging'
+                - '@bigtest/performance'
+                - '@bigtest/project'
+                - '@bigtest/server'
+                - '@bigtest/suite'
+                - '@bigtest/webdriver'
+                - '@interactors/html'
           requires:
             - prepack
       - integrations:
@@ -170,18 +170,18 @@ workflows:
             - run:
                 name: "Install Microsoft Edge"
                 command: choco install microsoft-edge
-          package: cli
+          package: '@bigtest/cli'
       - test:
           name: "test-cli-firefox"
           driver: "firefox.headless"
-          package: cli
+          package: '@bigtest/cli'
           prepack: false
           requires:
             - prepack
       - test:
           name: "test-cli-macos"
           executor: macos
-          package: cli
+          package: '@bigtest/cli'
           driver: safari
           pre-steps:
             - run:

--- a/packages/interactor/CHANGELOG.md
+++ b/packages/interactor/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @bigtest/interactor
+# @interactors/html
 
 ## 0.31.1
 

--- a/packages/interactor/README.md
+++ b/packages/interactor/README.md
@@ -1,4 +1,4 @@
-# @bigtest/interactor
+# @interactors/html
 
 Interact with applications while avoiding many classes of race conditions which
 normally plague test suites.

--- a/packages/interactor/package.json
+++ b/packages/interactor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bigtest/interactor",
+  "name": "@interactors/html",
   "version": "0.31.1",
   "description": "Interactors for working with applications",
   "main": "dist/cjs/index.js",

--- a/packages/interactor/test/create-interactor.test.ts
+++ b/packages/interactor/test/create-interactor.test.ts
@@ -59,7 +59,7 @@ const Datepicker = createInteractor<HTMLDivElement>("datepicker")
 const MainNav = createInteractor('main nav')
   .selector('nav')
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('.exists', () => {
     it('can determine whether an element exists based on the interactor', async () => {
       dom(`

--- a/packages/interactor/test/definitions/button.test.ts
+++ b/packages/interactor/test/definitions/button.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { Button, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('Button', () => {
     it('finds `button` tags by text', async () => {
       dom(`

--- a/packages/interactor/test/definitions/check-box.test.ts
+++ b/packages/interactor/test/definitions/check-box.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { CheckBox, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('CheckBox', () => {
     it('finds `input[type=checkbox]` tags by label', async () => {
       dom(`

--- a/packages/interactor/test/definitions/heading.test.ts
+++ b/packages/interactor/test/definitions/heading.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('Heading', () => {
     it('finds `h1`, `h2`, etc... tags by text', async () => {
       dom(`

--- a/packages/interactor/test/definitions/html.test.ts
+++ b/packages/interactor/test/definitions/html.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { HTML } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('HTML', () => {
     it('finds any tag by text', async () => {
       dom(`

--- a/packages/interactor/test/definitions/link.test.ts
+++ b/packages/interactor/test/definitions/link.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { Link, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('Link', () => {
     it('finds `a` tags by text', async () => {
       dom(`

--- a/packages/interactor/test/definitions/multi-select.test.ts
+++ b/packages/interactor/test/definitions/multi-select.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { MultiSelect, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('MultiSelect', () => {
     it('finds `select` tags with `multiple` by label', async () => {
       dom(`

--- a/packages/interactor/test/definitions/radio-button.test.ts
+++ b/packages/interactor/test/definitions/radio-button.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { RadioButton, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('RadioButton', () => {
     it('finds `input[type=radio]` tags by label', async () => {
       dom(`

--- a/packages/interactor/test/definitions/select.test.ts
+++ b/packages/interactor/test/definitions/select.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { Select, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('Select', () => {
     it('finds `select` tags by label', async () => {
       dom(`

--- a/packages/interactor/test/definitions/text-field.test.ts
+++ b/packages/interactor/test/definitions/text-field.test.ts
@@ -3,7 +3,7 @@ import expect from 'expect';
 import { TextField, Heading } from '../../src/index';
 import { dom } from '../helpers';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('TextField', () => {
     it('finds `input` tags without type by label', async () => {
       dom(`

--- a/packages/interactor/test/extend.test.ts
+++ b/packages/interactor/test/extend.test.ts
@@ -41,7 +41,7 @@ const Header = createInteractor('header')
 //@ts-ignore
 const HTMLWithNoLabel = HTML.extend()
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('.extend', () => {
     it('can use filters from base interactor', async () => {
       dom(`

--- a/packages/interactor/test/inspector.test.ts
+++ b/packages/interactor/test/inspector.test.ts
@@ -6,7 +6,7 @@ import { createInspector, createInteractor, including, Link } from '../src/index
 
 const Div = createInteractor('div').selector('div')
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('inspector', () => {
     it('.find', async () => {
       dom(`

--- a/packages/interactor/test/interactor.test.ts
+++ b/packages/interactor/test/interactor.test.ts
@@ -9,7 +9,7 @@ const MainNav = createInteractor('main nav')({
   selector: 'nav'
 });
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('instantiation', () => {
     describe('no arguments', () => {
       it('just uses the selector to locate', async () => {

--- a/packages/interactor/test/matcher.test.ts
+++ b/packages/interactor/test/matcher.test.ts
@@ -21,7 +21,7 @@ function shouted(value: string): Matcher<string> {
   }
 }
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('matchers', () => {
     it('can use matcher on locator when locating element', async () => {
       dom(`

--- a/packages/interactor/test/matchers/and.test.ts
+++ b/packages/interactor/test/matchers/and.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { HTML, and, including } from '../../src/index';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('and', () => {
     it('can check whether the given value matches all of the given matchers', async () => {
       dom(`

--- a/packages/interactor/test/matchers/every.test.ts
+++ b/packages/interactor/test/matchers/every.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { MultiSelect, every, including } from '../../src/index';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('every', () => {
     it('can check whether the given string is contained in an array', async () => {
       dom(`

--- a/packages/interactor/test/matchers/including.test.ts
+++ b/packages/interactor/test/matchers/including.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { HTML, including } from '../../src/index';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('including', () => {
     it('can check whether the given string is contained', async () => {
       dom(`

--- a/packages/interactor/test/matchers/matching.test.ts
+++ b/packages/interactor/test/matchers/matching.test.ts
@@ -16,7 +16,7 @@ function matchingWithDeprecatedFormat(regexp: RegExp): Matcher<string> {
   }
 }
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   beforeEach(() => {
     dom(`
       <div title="hello world"></div>

--- a/packages/interactor/test/matchers/not.test.ts
+++ b/packages/interactor/test/matchers/not.test.ts
@@ -7,7 +7,7 @@ import { HTML, not, including } from '../../src/index';
 
 const div = HTML({ id: "test-div" });
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
 
   describe('not', () => {
     it('can check whether the filter does not match the given matcher', async () => {

--- a/packages/interactor/test/matchers/or.test.ts
+++ b/packages/interactor/test/matchers/or.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { HTML, or, including } from '../../src/index';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('or', () => {
     it('can check whether the given value matches any of the given matchers', async () => {
       dom(`

--- a/packages/interactor/test/matchers/some.test.ts
+++ b/packages/interactor/test/matchers/some.test.ts
@@ -4,7 +4,7 @@ import { dom } from '../helpers';
 
 import { MultiSelect, some, including } from '../../src/index';
 
-describe('@bigtest/interactor', () => {
+describe('@interactors/html', () => {
   describe('some', () => {
     it('can check whether the given string is contained in an array', async () => {
       dom(`

--- a/packages/interactor/test/page.test.ts
+++ b/packages/interactor/test/page.test.ts
@@ -10,7 +10,7 @@ import { dom } from './helpers';
 
 import { Page, read } from '../src/index';
 
-describe('@bigtest/interactor', function() {
+describe('@interactors/html', function() {
   describe('Page', () => {
     describe('visit', () => {
       let jsdom: JSDOM;

--- a/packages/interactor/typedoc.json
+++ b/packages/interactor/typedoc.json
@@ -1,6 +1,6 @@
 {
   "out": "docs",
-  "name": "@bigtest/interactor",
+  "name": "@interactors/html",
   "entryPoints": "src/index.ts",
   "readme": "API.md",
   "includeVersion": true,

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -24,7 +24,8 @@
       "@bigtest/project": ["packages/project/src"],
       "@bigtest/server": ["packages/server/src"],
       "@bigtest/suite": ["packages/suite/src"],
-      "@bigtest/webdriver": ["packages/webdriver/src"]
+      "@bigtest/webdriver": ["packages/webdriver/src"],
+      "@interactors/html": ["packages/interactor/src"],
     }
   }
 }

--- a/website/docs/interactors/8-storybook.md
+++ b/website/docs/interactors/8-storybook.md
@@ -5,7 +5,7 @@ title: Storybook
 
 Interactors not only make writing tests easier, it can also help you develop UI components. With the upcoming release of [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/), you will be able to use Interactors in [`Storybook`](https://storybook.js.org/).
 
-This requires no additional setup. Just install `@bigtest/interactor` to your project, and then you can use interactors in your stories immediately.
+This requires no additional setup. Just install `@interactors/html` to your project, and then you can use interactors in your stories immediately.
 
 In the same way Interactors make tests more reliable and easier to read, it will also enhance your developer experience with Storybook.
 
@@ -25,7 +25,7 @@ export const FormSignIn = {
 
 And this is the same story but written with interactors:
 ```js
-import { Button, TextField } from '@bigtest/interactor';
+import { Button, TextField } from '@/interactors/html';
 
 export const FormSignIn = {
   play: async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,6 +1708,17 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
+"@bigtest/interactor@0.31.1", "@bigtest/interactor@^0.31.0":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.31.1.tgz#2eb3b59730dea2b028234f999b84869544981dbc"
+  integrity sha512-bvZxHDyb9HyqgQjxfYujFIQ5spnl0WdIB5ze1jUO2Igvmq+ND/oD84IHMyG58Jhu9KfBWdk+2smF++9QcgrPbQ==
+  dependencies:
+    "@bigtest/globals" "^0.7.6"
+    "@bigtest/performance" "^0.5.0"
+    change-case "^4.1.1"
+    element-is-visible "^1.0.0"
+    lodash.isequal "^4.5.0"
+
 "@changesets/apply-release-plan@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.0.0.tgz#e78efb56a4e459a8dab814ba43045f2ace0f27c9"


### PR DESCRIPTION
## Motivation
The Interactors concept and package are not really coupled to the BigTest runner. Because interactors also work with Cypress, Jest, etc., they would benefit from a branding decoupling.

We can start publishing to the `@interactors` scope instead.

## Next steps after merge
~- [ ] update which Circle jobs are required, since they changed names a bit to deal with multiple scopes~
- [x] create PR to switch dependencies within this monorepo to `@interactors/html`
- [x] `npm deprecate` the `@bigtest/interactor` package

## The next steps after that
- Switch `cypress` package scope
- Change `material-ui-interactors` publish path
- Create separate `interactors` monorepo
- Move `material-ui-interactors` to the new `interactors` monorepo
