### PR TITLE
spawn request handler directly on proxy task

### DIFF
--- a/.changeset/remove-deprecated-spawn-form.md
+++ b/.changeset/remove-deprecated-spawn-form.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/server": patch
+--
+remove deprecated usage of `spawn(operation).within(task)` from proxy server

--- a/packages/server/src/proxy.ts
+++ b/packages/server/src/proxy.ts
@@ -138,7 +138,7 @@ export const proxyServer = (options: ProxyServerOptions): Operation<void> => wit
     }));
 
     yield onEmit<ProxyResEvent>(proxyServer, 'proxyRes').forEach(function*([proxyRes, req, res]) {
-      yield spawn(handleRequest(proxyRes, req, res), { blockParent: true }).within(proxyTask);
+      yield proxyTask.spawn(handleRequest(proxyRes, req, res));
     });
   } finally {
     proxyServer.close();


### PR DESCRIPTION
## Motivation

The `spawn(operation).within(task))` syntax is going to be deprecated, as it is no longer needed. There is a `Task#spawn` operation which can be used to spawn a task directly from its parent.

## Approach

1. spawn directly off of the proxy task
2. Remove the `blockParent` option since the `onEmit` operation is infinite and it is impossible for the handler to _ever_ finish before its parent and is therefore redundant.
