### PR TITLE
rename monorepo package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "bigtest",
+  "name": "@bigtest/monorepo",
   "version": "0.0.0-monorepo",
   "description": "Tests that speed up development ",
   "repository": "git@github.com:thefrontside/bigtest.git",


### PR DESCRIPTION
## Motivation
The 'bigtest' npm package is a thing, and so we don't want our monorepo package private name to conflict with.

## Approach

name it `@bigtest/monorepo` which is fun, catchy, and unlikely to conflict with other package names (until of course it does, but at least we're kicking this can over the horizon). 