### PR TITLE
fix start server timeout doesn't cancel

### DIFF
--- a/.changeset/fix-stat-server-timeout.md
+++ b/.changeset/fix-stat-server-timeout.md
@@ -1,0 +1,5 @@
+---
+"@bigtest/cli": patch
+---
+
+Fix start server timeout doesn't cancel

--- a/packages/cli/src/start-server.ts
+++ b/packages/cli/src/start-server.ts
@@ -11,13 +11,13 @@ interface Options {
 export function startServer(project: ProjectOptions, options: Options): Resource<void> {
   return {
     name: 'server',
-    *init() {
+    *init(_, local) {
       ensureConfiguration(project);
 
       let atom = createOrchestratorAtom();
       yield spawn(createOrchestrator({ atom, project }));
 
-      yield spawn(function*() {
+      yield local.spawn(function*() {
         yield sleep(options.timeout);
         throw new MainError({ exitCode: 3, message: chalk.red(`ERROR: Timed out waiting for server to start after ${options.timeout}ms`) });
       });


### PR DESCRIPTION
## Motivation

The timeout operation continues to live in the background even server resource is ready.

## Approach

Execute operation in the local scope of resource