### PR TITLE
Update release action source to v1.9

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,16 +8,19 @@ on:
 jobs:
   publish-previews:
     name: Publish Preview Packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     steps:
-    - uses: actions/checkout@v1
-    - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@v1.4
+    - uses: actions/checkout@v2
       with:
-        before_all: yarn prepack
-        npm_publish: yarn publish
-        ignore: website
+        fetch-depth: 0
+    - uses: actions/setup-node@v2
+      with:
+        registry-url: https://registry.npmjs.org
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@main
+      with:
+        INSTALL_SCRIPT: yarn install && yarn prepack
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.FRONTSIDEJACK_GITHUB_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ secrets.FRONTSIDEJACK_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ on:
 jobs:
   publish-releases:
     name: Publish Releases
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v1
     - name: Publish Releases
-      uses: thefrontside/actions/synchronize-with-npm@mk/fix-dockerfiles
+      uses: thefrontside/actions/synchronize-with-npm@v1.9
       with:
         before_all: yarn prepack
         npm_publish: yarn publish


### PR DESCRIPTION
## Motivation

Our release action stopped working because of changes to the alpine docker image. We created a fix for it and tried it out here: [#1053](https://github.com/thefrontside/bigtest/pull/1053). Now that we've confirmed it's working, this PR is to update the source of the action to the official release.

## Approach

Updated action to call from the new `v1.9` release. And I also set the actions workflow runner to `ubuntu-20.04` instead of `ubuntu-latest`.

And I updated the preview workflow too.