### PR TITLE
Update dependencies on @bigtest/interactor

### DIFF
--- a/.changeset/chilly-kids-yawn.md
+++ b/.changeset/chilly-kids-yawn.md
@@ -1,0 +1,6 @@
+---
+"@bigtest/agent": patch
+"bigtest": patch
+---
+
+Update @bigtest/interactor dependencies to @interactors/html

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bigtest/cypress",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Cypress Integration for BigTest Interactors",
   "main": "dist/index.js",
   "module": "dist/index.js",
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@bigtest/globals": "^0.7.6",
-    "@bigtest/interactor": "^0.29.0"
+    "@interactors/html": "^0.31.2"
   },
   "peerDependencies": {
     "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -25,7 +25,7 @@
     "cypress:run": "npx cypress run --spec 'cypress/integration/*.spec.ts'",
     "test": "start-server-and-test 'npm run start' http://localhost:3000 cypress:run",
     "prepack": "tsc --build",
-    "lint":  "eslint \"src/**/*.ts\""
+    "lint": "eslint \"src/**/*.ts\""
   },
   "devDependencies": {
     "@frontside/eslint-config": "^2.0.0",

--- a/integrations/cypress/src/cypress.ts
+++ b/integrations/cypress/src/cypress.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-namespace */
 /// <reference types="cypress" />
 import { bigtestGlobals, RunnerState } from '@bigtest/globals';
-import { Interaction, ReadonlyInteraction } from '@bigtest/interactor';
+import { Interaction, ReadonlyInteraction } from '@interactors/html';
 
 declare global {
   namespace Cypress {

--- a/integrations/cypress/src/index.ts
+++ b/integrations/cypress/src/index.ts
@@ -1,2 +1,2 @@
-export * from '@bigtest/interactor';
+export * from '@interactors/html';
 import './cypress';

--- a/integrations/cypress/yarn.lock
+++ b/integrations/cypress/yarn.lock
@@ -31,17 +31,6 @@
     "@bigtest/suite" "^0.11.2"
     effection "^1.0.0"
 
-"@bigtest/interactor@^0.29.0":
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.29.0.tgz#02617a825d4481672c780fe726615b0151ca2fef"
-  integrity sha512-5JOHIzhD25R7CuqR7eyNV+9iDOugGAEP/NDILRz63qyEAICx0fi2UYMOGZCj36yoh1oVj8BDOS8Scg3uJ7Qopg==
-  dependencies:
-    "@bigtest/globals" "^0.7.6"
-    "@bigtest/performance" "^0.5.0"
-    change-case "^4.1.1"
-    element-is-visible "^1.0.0"
-    lodash.isequal "^4.5.0"
-
 "@bigtest/performance@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@bigtest/performance/-/performance-0.5.0.tgz#195f2c445cbe2ebe4357e08f7b39449240bf62d7"
@@ -136,6 +125,17 @@
   integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@interactors/html@^0.31.2":
+  version "0.31.2"
+  resolved "https://registry.yarnpkg.com/@interactors/html/-/html-0.31.2.tgz#55979155245b7cfe6a6d000b89dafb078f09adbd"
+  integrity sha512-8Z2eb61zKtcfQASvptEkFzlqlRJYnh/fgqo8AxuDwevCRnkFHTP0HWr7mrmVQ+sR1ehAg2/B+0U4NlDjDEsCJA==
+  dependencies:
+    "@bigtest/globals" "^0.7.6"
+    "@bigtest/performance" "^0.5.0"
+    change-case "^4.1.1"
+    element-is-visible "^1.0.0"
+    lodash.isequal "^4.5.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -656,10 +656,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-7.7.0.tgz#0839ae28e5520536f9667d6c9ae81496b3836e64"
-  integrity sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==
+cypress@^8.0.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.3.0.tgz#ba906d2170888073ad94b2be1b994a749bbb7c7d"
+  integrity sha512-zA5Rcq8AZIfRfPXU0CCcauofF+YpaU9HYbfqkunFTmFV0Kdlo14tNjH2E3++MkjXKFnv3/pXq+HgxWtw8CSe8Q==
   dependencies:
     "@cypress/request" "^2.88.5"
     "@cypress/xvfb" "^1.2.4"
@@ -2107,9 +2107,9 @@ tslib@^1.8.1, tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.19.1"

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -25,12 +25,12 @@
     "pretest": "yarn pretest:manifest && yarn pretest:app"
   },
   "devDependencies": {
-    "@bigtest/interactor": "^0.31.0",
     "@bigtest/suite": "^0.11.2",
     "@bigtest/webdriver": "^0.8.4",
-    "@frontside/tsconfig": "^1.2.0",
     "@frontside/eslint-config": "^2.0.0",
+    "@frontside/tsconfig": "^1.2.0",
     "@frontside/typescript": "^1.1.1",
+    "@interactors/html": "^0.31.2",
     "@types/express": "^4.17.6",
     "@types/istanbul-lib-coverage": "^2.0.3",
     "@types/localforage": "^0.0.34",

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -1,7 +1,7 @@
 const { test } = require('@bigtest/suite');
 const { bigtestGlobals } = require('@bigtest/globals');
 const { strict: assert } = require('assert');
-const { createInteractor, App } = require('@bigtest/interactor');
+const { createInteractor, App } = require('@interactors/html');
 
 const localforage = require('localforage');
 

--- a/packages/bigtest/package.json
+++ b/packages/bigtest/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@bigtest/cli": "0.19.0",
-    "@bigtest/interactor": "0.31.1",
-    "@bigtest/suite": "0.11.3"
+    "@bigtest/suite": "0.11.3",
+    "@interactors/html": "^0.31.2"
   },
   "volta": {
     "node": "12.16.0",

--- a/packages/bigtest/src/index.ts
+++ b/packages/bigtest/src/index.ts
@@ -1,2 +1,2 @@
-export * from '@bigtest/interactor';
+export * from '@interactors/html';
 export { test, TestBuilder } from '@bigtest/suite';

--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -18,7 +18,6 @@
       "@bigtest/effection-express": ["packages/effection-express/src"],
       "@bigtest/eslint-plugin": ["packages/eslint-plugin/src"],
       "@bigtest/globals": ["packages/globals/src"],
-      "@bigtest/interactor": ["packages/interactor/src"],
       "@bigtest/logging": ["packages/logging/src"],
       "@bigtest/performance": ["packages/performance/src"],
       "@bigtest/project": ["packages/project/src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1708,17 +1708,6 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@bigtest/interactor@0.31.1", "@bigtest/interactor@^0.31.0":
-  version "0.31.1"
-  resolved "https://registry.yarnpkg.com/@bigtest/interactor/-/interactor-0.31.1.tgz#2eb3b59730dea2b028234f999b84869544981dbc"
-  integrity sha512-bvZxHDyb9HyqgQjxfYujFIQ5spnl0WdIB5ze1jUO2Igvmq+ND/oD84IHMyG58Jhu9KfBWdk+2smF++9QcgrPbQ==
-  dependencies:
-    "@bigtest/globals" "^0.7.6"
-    "@bigtest/performance" "^0.5.0"
-    change-case "^4.1.1"
-    element-is-visible "^1.0.0"
-    lodash.isequal "^4.5.0"
-
 "@changesets/apply-release-plan@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-4.0.0.tgz#e78efb56a4e459a8dab814ba43045f2ace0f27c9"
@@ -1918,7 +1907,12 @@
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.34", "@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
+"@definitelytyped/typescript-versions@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.34.tgz#6167363d378670ad7ef9485b7cff7d198106dcdf"
+  integrity sha512-7IqWcbHKYbfY8Lt7AigXDa29cbz3gynzBHMjwMUCeLnex8D682M6OW8uBLouvVHCr+YENL58tQB3dn0Zos8mFQ==
+
+"@definitelytyped/typescript-versions@^0.0.40", "@definitelytyped/typescript-versions@latest":
   version "0.0.40"
   resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.40.tgz#e7888b5bd0355777f78c76c50b13b9b1aa78b18e"
   integrity sha512-bhgrKayF1LRHlWgvsMtH1sa/y3JzJhsEVZiZE3xdoWyv9NjZ76dpGvXTNix2dz5585KgQJLP+cKeIdZbwHnCUA==
@@ -11177,10 +11171,33 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yargs-parser@13.1.2, yargs-parser@^10.0.0, yargs-parser@^13.1.2, yargs-parser@^15.0.1, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
+yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
   integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^15.0.1:
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.3.tgz#316e263d5febe8b38eef61ac092b33dfcc9b1115"
+  integrity sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs-parser@^18.1.1, yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## Motivation
Sequel to https://github.com/thefrontside/bigtest/pull/982

## Approach
Update `@bigtest` packages that had a dependency (or `devDependency`) on `@bigtest/interactor` to new `@interactors/html` name.

## Next step
- Update the `sample` app after merging/publishing these changes.

## Question
Is the `cypress package` not hooked up to the `changesets` workflow? I manually bumped the patch version here.