### PR TITLE
Update interactors to 1.0rc

### DIFF
--- a/.changeset/odd-fans-prove.md
+++ b/.changeset/odd-fans-prove.md
@@ -1,0 +1,7 @@
+---
+"@bigtest/agent": patch
+"bigtest": patch
+"@bigtest/globals": patch
+---
+
+update interactors to 1.0rc

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img alt="BigTest" src="logo.svg" width="500">
 </p>
 
-<p align="center">  
+<p align="center">
   <a href="https://app.circleci.com/pipelines/github/thefrontside/bigtest?branch=v0"><img alt="CircleCI" src="https://circleci.com/gh/thefrontside/bigtest.svg?style=shield"/></a>
   <a href="https://discord.gg/r6AvtnU"><img alt="Chat on Discord" src="https://img.shields.io/discord/700803887132704931?Label=Discord)](https://discord.gg/r6AvtnU"/></a>
   <a href="https://frontside.com"><img alt="created by Frontside" src="https://img.shields.io/badge/created%20by-frontside-26abe8.svg"/></a>
@@ -68,10 +68,10 @@ yarn bigtest init
 Add a test file in `test/my-test.test.js`:
 
 ``` javascript
-import { test, Page, Heading } from 'bigtest';
+import { test, visit, Heading } from 'bigtest';
 
 export default test('My Test')
-  .step(Page.visit('/'))
+  .step(visit('/'))
   .step(Heading("My Application").exists());
 ```
 

--- a/packages/agent/app/run-lane.ts
+++ b/packages/agent/app/run-lane.ts
@@ -1,7 +1,7 @@
 import { Operation, spawn, all, withTimeout } from 'effection';
 import { on } from '@effection/events';
 import { bigtestGlobals } from '@bigtest/globals';
-import { globals, addActionWrapper } from '@interactors/globals';
+import { globals, addActionWrapper, setDocumentResolver } from '@interactors/globals';
 import { TestImplementation, Context as TestContext } from '@bigtest/suite';
 
 import { findIFrame } from './find-iframe';
@@ -113,6 +113,7 @@ export function* runLane(config: LaneConfig): Operation<TestImplementation> {
   }
 
   setLogConfig({ events: [] });
