### PR TITLE
Switch version commit message to sentence case

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -15,5 +15,8 @@ jobs:
       run: yarn
     - name: Create Release Pull Request
       uses: changesets/action@master
+      with:
+        commit: "Version packages"
+        title: "Version packages"
       env:
         GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation
Most projects I've encountered (including this repo), write their commit messages in _Sentence case_.

## Approach
Switch automatic commit message from _Title Case_ to _Sentence case_.