### PR TITLE
point release action to version containing fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@v1.6
+      uses: thefrontside/actions/synchronize-with-npm@mk/fix-dockerfiles
       with:
         before_all: yarn prepack
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation

@minkimcello is in the process of fixing the docker files for the release action. While that work is still settling, we still need to do a release of BigTest, and so this will allow us to do it as a stopgap while the full fix is coming through.
