### PR TITLE
Remove effection from bigtest/globals

### DIFF
--- a/.changeset/plenty-pugs-help.md
+++ b/.changeset/plenty-pugs-help.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/globals": patch
+---
+
+Remove unnecessary effection dependency

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -22,8 +22,7 @@
     "prepack:commonjs": "tsc --project ./tsconfig.build.json --outdir dist/cjs --module commonjs"
   },
   "dependencies": {
-    "@bigtest/suite": "^0.12.0",
-    "effection": "^2.0.0-beta.12"
+    "@bigtest/suite": "^0.12.0"
   },
   "devDependencies": {
     "@frontside/eslint-config": "^2.0.0",


### PR DESCRIPTION
## Motivation

We don't need `effection` in `packages/global`.

## Approach

Removed and added patch changeset.