+  setDocumentResolver(() => bigtestGlobals.document)
   addActionWrapper((description, action, type) =>
     async () => {
       if (bigtestGlobals.runnerState == 'assertion' && type == 'interaction')

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -31,7 +31,7 @@
     "@frontside/eslint-config": "^3.0.0",
     "@frontside/tsconfig": "^3.0.0",
     "@frontside/typescript": "^3.0.0",
-    "@interactors/html": "^0.31.2",
+    "@interactors/html": "^1.0.0-rc1.0",
     "@types/express": "^4.17.6",
     "@types/istanbul-lib-coverage": "^2.0.3",
     "@types/localforage": "^0.0.34",
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@bigtest/effection-express": "^0.13.0",
-    "@interactors/globals": "0.1.0",
     "@bigtest/globals": "^0.9.0",
+    "@interactors/globals": "1.0.0-rc1.0",
     "bowser": "^2.9.0",
     "effection": "^2.0.1",
     "error-stack-parser": "^2.0.6",

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -1,7 +1,8 @@
+const { visit } = require('bigtest')
 const { test } = require('@bigtest/suite');
 const { bigtestGlobals } = require('@bigtest/globals');
 const { strict: assert } = require('assert');
-const { createInteractor, Page } = require('@interactors/html');
+const { createInteractor } = require('@interactors/html');
 
 const localforage = require('localforage');
 
@@ -64,7 +65,7 @@ function coverageTest(filepath) {
 }
 
 module.exports = test("tests")
-  .step(Page.visit('/app.html'))
+  .step(visit('/app.html'))
   .child(
     "test with failing assertion", test => test
       .step("successful step", async () => {

--- a/packages/agent/test/fixtures/manifest.js
+++ b/packages/agent/test/fixtures/manifest.js
@@ -2,7 +2,7 @@ const { visit } = require('bigtest')
 const { test } = require('@bigtest/suite');
 const { bigtestGlobals } = require('@bigtest/globals');
 const { strict: assert } = require('assert');
-const { createInteractor } = require('@interactors/html');
+const { HTML } = require('@interactors/html');
 
 const localforage = require('localforage');
 
@@ -16,8 +16,6 @@ globalThis.fetch = async function(url) {
     }
   }
 }
-
-const H2 = createInteractor('h2')({ selector: 'h2' });
 
 function storageTest(test) {
   return test
@@ -105,7 +103,7 @@ module.exports = test("tests")
       .step("this takes literally forever", async () => await new Promise(() => {})))
   .child(
     "test fetch", test => test
-      .step("fetch is mocked", async () => await H2('hello from mocked fetch').exists()))
+      .step("fetch is mocked", async () => await HTML('hello from mocked fetch').exists()))
   .child("local storage and session storage 1", storageTest)
   .child("local storage and session storage 2", storageTest)
   .child("indexedDB 1", indexedDBTest)

--- a/packages/bigtest/package.json
+++ b/packages/bigtest/package.json
@@ -31,8 +31,8 @@
   "dependencies": {
     "@bigtest/cli": "0.23.0",
     "@bigtest/suite": "0.13.0",
-    "@interactors/html": "^0.31.2",
-    "@interactors/globals": "0.1.0"
+    "@interactors/globals": "1.0.0-rc1.0",
+    "@interactors/html": "^1.0.0-rc1.0"
   },
   "volta": {
     "node": "14.17.5",

--- a/packages/bigtest/src/visit.ts
+++ b/packages/bigtest/src/visit.ts
@@ -26,47 +26,48 @@ let visitCounter = 1;
 export function visit(path = '/'): Interaction<void> {
   let promise: Promise<void>;
   let description = `visiting ${JSON.stringify(path)}`
+  let action = globals.wrapAction(description, async () => {
+    // eslint-disable-next-line prefer-let/prefer-let
+    const { appUrl, testFrame } = bigtestGlobals;
+
+    if(!appUrl) throw new Error('no app url defined');
+    if(!testFrame) throw new Error('no test frame defined');
+
+    let url = new URL(appUrl);
+    let [pathname = '', hash = ''] = path.split('#');
+    url.pathname = pathname;
+    url.hash = hash;
+    url.searchParams.set('bigtest-interactor-page-number', String(visitCounter));
+    visitCounter += 1;
+    testFrame.src = url.toString();
+    await new Promise<void>((resolve, reject) => {
+      let listener = () => {
+        clearTimeout(timeout);
+        testFrame.removeEventListener('load', listener);
+        resolve();
+      }
+      testFrame.addEventListener('load', listener);
+      let timeout = setTimeout(() => {
+        clearTimeout(timeout);
+        testFrame.removeEventListener('load', listener);
+        reject(new Error('timed out trying to load application'));
+      }, bigtestGlobals.defaultAppTimeout);
+    });
+  }, 'interaction')
   return {
       description,
       [Symbol.toStringTag]: `[interaction ${description}]`,
-      action: globals.wrapAction(description, async () => {
-        // eslint-disable-next-line prefer-let/prefer-let
-        const { appUrl, testFrame } = bigtestGlobals;
-
-        if(!appUrl) throw new Error('no app url defined');
-        if(!testFrame) throw new Error('no test frame defined');
-
-        let url = new URL(appUrl);
-        let [pathname = '', hash = ''] = path.split('#');
-        url.pathname = pathname;
-        url.hash = hash;
-        url.searchParams.set('bigtest-interactor-page-number', String(visitCounter));
-        visitCounter += 1;
-        testFrame.src = url.toString();
-        await new Promise<void>((resolve, reject) => {
-          let listener = () => {
-            clearTimeout(timeout);
-            testFrame.removeEventListener('load', listener);
-            resolve();
-          }
-          testFrame.addEventListener('load', listener);
-          let timeout = setTimeout(() => {
-            clearTimeout(timeout);
-            testFrame.removeEventListener('load', listener);
-            reject(new Error('timed out trying to load application'));
-          }, bigtestGlobals.defaultAppTimeout);
-        });
-      }, 'interaction'),
+      action,
       then(onFulfill, onReject) {
-        if(!promise) { promise = this.action(); }
+        if(!promise) { promise = action(); }
         return promise.then(onFulfill, onReject);
       },
       catch(onReject) {
-        if(!promise) { promise = this.action(); }
+        if(!promise) { promise = action(); }
         return promise.catch(onReject);
       },
       finally(handler) {
-        if(!promise) { promise = this.action(); }
+        if(!promise) { promise = action(); }
         return promise.finally(handler);
       }
     };

--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@bigtest/suite": "^0.13.0",
-    "@interactors/globals": "0.1.0"
+    "@interactors/globals": "1.0.0-rc1.0"
   },
   "devDependencies": {
     "@frontside/eslint-config": "^3.0.0",

--- a/packages/suite/src/dsl.ts
+++ b/packages/suite/src/dsl.ts
@@ -138,7 +138,7 @@ export class TestBuilder<C extends Context> implements TestImplementation {
    *   return { post: await Post.create({ user }) }
    * })
    * .step("when I visit the post", async ({ user, post }) {
-   *   await Page.visit(`/users/${user.id}/posts/${post.id}`);
+   *   await visit(`/users/${user.id}/posts/${post.id}`);
    * })
    * ```
    *

--- a/sample/app/src/test/bigtest.test.js
+++ b/sample/app/src/test/bigtest.test.js
@@ -1,7 +1,7 @@
-import { Button, Heading, Link, Page, test } from 'bigtest';
+import { Button, Heading, Link, visit, test } from 'bigtest';
 
 export default test('Interactors with BigTest')
-  .step(Page.visit('/'))
+  .step(visit('/'))
   .child('click sign in button', test => test
     .step(Button('SIGN IN').click())
     .assertion(

--- a/website/docs/2-writing-your-first-test.md
+++ b/website/docs/2-writing-your-first-test.md
@@ -31,10 +31,10 @@ Go ahead and create a `test` directory inside your project and make a new test f
 Before you write your own test, let's look at an example. Here is what a test for a To-Do app could look like. It visits the index route of the app, checks to make sure the heading's text has rendered, and adds a task to the list:
 
 ```js
-import { Button, CheckBox, Heading, Page, test } from `bigtest`;
+import { Button, CheckBox, Heading, visit, test } from `bigtest`;
 
 export default test('bigtest todomvc')
-  .step(Page.visit('/'))
+  .step(visit('/'))
   .assertion(Heading('todos').exists())
   .child('create todo', test => test
     .step(
@@ -51,20 +51,20 @@ First, look for some text on your app's index page that is wrapped in an `<h1>`.
 Then, copy and paste the example below into your own test file, substituting "My Heading Text" in the example below with your own text.
 
 ```js
-import { Heading, Page, test } from `bigtest`;
+import { Heading, visit, test } from `bigtest`;
 
 export default test('home page rendering')
-  .step(Page.visit('/'))
+  .step(visit('/'))
   .assertion(Heading('My Heading Text').exists())
 ```
 
 If your app does not have any heading text, you could check for a button instead:
 
 ```js
-import { Button, Page, test } from `bigtest`;
+import { Button, visit, test } from `bigtest`;
 
 export default test('home page rendering')
-  .step(Page.visit('/'))
+  .step(visit('/'))
   .assertion(Button('My Button Text').exists())
 ```
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,12 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
-  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.14.5":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
+  integrity sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==
   dependencies:
-    "@babel/highlight" "^7.14.5"
+    "@babel/highlight" "^7.16.0"
 
 "@babel/compat-data@^7.13.11", "@babel/compat-data@^7.13.8", "@babel/compat-data@^7.14.0", "@babel/compat-data@^7.15.0":
   version "7.15.0"
@@ -213,10 +213,10 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
-  version "7.14.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
-  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
+"@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.15.7":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-option@^7.12.17", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -242,12 +242,12 @@
     "@babel/traverse" "^7.15.0"
     "@babel/types" "^7.15.0"
 
-"@babel/highlight@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
-  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
+"@babel/highlight@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
+  integrity sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.15.7"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -919,24 +919,6 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@bigtest/globals@^0.7.6":
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/@bigtest/globals/-/globals-0.7.6.tgz#e435d370059cfde66b20d31ba1d91cf0db63ba53"
-  integrity sha512-VEMqUGmCPskM6/YKtBEOyS0sgrIfH0zcNTd1AXTJXCSMtiI5eIe46Nq6nEebjdLeI4gJiVDflvQmgidTNHvC9w==
-  dependencies:
-    "@bigtest/suite" "^0.11.2"
-    effection "^1.0.0"
-
-"@bigtest/performance@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@bigtest/performance/-/performance-0.5.0.tgz#195f2c445cbe2ebe4357e08f7b39449240bf62d7"
-  integrity sha512-5lmaul6UIdyEApxapYumCShEdKca7PjwYlcIHiu/5iI032DUQsq4dygYMX07cgevfCZSR2fss57uMGfdB22GbQ==
-
-"@bigtest/suite@^0.11.2":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@bigtest/suite/-/suite-0.11.3.tgz#f6c915ad91c69567d8585f8f4efe479b1e1b1ba0"
-  integrity sha512-50M5zC0xjEE9maNayWNNUKatR6NSEPrwNOVjEZKVRL3n3DdNwBV5OIE2xuwVIaWz1Wgbdg/lsojLefRNzOIapA==
-
 "@changesets/apply-release-plan@^5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@changesets/apply-release-plan/-/apply-release-plan-5.0.0.tgz#11bf168acecbf4cfa2b0e6425160bac5ceeec1c3"
@@ -1363,21 +1345,38 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
-"@interactors/globals@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@interactors/globals/-/globals-0.1.0.tgz#644eae081b03396665f9ca4ec85729e29c4b685d"
-  integrity sha512-KUwFrYJrt885NmmIeohfgIrkL3wtIzqHZX7XOgJCBL9xzi1KadvbBWHvWPk+qyBTTb202lbaJ3XTp0DB8Knr/Q==
-
-"@interactors/html@^0.31.2":
-  version "0.31.2"
-  resolved "https://registry.yarnpkg.com/@interactors/html/-/html-0.31.2.tgz#55979155245b7cfe6a6d000b89dafb078f09adbd"
-  integrity sha512-8Z2eb61zKtcfQASvptEkFzlqlRJYnh/fgqo8AxuDwevCRnkFHTP0HWr7mrmVQ+sR1ehAg2/B+0U4NlDjDEsCJA==
+"@interactors/core@^1.0.0-rc1.0":
+  version "1.0.0-rc1.0"
+  resolved "https://registry.yarnpkg.com/@interactors/core/-/core-1.0.0-rc1.0.tgz#cb8204e051382021c6e21285c17ef9d5a1e92f7a"
+  integrity sha512-F+m0hcp7hndmLkz1AsLWKdV8/YgsId9CygEwbP6S2NwhGN8ALzIfML96qhbf9rfsqbAuhVubPaDf1Spz5NkD1Q==
   dependencies:
-    "@bigtest/globals" "^0.7.6"
-    "@bigtest/performance" "^0.5.0"
+    "@interactors/globals" "^1.0.0-rc1.0"
+    "@testing-library/dom" "^8.5.0"
+    "@testing-library/user-event" "^13.2.1"
     change-case "^4.1.1"
     element-is-visible "^1.0.0"
     lodash.isequal "^4.5.0"
+    performance-api "^1.0.0"
+
+"@interactors/globals@1.0.0-rc1.0", "@interactors/globals@^1.0.0-rc1.0":
+  version "1.0.0-rc1.0"
+  resolved "https://registry.yarnpkg.com/@interactors/globals/-/globals-1.0.0-rc1.0.tgz#5b3cb25245fd6c2ac801d4abd1af8838d240ed77"
+  integrity sha512-js1pND/mgaOcLEmaX/HKbfEyD57zGStsQ06QISFRBl942zlQpnQQsmXUcr7NI/vASvcEYDsZo6aqadiQOmw28Q==
+
+"@interactors/html@^1.0.0-rc1.0":
+  version "1.0.0-rc1.0"
+  resolved "https://registry.yarnpkg.com/@interactors/html/-/html-1.0.0-rc1.0.tgz#3f4bdddec8d90cbc48c03c4ff75a33b9fbaf66fc"
+  integrity sha512-hkoyvHX0cIzjH/cbA/yzXza1Ky+QzfRSjIUAdrZvXe0CUvGX5CcpJ9f2FfzWaHQ6QRsNo6HlrTFlIEp5fCDdCA==
+  dependencies:
+    "@interactors/core" "^1.0.0-rc1.0"
+    "@interactors/keyboard" "^1.0.0-rc1.0"
+
+"@interactors/keyboard@^1.0.0-rc1.0":
+  version "1.0.0-rc1.0"
+  resolved "https://registry.yarnpkg.com/@interactors/keyboard/-/keyboard-1.0.0-rc1.0.tgz#6fec28e751f929b393c78648e4453f98f9bb4e15"
+  integrity sha512-s0m+3wSXXDoNEyoMV5BFm8ctnObkxCCSC+fd8ZwhmAK+JHHBpv6DpRa/NSsg/UdUr4i+bdrYebPg9Hy5wYFpGQ==
+  dependencies:
+    "@interactors/core" "^1.0.0-rc1.0"
 
 "@jest/console@^24.9.0":
   version "24.9.0"
@@ -1424,6 +1423,17 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@manypkg/find-root@^1.1.0":
@@ -2144,10 +2154,36 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
+"@testing-library/dom@^8.5.0":
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.1.tgz#03fa2684aa09ade589b460db46b4c7be9fc69753"
+  integrity sha512-3KQDyx9r0RKYailW2MiYrSSKEfH0GTkI51UGEvJenvcoDoeRYs0PZpi2SXqtnMClQvCqdtTTpOfFETDTVADpAg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/user-event@^13.2.1":
+  version "13.5.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@trysound/sax@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.1.1.tgz#3348564048e7a2d7398c935d466c0414ebb6a669"
   integrity sha512-Z6DoceYb/1xSg5+e+ZlPZ9v0N16ZvZ+wYMraFue4HYrE4ttONKtsvruIRf6t9TBR0YvSOfi1hUU0fJfBLCDYow==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.1.12":
   version "7.1.14"
@@ -2495,6 +2531,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
+  dependencies:
+    "@types/yargs-parser" "*"
+
 "@types/yauzl@^2.9.1":
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.9.1.tgz#d10f69f9f522eef3cf98e30afb684a1e1ec923af"
@@ -2727,10 +2770,10 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -2750,6 +2793,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@~3.1.1:
   version "3.1.2"
@@ -2796,6 +2844,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -4392,6 +4445,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dom-accessibility-api@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
+  integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
+
 dom-serializer@^1.0.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.1.tgz#d845a1565d7c041a95e5dab62184ab41e3a519be"
@@ -4524,11 +4582,6 @@ effection@2.0.1, effection@^2.0.1:
     "@effection/main" "2.0.1"
     "@effection/stream" "2.0.1"
     "@effection/subscription" "2.0.1"
-
-effection@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/effection/-/effection-1.0.0.tgz#7c20ee4ea6e63fddb5a51461dda8009b649b4195"
-  integrity sha512-ITAAnuI7sJqKhjvYlnm66NHaW7zrXzqgsGsjVaaqFHYDWPN8WylVj46xASfkrtwq5wmklbzy6tvRYaj2C4rDHw==
 
 ejs@^2.6.1:
   version "2.7.4"
@@ -7046,6 +7099,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -8087,6 +8145,11 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
+performance-api@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/performance-api/-/performance-api-1.0.0.tgz#0fe0198fa2db8f92e2786be1166fd134648cec9e"
+  integrity sha512-hZKWxgX3+rv9iPA6hBTr9U+9rNN8mf5joahZ5m9z/fEoqyfS/9qkVs7GGrb/JifjNlgqgduK6uWp+16n+petMg==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -8555,6 +8618,16 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+pretty-format@^27.0.2:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
+  integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -8753,6 +8826,11 @@ react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-refresh@^0.9.0:
   version "0.9.0"


### PR DESCRIPTION
## Motivation

HP uses bigtest with old interactors version. And installing the last version of `@interactors/with-cypress` there makes a little mess with hosting `@interactors/html` package.

## Approach

Update `@interactors/html` in bigtest
