### PR TITLE
Use task group for collecting tasks with the same lifetime

### DIFF
--- a/.changeset/socket-handler-task-group.md
+++ b/.changeset/socket-handler-task-group.md
@@ -1,0 +1,4 @@
+---
+"@bigtest/server": patch
+---
+use a task group instead of `blockParent` for socket handlers

--- a/packages/server/src/command-server.ts
+++ b/packages/server/src/command-server.ts
@@ -122,7 +122,7 @@ function handleSocketConnection(options: CommandServerOptions): (socket: Socket<
   }
 
   return (socket) => function*() {
-    let handlers: TaskGroup = yield createTaskGroup('message handlers');
+    let handlers = yield* createTaskGroup('message handlers');
 
     yield socket.forEach(function*(message) {
       if (isQuery(message)) {
@@ -136,6 +136,6 @@ function handleSocketConnection(options: CommandServerOptions): (socket: Socket<
       }
     });
 
-    yield handlers;
+    yield handlers.allSettled();
   }
 }

--- a/packages/server/src/task-group.ts
+++ b/packages/server/src/task-group.ts
@@ -6,10 +6,14 @@ export interface TaskGroup {
   allSettled(): Operation<void>;
 }
 
-export function createTaskGroup(name = 'task group'): Operation<TaskGroup> {
+export interface Create<T> {
+  [Symbol.iterator](): Iterator<Operation<T>, T, T>;
+}
+
+export function* createTaskGroup(name = 'task group'): Create<TaskGroup> {
   let tasks = new Set<Task>();
 
-  return {
+  return yield {
     name,
     *init(scope) {
       return {

--- a/packages/server/src/task-group.ts
+++ b/packages/server/src/task-group.ts
@@ -15,12 +15,12 @@ export function createTaskGroup(name = 'task group'): Resource<TaskGroup> {
         *spawn<T>(operation: Operation<T>) {
           let task: Task<T> | undefined;
           yield spawn(function*() {
-            let t: Task<T> = task = yield scope.spawn(operation);
-            tasks.add(t);
+            task = (yield scope.spawn(operation)) as Task<T>;
+            tasks.add(task);
             try {
-              yield t.future;
+              yield task.future;
             } finally {
-              tasks.delete(t);
+              tasks.delete(task);
             }
           });
           assert(!!task, "task was not initialized");

--- a/packages/server/src/task-group.ts
+++ b/packages/server/src/task-group.ts
@@ -1,0 +1,38 @@
+import { Operation, Resource, Task, spawn } from 'effection';
+import assert from 'assert-ts';
+
+export interface TaskGroup extends Resource<void> {
+  spawn<T>(operation: Operation<T>): Operation<Task<T>>;
+}
+
+export function createTaskGroup(name = 'task group'): Resource<TaskGroup> {
+  let tasks = new Set<Task>();
+
+  return {
+    name,
+    *init(scope) {
+      return {
+        *spawn<T>(operation: Operation<T>) {
+          let task: Task<T> | undefined;
+          yield spawn(function*() {
+            let t: Task<T> = task = yield scope.spawn(operation);
+            tasks.add(t);
+            try {
+              yield t.future;
+            } finally {
+              tasks.delete(t);
+            }
+          });
+          assert(!!task, "task was not initialized");
+          return task;
+        },
+        *init() {
+          for (let task of tasks) {
+            yield task.future;
+          }
+        },
+        name: `await ${name}`,
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
Instead of using an option 'blockParent'. We can explicitly spawn different tasks into collections of groups that can be waited upon individually. This not only makes which group a task is part of explicit, but it allows flexibility in how you consume the blocking tasks.

This is fairly common in other structured concurrency frameworks like Swift or ember-concurrency, and can be expanded upon to add other aspects like "how many concurrent things can be going at the same time" or "what do we do when the max concurrency is attained... do we drop incoming operations? do we respond with a "503 operation"? do we cancel the currently running things? do we enqueue the new operations? How many do we enqueue?"

So this is an experiment in what that might look like.