### PR TITLE
Add introduction for `mui` and add `Existing Interactors` page

### DIFF
--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -90,7 +90,7 @@ If you are using Cypress, you will only need to install `@interactors/with-cypre
 
 Interactors can do a lot, but let's keep things simple for now and begin testing one of the most common user interactions - a button click.
 
-Interactors have methods like `click` that mimic user actions. If you are using your own app, in your codebase find a test that already has a button click in it. In that test, import the `Button` interactor from `bigtest` and use it to replace the click interaction as exemplified below (make sure to substitute "Sign In" with your own button text):
+Interactors have methods like `click` that mimic user actions. If you are using your own app, in your codebase find a test that already has a button click in it. In that test, import the `Button` interactor from `@interactors/html` and use it to replace the click interaction as exemplified below (make sure to substitute "Sign In" with your own button text):
 
 <Tabs
   groupId="runner"
@@ -141,8 +141,8 @@ Interactors have methods like `click` that mimic user actions. If you are using 
   <TabItem value="bigtest">
 
   ```js
-  import { Page, test } from 'bigtest';
-  import { Button } from '@interactors/html';
+  import { test } from 'bigtest';
+  import { Button, Page } from '@interactors/html';
 
   export default test('BigTest')
     .step(
@@ -215,8 +215,8 @@ In the sample project, when you click the “Sign In” button it disappears and
   <TabItem value="bigtest">
 
   ```js
-  import { Page, test } from 'bigtest';
-  import { Button } from '@interactors/html';
+  import { test } from 'bigtest';
+  import { Button, Page } from '@interactors/html';
 
   export default test('BigTest')
     .step(
@@ -293,8 +293,8 @@ Here are examples of what a test for an airline datepicker interface could look 
   <TabItem value="bigtest">
 
   ```js
-  import { Page, test } from 'bigtest';
-  import { Heading, RadioButton, TextField } from '@interactors/html';
+  import { test } from 'bigtest';
+  import { Heading, Page, RadioButton, TextField } from '@interactors/html';
   import { DatePicker, Modal } from './MyInteractors';
 
   export default test('BigTest')

--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -4,12 +4,12 @@ title: Quick Start
 slug: /interactors
 ---
 
-BigTest's Interactors make writing your UI tests easier, faster, and more reliable. You can use them across many different testing frameworks.
+Interactors make writing your UI tests easier, faster, and more reliable. You can use them across many different testing frameworks.
 
 By the end of this page you will be testing one of your own apps with Interactors.
 
 :::note We're here to help
- If you need help or have questions along the way, please let us know in [the Discord chat](https://discord.gg/r6AvtnU) or [open a discussion](https://github.com/thefrontside/bigtest/discussions/) on Github.
+ If you need help or have questions along the way, please let us know in [the Discord chat](https://discord.gg/r6AvtnU) or [open a discussion](https://github.com/thefrontside/interactors/discussions/) on Github.
 :::
 
 ## Prerequisites
@@ -31,7 +31,7 @@ After you’ve installed the project, you’ll be able to run the test suite of 
 
 ## Installation
 
-If you're using your own app, install `bigtest` with the following command:
+If you're using your own app, install Interactors with the following command:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -46,14 +46,14 @@ import TabItem from '@theme/TabItem';
   <TabItem value="npm">
 
   ```
-  npm install bigtest --save-dev
+  npm install @interactors/html --save-dev
   ```
 
   </TabItem>
   <TabItem value="yarn">
 
   ```
-  yarn add bigtest --dev
+  yarn add @interactors/html --dev
   ```
 
   </TabItem>
@@ -107,7 +107,7 @@ Interactors have methods like `click` that mimic user actions. If you are using 
   import { render } from '@testing-library/react';
   import App from './App';
 
-  import { Button } from 'bigtest';
+  import { Button } from '@interactors/html';
 
   describe('Interactors with Jest', () => {
     beforeEach(() => render(<App />));
@@ -141,7 +141,8 @@ Interactors have methods like `click` that mimic user actions. If you are using 
   <TabItem value="bigtest">
 
   ```js
-  import { Button, Page, test } from 'bigtest';
+  import { Page, test } from 'bigtest';
+  import { Button } from '@interactors/html';
 
   export default test('BigTest')
     .step(
@@ -158,7 +159,7 @@ If you are using the sample project, you can find these examples inside `bigtest
 Now run your tests as you usually would or use any of the sample project options. Congratulations – you used your first Interactor!
 
 :::note The BigTest Runner
-There's more to BigTest than just Interactors. BigTest can also run your tests on any _real_ browser – just like your users use. We have built a new integrated platform from the ground up to help you test more with less effort. And best of all it's free and Open Source! [Check it out](/platform), and let us know what you think.
+BigTest can run your tests on any _real_ browser – just like your users use. We have built a new integrated platform from the ground up to help you test more with less effort. And best of all it's free and Open Source! [Check it out](/platform), and let us know what you think.
 :::
 
 ## Making test assertions
@@ -214,7 +215,8 @@ In the sample project, when you click the “Sign In” button it disappears and
   <TabItem value="bigtest">
 
   ```js
-  import { Button, Page, test } from 'bigtest';
+  import { Page, test } from 'bigtest';
+  import { Button } from '@interactors/html';
 
   export default test('BigTest')
     .step(
@@ -245,7 +247,7 @@ Here are examples of what a test for an airline datepicker interface could look 
   <TabItem value="jest">
 
   ```js
-  import { Heading, RadioButton, TextField } from 'bigtest';
+  import { Heading, RadioButton, TextField } from '@interactors/html';
   import { DatePicker, Modal } from './MyInteractors';
 
   describe('Interactors with Jest', () => {
@@ -291,7 +293,8 @@ Here are examples of what a test for an airline datepicker interface could look 
   <TabItem value="bigtest">
 
   ```js
-  import { Heading, RadioButton, Page, test, TextField } from 'bigtest';
+  import { Page, test } from 'bigtest';
+  import { Heading, RadioButton, TextField } from '@interactors/html';
   import { DatePicker, Modal } from './MyInteractors';
 
   export default test('BigTest')
@@ -323,4 +326,4 @@ Once you are comfortable with those, you’ll want to [write your own Interactor
 
 ### Join the BigTest community
 
-If you want to know more about BigTest or run into any problem with Interactors, you can reach out to us on our Discord channel. We're eager to help you get started and hear your feedback on how to improve BigTest. [Join us today!](https://discord.gg/r6AvtnU)
+If you want to know more about Interactors or have any questions, you can reach out to us on our Discord channel. We're eager to help you get started and hear your feedback on how to improve Interactors. [Join us today!](https://discord.gg/r6AvtnU)

--- a/website/docs/interactors/1-quick-start.md
+++ b/website/docs/interactors/1-quick-start.md
@@ -315,7 +315,7 @@ As you can see, Interactors not only make it simple to use DOM elements like Rad
 
 ### Continue learning about Interactors
 
-Try using more of the [Built-in Interactors](/docs/interactors/built-in-dom) within your tests such as `Link`, `CheckBox`, `TextField`, and more.
+Try using more of the [Predefined Interactors](/docs/interactors/predefined-interactors) within your tests such as `Link`, `CheckBox`, `TextField`, and more.
 
 You’ll quickly realize how much more powerful Interactors are when combined with [Locators, Filters, and Actions](/docs/interactors/locators-filters-actions).
 

--- a/website/docs/interactors/2-predefined-interactors.md
+++ b/website/docs/interactors/2-predefined-interactors.md
@@ -1,9 +1,9 @@
 ---
-id: built-in-dom
-title: Built-in Interactors
+id: predefined-interactors
+title: Predefined Interactors
 ---
 
-Built-in Interactors cover some of the most common UI testing needs for apps that run in the browser.
+Predefined interactors cover some of the most common UI testing needs for apps that run in the browser.
 
 These are the default interactors that are offered out-of-the-box with BigTest:
 
@@ -28,12 +28,12 @@ If your app has unique interfaces that are not covered by these built-in tools, 
 
 ### Page
 
-The `Page` interactor is unique. Unlike Big Test’s other built-in interactors, it's not designed to target one specific element but rather the whole page. It is useful for asserting for the url or title in your test environment:
+The `Page` interactor is unique. Unlike BigTest’s other predefined interactors, it's not designed to target one specific element but rather the whole page. It is useful for asserting for the url or title in your test environment:
 
 ```js
 Page.has({ title: 'BigTest Example App' });
 ```
-_The `Page` interactor is instantiated differently than the other built-in interactors so you do not need to call it `Page()` unless you want to pass in an argument._
+_The `Page` interactor is instantiated differently than the other predefined interactors so you do not need to call it `Page()` unless you want to pass in an argument._
 
 :::note Heads up
 We introduced `.exists()` and `.absent()` in the [Quick Start](/docs/interactors/) section but there are also `.has()` and `.is()` Interactor assertion methods. We will discuss their details on the [Assertions](/docs/interactors/assertions) page.

--- a/website/docs/interactors/2-predefined-interactors.md
+++ b/website/docs/interactors/2-predefined-interactors.md
@@ -24,7 +24,7 @@ As you might have seen on the [Quick Start](/docs/interactors/) page, you can im
 import { Button, TextField } from '@interactors/html';
 ```
 
-If your app has unique interfaces that are not covered by these built-in tools, you are encouraged to [write your own interactors](/docs/interactors/write-your-own).
+If your app has unique interfaces that are not covered by these built-in tools, you are encouraged to [write your own interactors](/docs/interactors/write-your-own). You can also check out [Existing Interactors](/docs/interactors/existing-interactors) to find out where you can see interactors written by other organizations.
 
 ### Page
 
@@ -49,43 +49,6 @@ export default test('BigTest Runner')
   .step(Page.visit('/contact'))
   .assertion(Page.has({ title: 'BigTest Example App'}));
 ```
-
-## More Interactors
-
-There are organizations that have already adopted interactors. With their permission we are able to share their interactors as they may be helpful to you.
-
-### FOLIO
-
-FOLIO uses interactors for testing their `Stripes` components. You can browse through their catalog of UI components [here](https://github.com/folio-org/stripes-components/tree/master/lib). 
-
-Click on any of the folders to see the component itself for reference. And within each component folder, you'll find a `test/` directory where they have written an interactor for the respective component and corresponding tests where they use the interactor.
-
-For example:
-
-```
-stripes-component/lib/
-  Accordion/
-    Accordion.js           <= UI component
-    tests/
-      interactor.js        <= Interactor for the component
-      Accordion-test.js    <= Tests using interactor
-```
-
-:::note
-They are using Mocha to test their components, but interactors can be used in a wide variety of testing frameworks as long it relies on DOM or a simulated DOM. Read more about it on the [Jest & Cypress](/docs/interactors/integrations) page.
-:::
-
-### Material-UI
-
-If you use [`Material UI`](https://material-ui.com/) to design your apps, we have some great news! The interactors for each Material UI components have already been written. You can see each of those interactors [here](https://github.com/thefrontside/material-ui-interactors/tree/v4/src).
-
-On our [Storybook & Material UI](/docs/interactors/storybook-mui) page, we show an example of how you can get started with Material UI interactors as well as discuss how it can be used to write stories in [Storybook](https://storybook.js.org/).
-
-## Show Us Your Interactors!
-
-If you would like to showcase your projects' interactors or if you think there any common UI components that you think should be added to the list of predefined interactors, please let us know!
-
-You can create a pull request in our [GitHub repository](https://github.com/thefrontside/interactors) or reach out to us on our [Discord channel](https://discord.gg/r6AvtnU).
 
 ## Up Next
 

--- a/website/docs/interactors/2-predefined-interactors.md
+++ b/website/docs/interactors/2-predefined-interactors.md
@@ -5,7 +5,7 @@ title: Predefined Interactors
 
 Predefined interactors cover some of the most common UI testing needs for apps that run in the browser.
 
-These are the default interactors that are offered out-of-the-box with BigTest:
+These are the default interactors that are offered in `@interactors/html`:
 
 - [Button](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/button.ts)
 - [CheckBox](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/check-box.ts)
@@ -28,7 +28,7 @@ If your app has unique interfaces that are not covered by these built-in tools, 
 
 ### Page
 
-The `Page` interactor is unique. Unlike BigTest’s other predefined interactors, it's not designed to target one specific element but rather the whole page. It is useful for asserting for the url or title in your test environment:
+The `Page` interactor is unique. Unlike the other predefined interactors, it's not designed to target one specific element but rather the whole page. It is useful for asserting for the url or title in your test environment:
 
 ```js
 Page.has({ title: 'BigTest Example App' });
@@ -42,7 +42,8 @@ We introduced `.exists()` and `.absent()` in the [Quick Start](/docs/interactors
 And when using the BigTest runner, the Page interactor can be used to navigate between routes:
 
 ```js
-import { Page, test } from 'bigtest';
+import { test } from 'bigtest';
+import { Page } from '@interactors/html';
 
 export default test('BigTest Runner')
   .step(Page.visit('/contact'))

--- a/website/docs/interactors/2-predefined-interactors.md
+++ b/website/docs/interactors/2-predefined-interactors.md
@@ -7,21 +7,21 @@ Predefined interactors cover some of the most common UI testing needs for apps t
 
 These are the default interactors that are offered out-of-the-box with BigTest:
 
-- [Button](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/button.ts)
-- [CheckBox](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/check-box.ts)
-- [FormField](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/form-field.ts)
-- [Heading](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/heading.ts)
-- [Link](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/link.ts)
-- [MultiSelect](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/multi-select.ts)
-- [Page](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/page.ts)
-- [RadioButton](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/radio-button.ts)
-- [Select](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/select.ts)
-- [TextField](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/text-field.ts)
+- [Button](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/button.ts)
+- [CheckBox](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/check-box.ts)
+- [FormField](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/form-field.ts)
+- [Heading](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/heading.ts)
+- [Link](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/link.ts)
+- [MultiSelect](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/multi-select.ts)
+- [Page](https://github.com/thefrontside/interactors/blob/main/packages/html/src/page.ts)
+- [RadioButton](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/radio-button.ts)
+- [Select](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/select.ts)
+- [TextField](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/text-field.ts)
 
-As you might have seen on the [Quick Start](/docs/interactors/) page, you can import any of the interactors directly from the `bigtest` package:
+As you might have seen on the [Quick Start](/docs/interactors/) page, you can import any of the interactors directly from the `@interactors/html` package:
 
 ```js
-import { Button, TextField } from 'bigtest';
+import { Button, TextField } from '@interactors/html';
 ```
 
 If your app has unique interfaces that are not covered by these built-in tools, you are encouraged to [write your own interactors](/docs/interactors/write-your-own).

--- a/website/docs/interactors/2-predefined-interactors.md
+++ b/website/docs/interactors/2-predefined-interactors.md
@@ -50,6 +50,43 @@ export default test('BigTest Runner')
   .assertion(Page.has({ title: 'BigTest Example App'}));
 ```
 
+## More Interactors
+
+There are organizations that have already adopted interactors. With their permission we are able to share their interactors as they may be helpful to you.
+
+### FOLIO
+
+FOLIO uses interactors for testing their `Stripes` components. You can browse through their catalog of UI components [here](https://github.com/folio-org/stripes-components/tree/master/lib). 
+
+Click on any of the folders to see the component itself for reference. And within each component folder, you'll find a `test/` directory where they have written an interactor for the respective component and corresponding tests where they use the interactor.
+
+For example:
+
+```
+stripes-component/lib/
+  Accordion/
+    Accordion.js           <= UI component
+    tests/
+      interactor.js        <= Interactor for the component
+      Accordion-test.js    <= Tests using interactor
+```
+
+:::note
+They are using Mocha to test their components, but interactors can be used in a wide variety of testing frameworks as long it relies on DOM or a simulated DOM. Read more about it on the [Jest & Cypress](/docs/interactors/integrations) page.
+:::
+
+### Material-UI
+
+If you use [`Material UI`](https://material-ui.com/) to design your apps, we have some great news! The interactors for each Material UI components have already been written. You can see each of those interactors [here](https://github.com/thefrontside/material-ui-interactors/tree/v4/src).
+
+On our [Storybook & Material UI](/docs/interactors/storybook-mui) page, we show an example of how you can get started with Material UI interactors as well as discuss how it can be used to write stories in [Storybook](https://storybook.js.org/).
+
+## Show Us Your Interactors!
+
+If you would like to showcase your projects' interactors or if you think there any common UI components that you think should be added to the list of predefined interactors, please let us know!
+
+You can create a pull request in our [GitHub repository](https://github.com/thefrontside/interactors) or reach out to us on our [Discord channel](https://discord.gg/r6AvtnU).
+
 ## Up Next
 
 What are the pieces that make up an interactor? Locators and filters help you find things in the UI and make assertions. Actions advance the state of your app. Keep reading on the [Locators, Filters, and Actions](/docs/interactors/locators-filters-actions) page to learn more.

--- a/website/docs/interactors/3-locators-filters-actions.md
+++ b/website/docs/interactors/3-locators-filters-actions.md
@@ -3,7 +3,7 @@ id: locators-filters-actions
 title: Locators, Filters, and Actions
 ---
 
-Whether they are built-in or written by you, all interactors have some things in common. They have to be able to find elements in the page and manipulate them like a user would. To do these things, Interactors use a locator, filters, and actions.
+Whether they are predefined or written by you, all interactors have some things in common. They have to be able to find elements in the page and manipulate them like a user would. To do these things, Interactors use a locator, filters, and actions.
 
 ## The Locator
 
@@ -18,7 +18,7 @@ Button(/Submit/).exists(); // regex
 
 A typical user identifies a button by the words printed across it, so in this example they would consider a button with the word 'Submit' on it as the "Submit" button. Interactors use locators to make that connection.
 
-What is going on behind the scenes? Just like the user, the built-in Button interactor provided by BigTest looks for a button with "Submit" on it. It uses [element.innerText](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/button.ts#L11) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.innerText` is equal to `Submit`.
+What is going on behind the scenes? Just like the user, the predefined Button interactor looks for a button with "Submit" on it. It uses [element.innerText](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/button.ts#L11) to find the match. Or to put it another way, `Button('Submit')` returns a button element whose `element.innerText` is equal to `Submit`.
 
 ### The locator is optional
 
@@ -50,10 +50,10 @@ The locator of the `TextField` interactor is the `innerText` of its associated l
 </label>
 ```
 
-_This is just the way the built-in TextField interactor is configured. It is possible to modify pre-existing interactors such as this TextField interactor or create your own interactors from scratch to suit your needs. We will be going over how you can do all of this on the [Writing Interactors](/docs/interactors/write-your-own) page._
+_This is just the way the predefined TextField interactor is configured. It is possible to modify pre-existing interactors such as this TextField interactor or create your own interactors from scratch to suit your needs. We will be going over how you can do all of this on the [Writing Interactors](/docs/interactors/write-your-own) page._
 :::
 
-You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why BigTest offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.
+You can think of the locator as the "default filter" since filters and locators both provide the same functionality. The reason why Interactors offers both solutions is convenience, because having to pass in an object for each interactor can get repetitive.
 
 Filters are useful in a variety of contexts. For example, most forms have multiple textfields. You would need to use a filter if they do not have labels or if there are multiple labels with the same value, as a locator would not work in such a scenario.
 
@@ -66,7 +66,7 @@ Take for instance, this example of a form with textfields that do not have label
 </form>
 ```
 
-We cannot specify a locator based on the label, so using `TextField()` without a locator would return two elements and therefore produce an error. We can narrow down from two TextFields to one using either the `id` or `placeholder` filters provided by the BigTest `TextField` interactor:
+We cannot specify a locator based on the label, so using `TextField()` without a locator would return two elements and therefore produce an error. We can narrow down from two TextFields to one using either the `id` or `placeholder` filters provided by the predefined `TextField` interactor:
 
 ```js
 TextField({ id: 'username-id' }).exists();
@@ -79,7 +79,7 @@ The filter object can take as many properties as you want it to:
 TextField({ id: 'username-id', placeholder: 'USERNAME', visible: true }).exists();
 ```
 
-The filters available are defined by each interactor, so look at the source code for the built-in interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters. In addition, TextField inherits all of the properties of the [FormField interactor](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/form-field.ts) and [HTML interactor](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/html.ts).
+The filters available are defined by each interactor, so look at the source code for the predefined interactors to know what is available. For example, if you take a look at the [TextField source code](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/text-field.ts), you'll see that the TextField interactor provides two filters. In addition, TextField inherits all of the properties of the [FormField interactor](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/form-field.ts) and [HTML interactor](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/html.ts).
 
 ## Actions
 

--- a/website/docs/interactors/4-assertions.md
+++ b/website/docs/interactors/4-assertions.md
@@ -62,4 +62,4 @@ Button('Sign In').absent();
 
 ## Up Next
 
-In the next page, [Matchers](/docs/interactors/matchers), we will be going over the different matchers that are offered with BigTest and ways in which you can compose your own matchers.
+In the next page, [Matchers](/docs/interactors/matchers), we will be going over the different matchers that are offered in Interactors and ways in which you can compose your own matchers.

--- a/website/docs/interactors/5-matchers.md
+++ b/website/docs/interactors/5-matchers.md
@@ -3,7 +3,7 @@ id: matchers
 title: Matchers
 ---
 
-Here, we will do a deep dive on how you can utilize matchers that are offered out-of-the-box with BigTest, and also go over how you can compose your own reusable matchers.
+Here, we will do a deep dive on how you can utilize matchers that are offered out-of-the-box in Interactors, and also go over how you can compose your own reusable matchers.
 
 ## Writing flexible assertions using Matchers
 
@@ -91,7 +91,7 @@ Heading().has({ or(id: 'foo', id: 'bar') }); // bad
 
 ### Iterable matchers
 
-For when you need to assert against iterables, you will find the `some()` and `every()` matchers very helpful. We will use the [`MultiSelect`](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/multi-select.ts#L48) interactor for the next example because its `values` filter returns an array based on its options' label:
+For when you need to assert against iterables, you will find the `some()` and `every()` matchers very helpful. We will use the [`MultiSelect`](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/multi-select.ts#L45) interactor for the next example because its `values` filter returns an array based on its options' label:
 
 ```js
 .filters({
@@ -124,7 +124,7 @@ Though the matchers are already ergonomic, you can make your tests even tidier a
 We will first go over how you can compose matchers using preexisting matchers. Let us start by creating a matcher called `hasFoo`:
 
 ```js
-import { including } from 'bigtest';
+import { including } from '@interactors/html';
 
 export const hasFoo = including('Foo');
 ```
@@ -138,7 +138,7 @@ Heading(hasFoo).exists()
 You can compose a matcher using other matchers too. This is convenient because it delegates most of the matcher's logic as well as the error message. In the example below, you can see that we use `or`, `including`, and `every` to create a matcher for a MultiSelect.
 
 ```js
-import { including, or } from 'bigtest';
+import { including, or } from '@interactors/html';
 
 export const blueOrGreen = or(
   including('Blue'),
@@ -169,7 +169,7 @@ export function including(subString) {
 };
 ```
 
-_You can find the source code for the `including()` matcher [here](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/matchers/including.ts)._
+_You can find the source code for the `including()` matcher [here](https://github.com/thefrontside/interactors/blob/main/packages/html/src/matchers/including.ts)._
 
 And the return value from the `description()` function is to display an error message for when no interactors are found:
 

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -9,7 +9,7 @@ In this section, you will learn how to write a new Interactor for any interface 
 
 ## Writing your first interactor
 
-In this tutorial, we will create our own `TextField` interactor. Although there already is a [built-in TextField](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/text-field.ts) interactor, recreating it is a great way to learn all the pieces that make up an interactor while using familiar examples.
+In this tutorial, we will create our own `TextField` interactor. Although there already is a predefined [TextField](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/text-field.ts) interactor, recreating it is a great way to learn all the pieces that make up an interactor while using familiar examples.
 
 There are four things to decide when creating an interactor:
 1. What to name and label the interactor
@@ -17,7 +17,7 @@ There are four things to decide when creating an interactor:
 3. The locator and filters, which helps users be able to narrow down the element they want to reference
 4. The action or actions that a test should `perform` when using the interactor (like `click`)
 
-Putting this together, let's create a new Interactor called `MyTextField` with a label of 'my-textfield-interactor'. We'll specify the selector as `input[type=text]` so that it targets all the text input elements, define a `value` filter, and provide a `fillIn` action. And to differentiate from the built-in TextField interactor, we'll configure the placeholder value as its locator:
+Putting this together, let's create a new Interactor called `MyTextField` with a label of 'my-textfield-interactor'. We'll specify the selector as `input[type=text]` so that it targets all the text input elements, define a `value` filter, and provide a `fillIn` action. And to differentiate from the predefined TextField interactor, we'll configure the placeholder value as its locator:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -32,7 +32,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="javascript">
 
   ```js
-  import { fillIn, HTML } from 'bigtest';
+  import { fillIn, HTML } from '@interactors/html';
 
   export const MyTextField = HTML.extend('my-textfield-interactor')
     .selector('input[type=text]')
@@ -49,7 +49,7 @@ import TabItem from '@theme/TabItem';
   <TabItem value="typescript">
 
   ```ts
-  import { fillIn, HTML } from 'bigtest';
+  import { fillIn, HTML } from '@interactors/html';
 
   export const MyTextField = HTML.extend<HTMLInputElement>('my-textfield-interactor')
     .selector('input[type=text]')
@@ -65,30 +65,30 @@ import TabItem from '@theme/TabItem';
   </TabItem>
 </Tabs>
 
-Locators, filters, and actions are optional when creating your own interactor. While the locator for the `TextField` interactor offered by BigTest uses the `innerText` of the associated label, the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of locators to anything that suits your needs. If you create an interactor without a locator, it would by default use the `innerText` value for its locator.
+Locators, filters, and actions are optional when creating your own interactor. While the locator for the predefined `TextField` interactor uses the `innerText` of the associated label, the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of locators to anything that suits your needs. If you create an interactor without a locator, it would by default use the `innerText` value for its locator.
 
 :::note
-`fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/fill-in.ts#L63-L76). You can use any of the functions defined by BigTest or implement your own.
-:::
+`fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/interactors/blob/main/packages/html/src/fill-in.ts#L63-L76). You can use any of the predefined functions or implement your own.
+::: 
 
 :::note Cypress
-If you're using Cypress, all of the built-in Interactors and Interactor functions will need to be imported from `@interactors/with-cypress` and not `bigtest`.
+If you're using Cypress, all of the predefined Interactors and Interactor functions will need to be imported from `@interactors/with-cypress` and not `@interactors/html`.
 :::
 
 ### `extend()` method
 
-In the example above, we're extending from the `HTML` interactor to compose the `MyTextField` interactor, but if you take a look at the implementation of the [built-in TextField](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/text-field.ts) interactor, you'll see that the `value` filter and `fillIn` action are already available.
+In the example above, we're extending from the `HTML` interactor to compose the `MyTextField` interactor, but if you take a look at the implementation of the predefined [TextField](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/text-field.ts) interactor, you'll see that the `value` filter and `fillIn` action are already available.
 
-You could reimplement the `value` filter and `fillIn` action from scratch like we did in the example, however, it would be more practical to just extend from the built-in TextField interactor instead:
+You could reimplement the `value` filter and `fillIn` action from scratch like we did in the example, however, it would be more practical to just extend from the predefined TextField interactor instead:
 
 ```js
-import { TextField } from 'bigtest';
+import { TextField } from '@interactors/html';
 
 export const MyTextField = TextField.extend('my-textfield-interactor')
   .locator((element) => element.placeholder)
 ```
 
-This approach would allow `MyTextField` to inherit the selector, locator, filters, and actions from the built-in `TextField`. You can overwrite any of the inherited properties to suit your needs, which is what we are doing with the locator in this instance.
+This approach would allow `MyTextField` to inherit the selector, locator, filters, and actions from the predefined `TextField`. You can overwrite any of the inherited properties to suit your needs, which is what we are doing with the locator in this instance.
 
 ### `HTML` interactor
 
@@ -96,7 +96,7 @@ You can think of the `HTML` interactor as the basic building block for all other
 
 Many common HTML properties and interactions, such as `className` and `click`, are included in the `HTML` interactor. This provides the convenience of not having to re-specify these properties over and over again for each of your interactors.
 
-Take a look at the [source code](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/html.ts) for the `HTML` interactor to see which filters and actions were added.
+Take a look at the [source code](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/html.ts) for the `HTML` interactor to see which filters and actions were added.
 
 ### Interactor label
 
@@ -142,7 +142,7 @@ The former syntax is necessary if you want to write an action that delegates to 
   <TabItem value="javascript">
 
   ```js
-  import { Button, HTML } from 'bigtest';
+  import { Button, HTML } from '@interactors/html';
 
   export const Form = HTML.extend('my-form-interactor')
     .selector('form')
@@ -157,7 +157,7 @@ The former syntax is necessary if you want to write an action that delegates to 
   <TabItem value="typescript">
 
   ```ts
-  import { Button, HTML } from 'bigtest';
+  import { Button, HTML } from '@interactors/html';
 
   export const Form = HTML.extend<HTMLFormElement>('my-form-interactor')
     .selector('form')
@@ -204,7 +204,7 @@ Let's get back to our example and add the new MyTextField interactor to a test. 
   import { render } from '@testing-library/react';
   import App from './App';
 
-  import { Button, Heading } from 'bigtest';
+  import { Button, Heading } from '@interactors/html';
   import { MyTextField } from './MyTextField';
 
   describe('email subscription form', () => {
@@ -264,11 +264,11 @@ TextField({ placeholder: 'email' }).fillIn('batman@gmail.com');
 MyTextField('email').fillIn('batman@gmail.com');
 ```
 
-Although the built-in interactors may cover most use cases, the composability of interactors means there is no limit to how much you can optimize and tailor them to your needs.
+Although the predefined interactors may cover most use cases, the composability of interactors means there is no limit to how much you can optimize and tailor them to your needs.
 
 ## Writing a more complex interactor
 
-One of the greatest benefits of Interactors is that you can turn complex testing scenarios into readable assertions. Let’s illustrate how that looks like with an historically cumbersome UI piece: a table. We want to be able to easily assert the contents of our tables, and that means that we should be able to know the value in a cell given its column and row. Once we’re done creating a TableCell Interactor, we’ll be able to make that happen and have it look like this:
+One of the greatest benefits of Interactors is that you can turn complex testing scenarios into readable assertions. Let’s illustrate how that looks like with a historically cumbersome UI piece: a table. We want to be able to easily assert the contents of our tables, and that means that we should be able to know the value in a cell given its column and row. Once we’re done creating a TableCell Interactor, we’ll be able to make that happen and have it look like this:
 
 ```js
 TableCell({ columnTitle: 'Name', rowNumber: 2 }).has({ value: 'Marge Simpson' });
@@ -300,7 +300,7 @@ First, consider some table markup defined as follows:
 Here is one way to create the `TableCell` interactor:
 
 ```js
-import { HTML } from 'bigtest';
+import { HTML } from '@interactors/html';
 
 export const TableCell = HTML.extend('table cell')
   .selector('[role=gridcell]')
@@ -336,7 +336,7 @@ export const TableCell = HTML.extend('table cell')
 This example uses [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) which is available in Node >=14.
 :::
 
-Once again, by extending from the `HTML` interactor, our new TableCell interactor inherits all of the pre-defined filters and actions of the `HTML` interactor as defined [here](https://github.com/thefrontside/interactors/blob/v0/packages/html/src/definitions/html.ts). If we needed to access a table cell's `id` property in our tests, we would not need to create a separate filter for it as it is already available on the `HTML` interactor.
+Once again, by extending from the `HTML` interactor, our new TableCell interactor inherits all of the pre-defined filters and actions of the `HTML` interactor as defined [here](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/html.ts). If we needed to access a tablecell's `id` property in our tests, we would not need to create a separate filter for it as it is already available on the `HTML` interactor.
 
 Inside the TableCell interactor we created `columnTitle` and `rowNumber` filters that will access its parent elements to get the appropriate value we're looking for. The locator was not specified, so it will default to `element.innerText || element.textContent`. We can now effectively use the TableCell interactor as we stated at the beginning of this page:
 
@@ -410,7 +410,7 @@ Now that we have the TableCell Interactor ready, let’s put it in action to tes
   </TabItem>
 </Tabs>
 
-With some thinking beforehand about how to test a data-driven UI, you can write interactors and tests that can be quickly modified as changes occur over the lifetime of your app. The BigTest Interactor approach is flexible and can handle changes like adding new columns, rearranging the order, inserting table headings, and more.
+With some thinking beforehand about how to test a data-driven UI, you can write interactors and tests that can be quickly modified as changes occur over the lifetime of your app. The Interactor approach is flexible and can handle changes like adding new columns, rearranging the order, inserting table headings, and more.
 
 ## Chaining interactors together
 
@@ -433,11 +433,11 @@ DatePicker().find(Button('31')).click();
 
 ## Common questions
 
-### When should I write a new Interactor instead of using the Built In DOM interactors?
+### When should I write a new Interactor instead of using the predefined interactors?
 
-If the built-in DOM Interactors work for your use case, they are probably the best choice. They are maintenance-free and support the most common user actions.
+If the predefined interactors work for your use case, they are probably the best choice. They are maintenance-free and support the most common user actions.
 
-When the built-in Interactors are not enough, we encourage you to write your own. They will help prevent duplicated logic in your tests, and if your interface changes, you only need to make changes to the Interactor instead of throughout the code.
+When the predefined interactors are not enough, we encourage you to write your own. They will help prevent duplicated logic in your tests, and if your interface changes, you only need to make changes to the Interactor instead of throughout the code.
 
 For example, let's say that you want to replace a custom datepicker with a popular third-party library instead. Although you may have many tests for flows with the date picker, only your Interactor needs to change.
 

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -7,6 +7,10 @@ Nearly every app has at least one user interaction that is unusual or special, l
 
 In this section, you will learn how to write a new Interactor for any interface and use it in your tests. We will start with a simple example for learning purposes, level up to a more complex scenario, and then cover common questions.
 
+:::note
+On the [Existing Interactors](/docs/interactors/existing-interactors) page, you will discover some examples of interactors written for other projects and libraries. Although you may be able to find prewritten interactors that suit your needs, we still recommend you read through the rest of this guide to understand how interactors are composed as you will find it useful to be able to modify existing and predefined interactors.
+:::
+
 ## Writing your first interactor
 
 In this tutorial, we will create our own `TextField` interactor. Although there already is a predefined [TextField](https://github.com/thefrontside/interactors/blob/main/packages/html/src/definitions/text-field.ts) interactor, recreating it is a great way to learn all the pieces that make up an interactor while using familiar examples.
@@ -442,6 +446,8 @@ If the predefined interactors work for your use case, they are probably the best
 When the predefined interactors are not enough, we encourage you to write your own. They will help prevent duplicated logic in your tests, and if your interface changes, you only need to make changes to the Interactor instead of throughout the code.
 
 For example, let's say that you want to replace a custom datepicker with a popular third-party library instead. Although you may have many tests for flows with the date picker, only your Interactor needs to change.
+
+You are also encouraged to browse through the collection of interactors written by other oganizations. We share some of them on the [Existing Interactors](/docs/interactors/existing-interactors) page. Even if you end up writing your own interactors, seeing examples in other projects will provide you with a good point of reference.
 
 ### I have an interaction that is really difficult to test. What should I do?
 

--- a/website/docs/interactors/6-write-your-own.md
+++ b/website/docs/interactors/6-write-your-own.md
@@ -68,7 +68,7 @@ import TabItem from '@theme/TabItem';
 Locators, filters, and actions are optional when creating your own interactor. While the locator for the predefined `TextField` interactor uses the `innerText` of the associated label, the example above has its locator configured as `element.placeholder`. This is just to demonstrate that you can set the properties of locators to anything that suits your needs. If you create an interactor without a locator, it would by default use the `innerText` value for its locator.
 
 :::note
-`fillIn` is a function exported by `bigtest`. See the implementation [here](https://github.com/thefrontside/interactors/blob/main/packages/html/src/fill-in.ts#L63-L76). You can use any of the predefined functions or implement your own.
+`fillIn` is a function exported by `@interactors/html`. See the implementation [here](https://github.com/thefrontside/interactors/blob/main/packages/html/src/fill-in.ts#L63-L76). You can use any of the predefined functions or implement your own.
 ::: 
 
 :::note Cypress
@@ -242,7 +242,8 @@ Let's get back to our example and add the new MyTextField interactor to a test. 
   <TabItem value="bigtest">
 
   ```js
-  import { Button, Heading, Page, test } from 'bigtest';
+  import { test } from 'bigtest';
+  import { Button, Heading, Page } from '@interactors/html';
   import { MyTextField } from './MyTextField';
 
   export default test('email subscription form')
@@ -396,7 +397,8 @@ Now that we have the TableCell Interactor ready, let’s put it in action to tes
 
 
   ```js
-  import { Page, test } from 'bigtest';
+  import { test } from 'bigtest';
+  import { Page } from '@interactors/html';
   import { TableCell } from './tablecell';
 
   export default test('Jeopardy chart')

--- a/website/docs/interactors/7-integrations.md
+++ b/website/docs/interactors/7-integrations.md
@@ -90,3 +90,7 @@ TypeScript users should make sure to add `cypress` to the types array in `tsconf
 }
 ```
 See Cypress' guide on [TypeScript support](https://docs.cypress.io/guides/tooling/typescript-support.html#Configure-tsconfig-json) for more details.
+
+## Up Next
+
+Now that we have seen how Interactors can enhance your tests in various testing frameworks, in the next page we will show you how Interactors can also help you _develop_ your app's UI components with its integration of `Storybook` and `Material-UI`.

--- a/website/docs/interactors/7-integrations.md
+++ b/website/docs/interactors/7-integrations.md
@@ -45,9 +45,9 @@ JSDOM versions 15 and below do not have support for `InputEvent` on which intera
 
 ## Cypress
 
-Interactors fit right in with Cypress as well, though as we explain below you may need some slight configuration for ES Modules and TypeScript. In order to use interactors with Cypress, you will need to install `@bigtest/cypress` - this package is from where you would import any of the [predefined interactors](/bigtest/docs/interactors/predefined-interactors).
+Interactors fit right in with Cypress as well, though as we explain below you may need some slight configuration for ES Modules and TypeScript. In order to use interactors with Cypress, you will need to install `@bigtest/cypress` - this package is from where you would import any of the [predefined interactors](/docs/interactors/predefined-interactors).
 
-Interactors can be used with the `cy.do()` and `cy.expect()` commands for interactions and assertions respectively. These Cypress commands are automatically registered whenever you are importing or creating interactors, and can take either a single interactor or an array of interactors. This helps your Cypress tests follow a arrange-act-assert pattern, which is inherent to [BigTest](/bigtest/docs/platform/architecture) and thus to Interactors.
+Interactors can be used with the `cy.do()` and `cy.expect()` commands for interactions and assertions respectively. These Cypress commands are automatically registered whenever you are importing or creating interactors, and can take either a single interactor or an array of interactors. This helps your Cypress tests follow a arrange-act-assert pattern, which is inherent to [BigTest](/docs/platform/architecture) and thus to Interactors.
 
 In the following example, we demonstrate how to to use `cy.do()` and `cy.expect()` in a Cypress test together with Interactors:
 

--- a/website/docs/interactors/7-integrations.md
+++ b/website/docs/interactors/7-integrations.md
@@ -93,4 +93,4 @@ See Cypress' guide on [TypeScript support](https://docs.cypress.io/guides/toolin
 
 ## Up Next
 
-Now that we have seen how Interactors can enhance your tests in various testing frameworks, in the next page we will show you how Interactors can also help you _develop_ your app's UI components with its integration of `Storybook` and `Material-UI`.
+Now that we have seen how Interactors can enhance your tests in various testing frameworks, in the next page, we will show you how Interactors can also help you _develop_ your app's UI components with `Storybook`.

--- a/website/docs/interactors/7-integrations.md
+++ b/website/docs/interactors/7-integrations.md
@@ -23,7 +23,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-import { Button } from 'bigtest';
+import { Button } from '@interactors/html';
 
 describe('Interactors with Jest', () => {
   beforeEach(() => render(<App />));
@@ -45,7 +45,7 @@ JSDOM versions 15 and below do not have support for `InputEvent` on which intera
 
 ## Cypress
 
-Interactors fit right in with Cypress as well, though as we explain below you may need some slight configuration for ES Modules and TypeScript.
+Interactors fit right in with Cypress as well, though as we explain below you may need some slight configuration for ES Modules and TypeScript. In order to use interactors with Cypress, you will need to install `@bigtest/cypress` - this package is from where you would import any of the [predefined interactors](/bigtest/docs/interactors/predefined-interactors).
 
 Interactors can be used with the `cy.do()` and `cy.expect()` commands for interactions and assertions respectively. These Cypress commands are automatically registered whenever you are importing or creating interactors, and can take either a single interactor or an array of interactors. This helps your Cypress tests follow a arrange-act-assert pattern, which is inherent to [BigTest](/bigtest/docs/platform/architecture) and thus to Interactors.
 

--- a/website/docs/interactors/8-storybook.md
+++ b/website/docs/interactors/8-storybook.md
@@ -1,9 +1,7 @@
 ---
-id: storybook-mui
-title: Storybook & Material UI
+id: storybook
+title: Storybook
 ---
-
-## Storybook
 
 Interactors not only make writing tests easier, it can also help you develop UI components. With the upcoming release of [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/), you will be able to use Interactors in [`Storybook`](https://storybook.js.org/).
 
@@ -40,91 +38,8 @@ export const FormSignIn = {
 };
 ```
 
-## Material UI
+## Up Next
 
-If your application is designed using [`Material UI`](https://material-ui.com/), we have already written interactors for each `Material UI` component so that you do not have to.
+On this page we have gone over how Interactors can enhance your experience with Storybook. If you use `Material UI` to design your apps, you will be pleased to know that `Material UI` too can be used with Interactors and Storybook.
 
-There is no longer a need to write complex query selectors or search for components by class; just import the corresponding `Material UI` components from the `material-ui-interactors` package and start writing your tests - it's that simple.
-
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
-<Tabs
-  groupId="runner"
-  defaultValue="jest"
-  values={[
-    {label: 'Jest', value: 'jest'},
-    {label: 'Cypress', value: 'cypress'},
-    {label: 'BigTest (alpha)', value: 'bigtest'}
-]}>
-  <TabItem value="jest">
-
-  ```js
-  import React from 'react';
-  import { render } from '@testing-library/react';
-  import App from './App';
-
-  import { Button } from 'material-ui-interactors';
-
-  describe('Material UI with Interactors in Jest', () => {
-    beforeEach(() => render(<App />));
-
-    it('clicks Material UI Button', async () => {
-      await Button('Sign In').click();
-    });
-  });
-  ```
-
-  </TabItem>
-  <TabItem value="cypress">
-
-  ```js
-  import { Button } from 'material-ui-interactors';
-
-  describe('Material UI with Interactors in Cypress', () => {
-    beforeEach(() => cy.visit('/'));
-
-    it('clicks Material UI Button', () => {
-      cy.do(
-        Button('Sign In').click();
-      );
-    });
-  });
-  ```
-
-  </TabItem>
-  <TabItem value="bigtest">
-
-  ```js
-  import { test } from 'bigtest';
-  import { Page } from '@interactors/html';
-
-  import { Button } from 'material-ui-interactors';
-
-  export default test('BigTest')
-    .step(
-      Page.visit('/'),
-      Button('Sign In').click())
-    .assertion(Button('Log out').exists());
-  ```
-
-  </TabItem>
-</Tabs>
-
-### Material UI & Storybook
-
-Naturally, with the support of Interactors for both `Material UI` and `Storybook`, the three libraries will work together seamelessly. As we have mentioned earlier, `Storybook` will soon be releasing [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/) with which you will be able to use interactors. 
-
-Below is an example of how you would use `Material UI` interactors to write stories. It is very similar to an example we showed earlier with just the import source changed from `@interactors/html` to `material-ui-interactors`:
-
-```js
-import { Button, TextField } from 'material-ui-interactors';
-
-export const FormSignIn = {
-  play: async () => {
-    await TextField('Email').fillIn('homer@gmail.com');
-    await TextField('Password').fillIn('donuts123');
-    await Button('Sign In').click();
-  }
-};
-```
+So go on over to the next page where we will share with you some of the notable existing interactors written for other projects and libraries.

--- a/website/docs/interactors/8-storybook.md
+++ b/website/docs/interactors/8-storybook.md
@@ -96,7 +96,8 @@ import TabItem from '@theme/TabItem';
   <TabItem value="bigtest">
 
   ```js
-  import { Page, test } from 'bigtest';
+  import { test } from 'bigtest';
+  import { Page } from '@interactors/html';
 
   import { Button } from 'material-ui-interactors';
 

--- a/website/docs/interactors/8-storybook.md
+++ b/website/docs/interactors/8-storybook.md
@@ -1,8 +1,9 @@
 ---
-id: storybook
-title: Storybook
+id: storybook-mui
+title: Storybook & Material UI
 ---
 
+## Storybook
 Interactors not only make writing tests easier, it can also help you develop UI components. With the upcoming release of [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/), you will be able to use Interactors in [`Storybook`](https://storybook.js.org/).
 
 This requires no additional setup. Just install `@interactors/html` to your project, and then you can use interactors in your stories immediately.
@@ -26,6 +27,92 @@ export const FormSignIn = {
 And this is the same story but written with interactors:
 ```js
 import { Button, TextField } from '@interactors/html';
+
+export const FormSignIn = {
+  play: async () => {
+    await TextField('Email').fillIn('homer@gmail.com');
+    await TextField('Password').fillIn('donuts123');
+    await Button('Sign In').click();
+  }
+};
+```
+
+## Material UI
+If your application is designed using [`Material UI`](https://material-ui.com/), we have already written interactors for each `Material UI` component so that you do not have to.
+
+There is no longer a need to write complex query selectors or search for components by class; just import the corresponding `Material UI` components from the `material-ui-interactors` package and start writing your tests - it's that simple.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  groupId="runner"
+  defaultValue="jest"
+  values={[
+    {label: 'Jest', value: 'jest'},
+    {label: 'Cypress', value: 'cypress'},
+    {label: 'BigTest (alpha)', value: 'bigtest'}
+]}>
+  <TabItem value="jest">
+
+  ```js
+  import React from 'react';
+  import { render } from '@testing-library/react';
+  import App from './App';
+
+  import { Button } from 'material-ui-interactors';
+
+  describe('Material UI with Interactors in Jest', () => {
+    beforeEach(() => render(<App />));
+
+    it('clicks Material UI Button', async () => {
+      await Button('Sign In').click();
+    });
+  });
+  ```
+
+  </TabItem>
+  <TabItem value="cypress">
+
+  ```js
+  import { Button } from 'material-ui-interactors';
+
+  describe('Material UI with Interactors in Cypress', () => {
+    beforeEach(() => cy.visit('/'));
+
+    it('clicks Material UI Button', () => {
+      cy.do(
+        Button('Sign In').click();
+      );
+    });
+  });
+  ```
+
+  </TabItem>
+  <TabItem value="bigtest">
+
+  ```js
+  import { Page, test } from 'bigtest';
+
+  import { Button } from 'material-ui-interactors';
+
+  export default test('BigTest')
+    .step(
+      Page.visit('/'),
+      Button('Sign In').click())
+    .assertion(Button('Log out').exists());
+  ```
+
+  </TabItem>
+</Tabs>
+
+### Material UI & Storybook
+Naturally, with the support of Interactors for both `Material UI` and `Storybook`, the three libraries will work together seamelessly. As we have mentioned earlier, `Storybook` will soon be releasing [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/) with which you will be able to use interactors. 
+
+Below is an example of how you would use `Material UI` interactors to write stories. It is very similar to an example we showed earlier with just the import source changed from `@interactors/html` to `material-ui-interactors`:
+
+```js
+import { Button, TextField } from 'material-ui-interactors';
 
 export const FormSignIn = {
   play: async () => {

--- a/website/docs/interactors/8-storybook.md
+++ b/website/docs/interactors/8-storybook.md
@@ -4,6 +4,7 @@ title: Storybook & Material UI
 ---
 
 ## Storybook
+
 Interactors not only make writing tests easier, it can also help you develop UI components. With the upcoming release of [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/), you will be able to use Interactors in [`Storybook`](https://storybook.js.org/).
 
 This requires no additional setup. Just install `@interactors/html` to your project, and then you can use interactors in your stories immediately.
@@ -11,6 +12,7 @@ This requires no additional setup. Just install `@interactors/html` to your proj
 In the same way Interactors make tests more reliable and easier to read, it will also enhance your developer experience with Storybook.
 
 Here is an example of how you would normally write a story:
+
 ```js
 import { screen } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
@@ -25,6 +27,7 @@ export const FormSignIn = {
 ```
 
 And this is the same story but written with interactors:
+
 ```js
 import { Button, TextField } from '@interactors/html';
 
@@ -38,6 +41,7 @@ export const FormSignIn = {
 ```
 
 ## Material UI
+
 If your application is designed using [`Material UI`](https://material-ui.com/), we have already written interactors for each `Material UI` component so that you do not have to.
 
 There is no longer a need to write complex query selectors or search for components by class; just import the corresponding `Material UI` components from the `material-ui-interactors` package and start writing your tests - it's that simple.
@@ -107,6 +111,7 @@ import TabItem from '@theme/TabItem';
 </Tabs>
 
 ### Material UI & Storybook
+
 Naturally, with the support of Interactors for both `Material UI` and `Storybook`, the three libraries will work together seamelessly. As we have mentioned earlier, `Storybook` will soon be releasing [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/) with which you will be able to use interactors. 
 
 Below is an example of how you would use `Material UI` interactors to write stories. It is very similar to an example we showed earlier with just the import source changed from `@interactors/html` to `material-ui-interactors`:

--- a/website/docs/interactors/9-existing-interactors.md
+++ b/website/docs/interactors/9-existing-interactors.md
@@ -1,0 +1,105 @@
+---
+id: existing-interactors
+title: Existing Interactors
+---
+
+There are organizations that have already adopted interactors. With their permission we are able to share their interactors as they may be helpful to you.
+
+## FOLIO
+
+FOLIO uses interactors for testing their `Stripes` components. You can browse through their catalog of UI components [here](https://github.com/folio-org/stripes-testing/tree/master/interactors). 
+
+## Material-UI
+
+If you use [`Material UI`](https://material-ui.com/) to design your apps, we have some great news! The interactors for each Material UI components have already been written so that you do not have to create them yourself. You can see each of those interactors [here](https://github.com/thefrontside/material-ui-interactors/tree/v4/src).
+
+There is no longer a need to write complex query selectors or search for components by class; just import the corresponding `Material UI` components from the `material-ui-interactors` package and start writing your tests - it's that simple.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+  groupId="runner"
+  defaultValue="jest"
+  values={[
+    {label: 'Jest', value: 'jest'},
+    {label: 'Cypress', value: 'cypress'},
+    {label: 'BigTest (alpha)', value: 'bigtest'}
+]}>
+  <TabItem value="jest">
+
+  ```js
+  import React from 'react';
+  import { render } from '@testing-library/react';
+  import App from './App';
+
+  import { Button } from 'material-ui-interactors';
+
+  describe('Material UI with Interactors in Jest', () => {
+    beforeEach(() => render(<App />));
+
+    it('clicks Material UI Button', async () => {
+      await Button('Sign In').click();
+    });
+  });
+  ```
+
+  </TabItem>
+  <TabItem value="cypress">
+
+  ```js
+  import { Button } from 'material-ui-interactors';
+
+  describe('Material UI with Interactors in Cypress', () => {
+    beforeEach(() => cy.visit('/'));
+
+    it('clicks Material UI Button', () => {
+      cy.do(
+        Button('Sign In').click();
+      );
+    });
+  });
+  ```
+
+  </TabItem>
+  <TabItem value="bigtest">
+
+  ```js
+  import { test } from 'bigtest';
+  import { Page } from '@interactors/html';
+
+  import { Button } from 'material-ui-interactors';
+
+  export default test('BigTest')
+    .step(
+      Page.visit('/'),
+      Button('Sign In').click())
+    .assertion(Button('Log out').exists());
+  ```
+
+  </TabItem>
+</Tabs>
+
+### Material UI & Storybook
+
+Naturally, with the support of Interactors for both `Material UI` and `Storybook`, the three libraries will work together seamelessly. As we have mentioned earlier, `Storybook` will soon be releasing [`Component Story Format 3.0`](https://storybook.js.org/blog/component-story-format-3-0/) with which you will be able to use interactors. 
+
+Below is an example of how you would use `Material UI` interactors to write stories. It is very similar to an example we showed earlier with just the import source changed from `@interactors/html` to `material-ui-interactors`:
+
+```js
+import { Button, TextField } from 'material-ui-interactors';
+
+export const FormSignIn = {
+  play: async () => {
+    await TextField('Email').fillIn('homer@gmail.com');
+    await TextField('Password').fillIn('donuts123');
+    await Button('Sign In').click();
+  }
+};
+```
+
+## Show Us Your Interactors!
+
+If you would like to showcase your projects' interactors or if you think there any common UI components that you think should be added to the list of predefined interactors, please let us know!
+
+You can create a pull request in our [GitHub repository](https://github.com/thefrontside/interactors) or reach out to us on our [Discord channel](https://discord.gg/r6AvtnU).

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -7,7 +7,7 @@ module.exports = {
     'interactors/matchers',
     'interactors/write-your-own',
     'interactors/integrations',
-    'interactors/storybook',
+    'interactors/storybook-mui',
   ],
   platform: [
     'platform/installation',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -7,7 +7,8 @@ module.exports = {
     'interactors/matchers',
     'interactors/write-your-own',
     'interactors/integrations',
-    'interactors/storybook-mui',
+    'interactors/storybook',
+    'interactors/existing-interactors',
   ],
   platform: [
     'platform/installation',

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   interactors: [
     'interactors/quick-start',
-    'interactors/built-in-dom',
+    'interactors/predefined-interactors',
     'interactors/locators-filters-actions',
     'interactors/assertions',
     'interactors/matchers',


### PR DESCRIPTION
### ✨ Ready for Review ✨

## Motivation

Add mui to docs, showcase `folio` interactors, and adapt to `interactor` becoming its own package.

## Approach
- Changed `Built-in DOM` page to `Predefined Interactors`
  - `Why?` - In the process of trying to find an appropriate place to add interactor-adapters examples (`mui`/`folio`), I figured the best page would be where we list the "built-in" ones. And it made me think that maybe "built-in" has a "it's set in stone" connotation when in reality it can be modified and reshaped to users' needs. "Predefined? Cool, I'm going to RE-define _that_ to my liking".
      - This is also my reason why this is clumped together in one PR instead of two.
- ~~Changed `Storybook` page to `Storybook & Material UI`~~ Created `Existing Interactors` page
  - Introduce folio interactors from [this](https://github.com/folio-org/stripes-testing/tree/master/interactors) repo as examples
  - Talk about how we wrote interactors for mu components so that people can write tests for their mu app.
  - Talk about how mui can be used to write stories in storybook.

- Many of our examples were importing interactors from the `bigtest` package. And we also had many "Bigtest's interactors". So i've read through the entire docs to update the imports and also reword some of the phrasing to treat interactors as its own package.

## Questions
- [ ] I omitted the preview deployment of our story. I'm not entirely sure how much value it will provide to someone already familiar with storybook and material ui. And the code used for the preview deploy is not too well organized. See [here](https://github.com/thefrontside/material-ui-interactors/blob/storybook/stories/interactors.stories.tsx). I think the timeout used in those examples might throw people off.
- [x] Is it safe to assume bigtest will always include a dependency of interactors? Because in some examples of the bigtest runner, we could have both the interactors and runner modules being imported from `bigtest` but at the moment I've separated them out so that runner-specific ones are being imported from `bigtest` and interactors from `@interactors/html`.
- [x] ~~I left the `@bigtest/cypress` stuff as is until [this](https://github.com/thefrontside/interactors/pull/35) is complete.~~
- [x] Need to add section for `mui` and `folio` in `predefined interactors`
  - [x] The call-to-action heading is `Show Us Your Interactors!` which could sound a bit provocative depending on _how_ you say it. But if there's a better heading for it, we should change it.