### PR TITLE
Rename @bigtest/cypress to @interactors/with-cypress

### DIFF
--- a/integrations/cypress/README.md
+++ b/integrations/cypress/README.md
@@ -1,6 +1,6 @@
 ## Getting Started
 ```
-npm install @bigtest/cypress
+npm install @interactors/with-cypress
 ```
 
 This package includes both `cypress` and `interactors`. Please refer to our [Interactor Docs](https://frontside.com/bigtest/docs/interactors) to learn how to use Interactors with Cypress.

--- a/integrations/cypress/package.json
+++ b/integrations/cypress/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@bigtest/cypress",
-  "version": "0.1.1",
-  "description": "Cypress Integration for BigTest Interactors",
+  "name": "@interactors/with-cypress",
+  "version": "0.1.2",
+  "description": "Cypress Integration for Interactors",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -60,7 +60,7 @@ import TabItem from '@theme/TabItem';
 </Tabs>
 
 :::note Cypress
-If you are using Cypress, you will only need to install `@bigtest/cypress`:
+If you are using Cypress, you will only need to install `@interactors/with-cypress`:
 
 <Tabs
   groupId="package-manager"
@@ -72,14 +72,14 @@ If you are using Cypress, you will only need to install `@bigtest/cypress`:
   <TabItem value="npm">
 
   ```
-  npm install @bigtest/cypress --save-dev
+  npm install @interactors/with-cypress --save-dev
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  yarn add @bigtest/cypress --dev
+  yarn add @interactors/with-cypress --dev
   ```
 
   </TabItem>
@@ -123,7 +123,7 @@ Interactors have methods like `click` that mimic user actions. If you are using 
   <TabItem value="cypress">
 
   ```js
-  import { Button } from '@bigtest/cypress';
+  import { Button } from '@interactors/with-cypress';
 
   describe('Interactors with Cypress', () => {
     beforeEach(() => cy.visit('/'));
@@ -266,7 +266,7 @@ Here are examples of what a test for an airline datepicker interface could look 
   <TabItem value="cypress">
 
   ```js
-  import { Heading, RadioButton, TextField } from '@bigtest/cypress';
+  import { Heading, RadioButton, TextField } from '@interactors/with-cypress';
   import { DatePicker, Modal } from './MyInteractors';
 
   describe('Interactors with Cypress', () => {

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -72,7 +72,7 @@ Locators, filters, and actions are optional when creating your own interactor. W
 :::
 
 :::note Cypress
-If you're using Cypress, all of the built-in Interactors and Interactor functions will need to be imported from `@bigtest/cypress` and not `bigtest`.
+If you're using Cypress, all of the built-in Interactors and Interactor functions will need to be imported from `@interactors/with-cypress` and not `@interactors/html`.
 :::
 
 ### `extend()` method
@@ -222,7 +222,7 @@ Let's get back to our example and add the new MyTextField interactor to a test. 
   <TabItem value="cypress">
 
   ```js
-  import { Button, Heading } from '@bigtest/cypress';
+  import { Button, Heading } from '@interactors/with-cypress';
   import { MyTextField } from './MyTextField';
 
   describe('email subscription form', () => {

--- a/website/docs/interactors/7-integrations.md
+++ b/website/docs/interactors/7-integrations.md
@@ -52,7 +52,7 @@ Interactors can be used with the `cy.do()` and `cy.expect()` commands for intera
 In the following example, we demonstrate how to to use `cy.do()` and `cy.expect()` in a Cypress test together with Interactors:
 
 ```js
-import { Button } from '@bigtest/cypress';
+import { Button } from '@interactors/with-cypress';
 
 describe('Interactors with Cypress', () => {
   beforeEach(() => cy.visit('/'));


### PR DESCRIPTION
## Motivation
Part of https://github.com/thefrontside/bigtest/issues/981

## Approach
`@bigtest/cypress` -> `@interactors/with-cypress`

I really like Next.js's use of the `with-` prefix in their examples: https://github.com/vercel/next.js/tree/canary/examples

### Alternate Designs
On Discord, we have also discussed `@interactors/within-cypress`, `@interactors/integration-cypress` and `@interactors/cypress` as possibilities.
