### PR TITLE
Remove @interactors/html from changeset file

### DIFF
--- a/.changeset/hip-bikes-roll.md
+++ b/.changeset/hip-bikes-roll.md
@@ -9,7 +9,6 @@
 "@bigtest/effection-express": minor
 "@bigtest/eslint-plugin": minor
 "@bigtest/globals": minor
-"@interactors/html": minor
 "@bigtest/logging": minor
 "@bigtest/performance": minor
 "@bigtest/project": minor


### PR DESCRIPTION
## Motivation
https://github.com/thefrontside/bigtest/runs/3488276085?check_suite_focus=true

<img width="555" alt="Screen Shot 2021-09-01 at 2 44 10 PM" src="https://user-images.githubusercontent.com/230597/131734154-56e533a8-bb87-4104-8de6-d32d8e157a24.png">


## Approach
https://github.com/thefrontside/bigtest/pull/941 included some `interactor` changes that would've involved a `minor` bump. 

https://github.com/thefrontside/bigtest/pull/991 included that the moved `@interactors/html` needed to bump.

## Related
The `interactor` changes in https://github.com/thefrontside/bigtest/pull/941 didn't make it over to the new `interactors` monorepo. Working on a separate PR for that.