### PR TITLE
Return Task to prevent unhandled promise warning

### DIFF
--- a/packages/server/src/runner.ts
+++ b/packages/server/src/runner.ts
@@ -22,7 +22,7 @@ export interface RunOptions {
 }
 
 export interface Runner {
-  runTest(options: RunOptions): Promise<void>;
+  runTest(options: RunOptions): Task<void>;
   subscribe(id: string): AsyncIterator<TestEvent>;
 }
 
@@ -57,7 +57,7 @@ return {
   *init(scope: Task) {
     let { send, stream } = createChannel<TestEvent>();
     return {
-      async runTest({ testRunId, files }: RunOptions): Promise<void> {
+      runTest({ testRunId, files }: RunOptions): Task<void> {
         return scope.run(function*() {
           console.debug('[command processor] running test', testRunId);
           let stepTimeout = 60_000;

--- a/packages/server/test/command-server.test.ts
+++ b/packages/server/test/command-server.test.ts
@@ -1,6 +1,6 @@
 import { describe, beforeEach, it } from '@effection/mocha';
 import expect from 'expect';
-import { Operation, createQueue, Queue, Subscription, spawn, fetch } from 'effection';
+import { Operation, createQueue, Queue, Subscription, spawn, fetch, run } from 'effection';
 import { Slice } from '@effection/atom';
 import { Test } from '@bigtest/suite';
 import { createClient, Client } from '@bigtest/client';
@@ -25,8 +25,9 @@ describe('command server', () => {
     yield spawn(createCommandServer({
       status: atom.slice('commandServer'),
       runner: {
-        async runTest(options) {
+        runTest(options) {
           runs.send(options);
+          return run();
         },
         async *subscribe() {
           throw new Error('not implemented');


### PR DESCRIPTION
This makes `runTest` on the runner return a task, rather than a promise.

Since we call `runTest` without actually observing the result thereof, if we convert the task into a promise, we end up in a situation where we have created a promise but not attached any error handlers to it. This causes a warning to be printed to the console. By returning the task directly and not converting it to a promise, we avoid this problem and also increase flexibility in how the runner is used.